### PR TITLE
Disable indexing on malware features and call stack

### DIFF
--- a/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
@@ -54,6 +54,7 @@ fields:
               version: {}
               upx_packed: {}
               features:
+                enabled: false
                 fields:
                   data:
                     fields:
@@ -292,6 +293,7 @@ fields:
               version: {}
               upx_packed: {}
               features:
+                enabled: false
                 fields:
                   data:
                     fields:
@@ -400,6 +402,7 @@ fields:
           Ext:
             fields:
               call_stack:
+                enabled: false
                 fields:
                   module_path: {}
                   instruction_pointer: {}
@@ -464,6 +467,7 @@ fields:
               version: {}
               upx_packed: {}
               features:
+                enabled: false
                 fields:
                   data:
                     fields:
@@ -584,6 +588,7 @@ fields:
                   version: {}
                   upx_packed: {}
                   features:
+                    enabled: false
                     fields:
                       data:
                         fields:
@@ -643,6 +648,7 @@ fields:
               Ext:
                 fields:
                   call_stack:
+                    enabled: false
                     fields:
                       module_path: {}
                       instruction_pointer: {}
@@ -707,6 +713,7 @@ fields:
                   version: {}
                   upx_packed: {}
                   features:
+                    enabled: false
                     fields:
                       data:
                         fields:

--- a/generated/alerts/ecs/ecs_flat.yml
+++ b/generated/alerts/ecs/ecs_flat.yml
@@ -207,6 +207,13 @@ Target.dll.Ext.compile_time:
   original_fieldset: dll
   short: Timestamp from when the module was compiled.
   type: date
+Target.dll.Ext.malware_classification.features:
+  dashed_name: Target-dll-Ext-malware-classification-features
+  enabled: false
+  flat_name: Target.dll.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 Target.dll.Ext.malware_classification.features.data.buffer:
   dashed_name: Target-dll-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -625,6 +632,13 @@ Target.process.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+Target.process.Ext.malware_classification.features:
+  dashed_name: Target-process-Ext-malware-classification-features
+  enabled: false
+  flat_name: Target.process.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 Target.process.Ext.malware_classification.features.data.buffer:
   dashed_name: Target-process-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -1727,6 +1741,16 @@ Target.process.thread.Ext:
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
+Target.process.thread.Ext.call_stack:
+  dashed_name: Target-process-thread-Ext-call-stack
+  description: Fields describing a stack frame.  call_stack is expected to be an array
+    where each array element represents a stack frame.
+  enabled: false
+  flat_name: Target.process.thread.Ext.call_stack
+  name: call_stack
+  original_fieldset: call_stack
+  short: Fields describing a stack frame.
+  type: group
 Target.process.thread.Ext.call_stack.instruction_pointer:
   dashed_name: Target-process-thread-Ext-call-stack-instruction-pointer
   description: The return address of this stack frame.
@@ -2204,6 +2228,13 @@ dll.Ext.compile_time:
   normalize: []
   short: Timestamp from when the module was compiled.
   type: date
+dll.Ext.malware_classification.features:
+  dashed_name: dll-Ext-malware-classification-features
+  enabled: false
+  flat_name: dll.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 dll.Ext.malware_classification.features.data.buffer:
   dashed_name: dll-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -3542,6 +3573,13 @@ file.Ext.macro.stream.raw_code_size:
   original_fieldset: macro
   short: The original stream size.  Indicates whether stream.raw_code was truncated.
   type: keyword
+file.Ext.malware_classification.features:
+  dashed_name: file-Ext-malware-classification-features
+  enabled: false
+  flat_name: file.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 file.Ext.malware_classification.features.data.buffer:
   dashed_name: file-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -4905,6 +4943,13 @@ process.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.Ext.malware_classification.features:
+  dashed_name: process-Ext-malware-classification-features
+  enabled: false
+  flat_name: process.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 process.Ext.malware_classification.features.data.buffer:
   dashed_name: process-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -5966,6 +6011,16 @@ process.thread.Ext:
   object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
