### PR TITLE
Disable dynamic mapping for all datasets

### DIFF
--- a/package/endpoint/dataset/alerts/manifest.yml
+++ b/package/endpoint/dataset/alerts/manifest.yml
@@ -1,3 +1,7 @@
 title: Endpoint Alerts
 
 type: logs
+
+elasticsearch:
+  index_template.mappings:
+    dynamic: false

--- a/package/endpoint/dataset/file/manifest.yml
+++ b/package/endpoint/dataset/file/manifest.yml
@@ -3,3 +3,7 @@ title: Endpoint File Events
 type: logs
 
 name: endpoint.events.file
+
+elasticsearch:
+  index_template.mappings:
+    dynamic: false

--- a/package/endpoint/dataset/library/manifest.yml
+++ b/package/endpoint/dataset/library/manifest.yml
@@ -3,3 +3,7 @@ title: Endpoint Library and Driver Events
 type: logs
 
 name: endpoint.events.library
+
+elasticsearch:
+  index_template.mappings:
+    dynamic: false

--- a/package/endpoint/dataset/metadata/manifest.yml
+++ b/package/endpoint/dataset/metadata/manifest.yml
@@ -1,3 +1,7 @@
 title: Endpoint Metadata
 
 type: metrics
+
+elasticsearch:
+  index_template.mappings:
+    dynamic: false

--- a/package/endpoint/dataset/metadata_mirror/manifest.yml
+++ b/package/endpoint/dataset/metadata_mirror/manifest.yml
@@ -1,3 +1,7 @@
 title: Endpoint Metadata Mirror
 
 type: metrics
+
+elasticsearch:
+  index_template.mappings:
+    dynamic: false

--- a/package/endpoint/dataset/network/manifest.yml
+++ b/package/endpoint/dataset/network/manifest.yml
@@ -3,3 +3,7 @@ title: Endpoint Network Events
 type: logs
 
 name: endpoint.events.network
+
+elasticsearch:
+  index_template.mappings:
+    dynamic: false

--- a/package/endpoint/dataset/policy/manifest.yml
+++ b/package/endpoint/dataset/policy/manifest.yml
@@ -1,3 +1,7 @@
 title: Endpoint Policy Response
 
 type: metrics
+
+elasticsearch:
+  index_template.mappings:
+    dynamic: false

--- a/package/endpoint/dataset/process/manifest.yml
+++ b/package/endpoint/dataset/process/manifest.yml
@@ -3,3 +3,7 @@ title: Endpoint Process Events
 type: logs
 
 name: endpoint.events.process
+
+elasticsearch:
+  index_template.mappings:
+    dynamic: false

--- a/package/endpoint/dataset/registry/manifest.yml
+++ b/package/endpoint/dataset/registry/manifest.yml
@@ -3,3 +3,7 @@ title: Endpoint Registry Events
 type: logs
 
 name: endpoint.events.registry
+
+elasticsearch:
+  index_template.mappings:
+    dynamic: false

--- a/package/endpoint/dataset/security/manifest.yml
+++ b/package/endpoint/dataset/security/manifest.yml
@@ -3,3 +3,7 @@ title: Endpoint Security Events
 type: logs
 
 name: endpoint.events.security
+
+elasticsearch:
+  index_template.mappings:
+    dynamic: false

--- a/package/endpoint/dataset/telemetry/manifest.yml
+++ b/package/endpoint/dataset/telemetry/manifest.yml
@@ -1,3 +1,7 @@
 title: Endpoint Telemetry
 
 type: metrics
+
+elasticsearch:
+  index_template.mappings:
+    dynamic: false


### PR DESCRIPTION
This PR disables the dynamic mappings for all templates that get created by the package.

It'll work once this PR gets merged: https://github.com/elastic/kibana/pull/70517