### PR TITLE
Updating the package requirements to only work for 7.9

### DIFF
--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -24,10 +24,8 @@ datasources:
     multiple: false
 
 requirement:
-  elasticsearch:
-    versions: ">7.4.0"
   kibana:
-    versions: ">7.4.0"
+    versions: ">=7.9.0"
 
 icons:
   - src: "/img/logo-endpoint-64-color.svg"


### PR DESCRIPTION
The elasticsearch requirement is being removed here: https://github.com/elastic/package-registry/pull/516

Also upping the version to >=7.9.0