### PR TITLE
EMT-401: add policy applied to malware event

### DIFF
--- a/custom_subsets/elastic_endpoint/events/malware_event.yaml
+++ b/custom_subsets/elastic_endpoint/events/malware_event.yaml
@@ -26,6 +26,8 @@ endpoint:
         applied:
           fields:
             id: {}
+            name: {}
+            status: {}
     artifact: {}
     event:
       fields:

--- a/generated/events/beats/fields.ecs.yml
+++ b/generated/events/beats/fields.ecs.yml
@@ -706,6 +706,18 @@
     ignore_above: 1024
     description: the id of the applied policy
     default_field: false
+  - name: policy.applied.name
+    level: custom
+    type: keyword
+    ignore_above: 1024
+    description: the name of this applied policy
+    default_field: false
+  - name: policy.applied.status
+    level: custom
+    type: keyword
+    ignore_above: 1024
+    description: the status of the applied policy
+    default_field: false
   - name: process
     level: custom
     type: object

--- a/generated/events/ecs/ecs_nested.yml
+++ b/generated/events/ecs/ecs_nested.yml
@@ -1141,6 +1141,26 @@ endpoint:
       normalize: []
       short: the id of the applied policy
       type: keyword
+    policy.applied.name:
+      dashed_name: endpoint-policy-applied-name
+      description: the name of this applied policy
+      flat_name: endpoint.policy.applied.name
+      ignore_above: 1024
+      level: custom
+      name: policy.applied.name
+      normalize: []
+      short: the name of this applied policy
+      type: keyword
+    policy.applied.status:
+      dashed_name: endpoint-policy-applied-status
+      description: the status of the applied policy
+      flat_name: endpoint.policy.applied.status
+      ignore_above: 1024
+      level: custom
+      name: policy.applied.status
+      normalize: []
+      short: the status of the applied policy
+      type: keyword
     process:
       dashed_name: endpoint-process
       description: Extended "process" field set

--- a/generated/events/elasticsearch/7/template.json
+++ b/generated/events/elasticsearch/7/template.json
@@ -408,6 +408,14 @@
                   "id": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "status": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   }
                 },
                 "type": "object"

--- a/package/endpoint/dataset/events/fields/fields.yml
+++ b/package/endpoint/dataset/events/fields/fields.yml
@@ -706,6 +706,18 @@
     ignore_above: 1024
     description: the id of the applied policy
     default_field: false
+  - name: policy.applied.name
+    level: custom
+    type: keyword
+    ignore_above: 1024
+    description: the name of this applied policy
+    default_field: false
+  - name: policy.applied.status
+    level: custom
+    type: keyword
+    ignore_above: 1024
+    description: the status of the applied policy
+    default_field: false
   - name: process
     level: custom
     type: object

--- a/schemas/v1/malware_event.yaml
+++ b/schemas/v1/malware_event.yaml
@@ -403,6 +403,14 @@ fields:
                 type: keyword
                 description: the id of the applied policy
 
+              - name: name
+                type: keyword
+                description: the name of this applied policy
+
+              - name: status
+                type: keyword
+                description: the status of the applied policy
+
       - name: process
         description: Extended "process" field set
         fields:


### PR DESCRIPTION
Summary:

Add policy.applied to malware event schema to match the typescript structure. 

