### PR TITLE
EMT-295: add default input for endpoint package

### DIFF
--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -28,7 +28,7 @@ datasources:
         linux:
           logging:
             file: info
-            stdout: debug
+            stdout: off
           events:
             process: true
             file: true
@@ -38,7 +38,7 @@ datasources:
             mode: prevent
           logging:
             file: info
-            stdout: debug
+            stdout: off
           events:
             registry: true
             process: true
@@ -52,7 +52,7 @@ datasources:
             mode: detect
           logging:
             file: info
-            stdout: debug
+            stdout: off
           events:
             process: true
             file: true


### PR DESCRIPTION
## Summary

Issue:
https://github.com/elastic/endpoint-app-team/issues/295

- [x] add default input for the endpoint datasource.
- [x] exclude all advanced sections of the input. 