### PR TITLE
Switching id to name in manifests

### DIFF
--- a/package/endpoint/dataset/file/manifest.yml
+++ b/package/endpoint/dataset/file/manifest.yml
@@ -2,4 +2,4 @@ title: Endpoint File Events
 
 type: logs
 
-id: endpoint.events.file
+name: endpoint.events.file

--- a/package/endpoint/dataset/library/manifest.yml
+++ b/package/endpoint/dataset/library/manifest.yml
@@ -2,4 +2,4 @@ title: Endpoint Library and Driver Events
 
 type: logs
 
-id: endpoint.events.library
+name: endpoint.events.library

--- a/package/endpoint/dataset/network/manifest.yml
+++ b/package/endpoint/dataset/network/manifest.yml
@@ -2,4 +2,4 @@ title: Endpoint Network Events
 
 type: logs
 
-id: endpoint.events.network
+name: endpoint.events.network

--- a/package/endpoint/dataset/process/manifest.yml
+++ b/package/endpoint/dataset/process/manifest.yml
@@ -2,4 +2,4 @@ title: Endpoint Process Events
 
 type: logs
 
-id: endpoint.events.process
+name: endpoint.events.process

--- a/package/endpoint/dataset/registry/manifest.yml
+++ b/package/endpoint/dataset/registry/manifest.yml
@@ -2,4 +2,4 @@ title: Endpoint Registry Events
 
 type: logs
 
-id: endpoint.events.registry
+name: endpoint.events.registry

--- a/package/endpoint/dataset/security/manifest.yml
+++ b/package/endpoint/dataset/security/manifest.yml
@@ -2,4 +2,4 @@ title: Endpoint Security Events
 
 type: logs
 
-id: endpoint.events.security
+name: endpoint.events.security


### PR DESCRIPTION
`id` has been moved to `name` in the dataset manifest for the package registry.