+process.thread.Ext.call_stack:
+  dashed_name: process-thread-Ext-call-stack
+  description: Fields describing a stack frame.  call_stack is expected to be an array
+    where each array element represents a stack frame.
+  enabled: false
+  flat_name: process.thread.Ext.call_stack
+  name: call_stack
+  original_fieldset: call_stack
+  short: Fields describing a stack frame.
+  type: group
 process.thread.Ext.call_stack.instruction_pointer:
   dashed_name: process-thread-Ext-call-stack-instruction-pointer
   description: The return address of this stack frame.

--- a/generated/alerts/ecs/subset/malware_event/ecs_flat.yml
+++ b/generated/alerts/ecs/subset/malware_event/ecs_flat.yml
@@ -208,6 +208,13 @@ Target.dll.Ext.compile_time:
   original_fieldset: dll
   short: Timestamp from when the module was compiled.
   type: date
+Target.dll.Ext.malware_classification.features:
+  dashed_name: Target-dll-Ext-malware-classification-features
+  enabled: false
+  flat_name: Target.dll.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 Target.dll.Ext.malware_classification.features.data.buffer:
   dashed_name: Target-dll-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -630,6 +637,13 @@ Target.process.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+Target.process.Ext.malware_classification.features:
+  dashed_name: Target-process-Ext-malware-classification-features
+  enabled: false
+  flat_name: Target.process.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 Target.process.Ext.malware_classification.features.data.buffer:
   dashed_name: Target-process-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -1760,6 +1774,16 @@ Target.process.thread.Ext:
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
+Target.process.thread.Ext.call_stack:
+  dashed_name: Target-process-thread-Ext-call-stack
+  description: Fields describing a stack frame.  call_stack is expected to be an array
+    where each array element represents a stack frame.
+  enabled: false
+  flat_name: Target.process.thread.Ext.call_stack
+  name: call_stack
+  original_fieldset: call_stack
+  short: Fields describing a stack frame.
+  type: group
 Target.process.thread.Ext.call_stack.instruction_pointer:
   dashed_name: Target-process-thread-Ext-call-stack-instruction-pointer
   description: The return address of this stack frame.
@@ -2241,6 +2265,13 @@ dll.Ext.compile_time:
   normalize: []
   short: Timestamp from when the module was compiled.
   type: date
+dll.Ext.malware_classification.features:
+  dashed_name: dll-Ext-malware-classification-features
+  enabled: false
+  flat_name: dll.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 dll.Ext.malware_classification.features.data.buffer:
   dashed_name: dll-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -3593,6 +3624,13 @@ file.Ext.macro.stream.raw_code_size:
   original_fieldset: macro
   short: The original stream size.  Indicates whether stream.raw_code was truncated.
   type: keyword
+file.Ext.malware_classification.features:
+  dashed_name: file-Ext-malware-classification-features
+  enabled: false
+  flat_name: file.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 file.Ext.malware_classification.features.data.buffer:
   dashed_name: file-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -5000,6 +5038,13 @@ process.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.Ext.malware_classification.features:
+  dashed_name: process-Ext-malware-classification-features
+  enabled: false
+  flat_name: process.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 process.Ext.malware_classification.features.data.buffer:
   dashed_name: process-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -6089,6 +6134,16 @@ process.thread.Ext:
   object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
+process.thread.Ext.call_stack:
+  dashed_name: process-thread-Ext-call-stack
+  description: Fields describing a stack frame.  call_stack is expected to be an array
+    where each array element represents a stack frame.
+  enabled: false
+  flat_name: process.thread.Ext.call_stack
+  name: call_stack
+  original_fieldset: call_stack
+  short: Fields describing a stack frame.
+  type: group
 process.thread.Ext.call_stack.instruction_pointer:
   dashed_name: process-thread-Ext-call-stack-instruction-pointer
   description: The return address of this stack frame.

