### PR TITLE
Using docker to run the registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+# This should start the environment with the latest snapshots.
+
+version: "3.8"
+services:
+  package-registry:
+    image: docker.elastic.co/package-registry/package-registry:master
+    volumes:
+      - ./package-registry.config.yml:/registry/config.yml
+      - ./out/packages:/registry/packages/endpoint-package
+    ports:
+      - "127.0.0.1:8080:8080"

--- a/package-registry.config.yml
+++ b/package-registry.config.yml
@@ -1,0 +1,4 @@
+package_paths:
+  - /registry/packages/endpoint-package
+  - /registry/packages/package-storage
+dev_mode: true


### PR DESCRIPTION
This PR removes the use of go and mage to run the registry. The package-registry removed support for the PACKAGE_PATHS variable so we need to use docker instead.