### PR TITLE
Temporary fix for double package issue

### DIFF
--- a/package-registry.config.yml
+++ b/package-registry.config.yml
@@ -1,4 +1,4 @@
 package_paths:
-  - /registry/packages/endpoint-package
   - /registry/packages/package-storage
+  - /registry/packages/endpoint-package
 dev_mode: true


### PR DESCRIPTION
This fixes an issue with the package registry returning two "latest" packages instead of the local one from the endpoint-package directory.