--- a/generated/alerts/elasticsearch/7/template.json
+++ b/generated/alerts/elasticsearch/7/template.json
@@ -114,6 +114,7 @@
                   "malware_classification": {
                     "properties": {
                       "features": {
+                        "enabled": false,
                         "properties": {
                           "data": {
                             "properties": {
@@ -130,7 +131,8 @@
                               }
                             }
                           }
-                        }
+                        },
+                        "type": "object"
                       },
                       "identifier": {
                         "ignore_above": 1024,
@@ -273,6 +275,7 @@
                   "malware_classification": {
                     "properties": {
                       "features": {
+                        "enabled": false,
                         "properties": {
                           "data": {
                             "properties": {
@@ -289,7 +292,8 @@
                               }
                             }
                           }
-                        }
+                        },
+                        "type": "object"
                       },
                       "identifier": {
                         "ignore_above": 1024,
@@ -712,7 +716,8 @@
                             "ignore_above": 1024,
                             "type": "keyword"
                           }
-                        }
+                        },
+                        "type": "group"
                       },
                       "service": {
                         "ignore_above": 1024,
@@ -875,6 +880,7 @@
               "malware_classification": {
                 "properties": {
                   "features": {
+                    "enabled": false,
                     "properties": {
                       "data": {
                         "properties": {
@@ -891,7 +897,8 @@
                           }
                         }
                       }
-                    }
+                    },
+                    "type": "object"
                   },
                   "identifier": {
                     "ignore_above": 1024,
@@ -1220,6 +1227,7 @@
               "malware_classification": {
                 "properties": {
                   "features": {
+                    "enabled": false,
                     "properties": {
                       "data": {
                         "properties": {
@@ -1236,7 +1244,8 @@
                           }
                         }
                       }
-                    }
+                    },
+                    "type": "object"
                   },
                   "identifier": {
                     "ignore_above": 1024,
@@ -1760,6 +1769,7 @@
               "malware_classification": {
                 "properties": {
                   "features": {
+                    "enabled": false,
                     "properties": {
                       "data": {
                         "properties": {
@@ -1776,7 +1786,8 @@
                           }
                         }
                       }
-                    }
+                    },
+                    "type": "object"
                   },
                   "identifier": {
                     "ignore_above": 1024,
@@ -2199,7 +2210,8 @@
                         "ignore_above": 1024,
                         "type": "keyword"
                       }
-                    }
+                    },
+                    "type": "group"
                   },
                   "service": {
                     "ignore_above": 1024,

--- a/package/endpoint/dataset/alerts/fields/fields.yml
+++ b/package/endpoint/dataset/alerts/fields/fields.yml
@@ -152,6 +152,10 @@
     type: date
     description: Timestamp from when the module was compiled.
     default_field: false
+  - name: dll.Ext.malware_classification.features
+    type: object
+    enabled: false
+    default_field: false
   - name: dll.Ext.malware_classification.features.data.buffer
     level: custom
     type: keyword
@@ -390,6 +394,10 @@
 
       Leave unpopulated if a certificate was unchecked.'
     example: 'true'
+    default_field: false
+  - name: process.Ext.malware_classification.features
+    type: object
+    enabled: false
     default_field: false
   - name: process.Ext.malware_classification.features.data.buffer
     level: custom
@@ -1048,6 +1056,12 @@
     object_type: keyword
     description: Object for all custom defined fields to live in.
     default_field: false
+  - name: process.thread.Ext.call_stack
+    type: group
+    description: Fields describing a stack frame.  call_stack is expected to be
+      an array where each array element represents a stack frame.
+    enabled: false
+    default_field: false
   - name: process.thread.Ext.call_stack.instruction_pointer
     level: custom
     type: keyword
@@ -1359,6 +1373,10 @@
     level: custom
     type: date
     description: Timestamp from when the module was compiled.
+    default_field: false
+  - name: Ext.malware_classification.features
+    type: object
+    enabled: false
     default_field: false
   - name: Ext.malware_classification.features.data.buffer
     level: custom
@@ -1982,6 +2000,10 @@
     ignore_above: 1024
     description: The original stream size.  Indicates whether stream.raw_code was
       truncated.
+    default_field: false
+  - name: Ext.malware_classification.features
+    type: object
+    enabled: false
     default_field: false
   - name: Ext.malware_classification.features.data.buffer
     level: custom
@@ -2782,6 +2804,10 @@
       Leave unpopulated if a certificate was unchecked.'
     example: 'true'
     default_field: false
+  - name: Ext.malware_classification.features
+    type: object
+    enabled: false
+    default_field: false
   - name: Ext.malware_classification.features.data.buffer
     level: custom
     type: keyword
@@ -3429,6 +3455,12 @@
     type: object
     object_type: keyword
     description: Object for all custom defined fields to live in.
+    default_field: false
+  - name: thread.Ext.call_stack
+    type: group
+    description: Fields describing a stack frame.  call_stack is expected to be
+      an array where each array element represents a stack frame.
+    enabled: false
     default_field: false
   - name: thread.Ext.call_stack.instruction_pointer
     level: custom

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -207,6 +207,13 @@ Target.dll.Ext.compile_time:
   original_fieldset: dll
   short: Timestamp from when the module was compiled.
   type: date
+Target.dll.Ext.malware_classification.features:
+  dashed_name: Target-dll-Ext-malware-classification-features
+  enabled: false
+  flat_name: Target.dll.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 Target.dll.Ext.malware_classification.features.data.buffer:
   dashed_name: Target-dll-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -625,6 +632,13 @@ Target.process.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+Target.process.Ext.malware_classification.features:
+  dashed_name: Target-process-Ext-malware-classification-features
+  enabled: false
+  flat_name: Target.process.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 Target.process.Ext.malware_classification.features.data.buffer:
   dashed_name: Target-process-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -1727,6 +1741,16 @@ Target.process.thread.Ext:
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
+Target.process.thread.Ext.call_stack:
+  dashed_name: Target-process-thread-Ext-call-stack
+  description: Fields describing a stack frame.  call_stack is expected to be an array
+    where each array element represents a stack frame.
+  enabled: false
+  flat_name: Target.process.thread.Ext.call_stack
+  name: call_stack
+  original_fieldset: call_stack
+  short: Fields describing a stack frame.
+  type: group
 Target.process.thread.Ext.call_stack.instruction_pointer:
   dashed_name: Target-process-thread-Ext-call-stack-instruction-pointer
   description: The return address of this stack frame.
@@ -2204,6 +2228,13 @@ dll.Ext.compile_time:
   normalize: []
   short: Timestamp from when the module was compiled.
   type: date
+dll.Ext.malware_classification.features:
+  dashed_name: dll-Ext-malware-classification-features
+  enabled: false
+  flat_name: dll.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 dll.Ext.malware_classification.features.data.buffer:
   dashed_name: dll-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -3542,6 +3573,13 @@ file.Ext.macro.stream.raw_code_size:
   original_fieldset: macro
   short: The original stream size.  Indicates whether stream.raw_code was truncated.
   type: keyword
+file.Ext.malware_classification.features:
+  dashed_name: file-Ext-malware-classification-features
+  enabled: false
+  flat_name: file.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 file.Ext.malware_classification.features.data.buffer:
   dashed_name: file-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -4905,6 +4943,13 @@ process.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.Ext.malware_classification.features:
+  dashed_name: process-Ext-malware-classification-features
+  enabled: false
+  flat_name: process.Ext.malware_classification.features
+  name: features
+  original_fieldset: malware_classification
+  type: object
 process.Ext.malware_classification.features.data.buffer:
   dashed_name: process-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -5966,6 +6011,16 @@ process.thread.Ext:
   object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
+process.thread.Ext.call_stack:
+  dashed_name: process-thread-Ext-call-stack
+  description: Fields describing a stack frame.  call_stack is expected to be an array
+    where each array element represents a stack frame.
+  enabled: false
+  flat_name: process.thread.Ext.call_stack
+  name: call_stack
+  original_fieldset: call_stack
+  short: Fields describing a stack frame.
+  type: group
 process.thread.Ext.call_stack.instruction_pointer:
   dashed_name: process-thread-Ext-call-stack-instruction-pointer
   description: The return address of this stack frame.


### PR DESCRIPTION
Adds `enabled: false` to fields that don't need to be indexed in malware alerts.  Works in conjunction with a new commit to https://github.com/marshallmain/ecs/tree/subset-format-update that fixes a bug where custom options on intermediate fields that are not explicitly listed in the schema (e.g. `malware_classification.features`) did not cause the intermediate fields to be listed in the generated files. To force `make` to use the new commit to the ECS tooling, run `make clean` first.