### PR TITLE
Change target.dll.code_signature as well

### DIFF
--- a/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
@@ -534,13 +534,6 @@ fields:
         fields:
           name: {}
           path: {}
-          code_signature:
-            fields:
-              exists: {}
-              status: {}
-              subject_name: {}
-              trusted: {}
-              valid: {}
           hash:
             fields:
               md5: {}
@@ -558,6 +551,13 @@ fields:
             fields:
               mapped_address: {}
               mapped_size: {}
+              code_signature:
+                fields:
+                  exists: {}
+                  status: {}
+                  subject_name: {}
+                  trusted: {}
+                  valid: {}
               compile_time: {}
               malware_classification:
                 fields:

--- a/generated/alerts/ecs/ecs_flat.yml
+++ b/generated/alerts/ecs/ecs_flat.yml
@@ -197,6 +197,84 @@ Target.dll.Ext:
   original_fieldset: dll
   short: Object for all custom defined fields to live in.
   type: object
+Target.dll.Ext.code_signature:
+  dashed_name: Target-dll-Ext-code-signature
+  description: Nested version of ECS code_signature fieldset.
+  flat_name: Target.dll.Ext.code_signature
+  level: custom
+  name: Ext.code_signature
+  normalize: []
+  original_fieldset: dll
+  short: Nested version of ECS code_signature fieldset.
+  type: nested
+Target.dll.Ext.code_signature.exists:
+  dashed_name: Target-dll-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: Target.dll.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  original_fieldset: dll
+  short: Boolean to capture if a signature is present.
+  type: boolean
+Target.dll.Ext.code_signature.status:
+  dashed_name: Target-dll-Ext-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: Target.dll.Ext.code_signature.status
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.status
+  normalize: []
+  original_fieldset: dll
+  short: Additional information about the certificate status.
+  type: keyword
+Target.dll.Ext.code_signature.subject_name:
+  dashed_name: Target-dll-Ext-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: Target.dll.Ext.code_signature.subject_name
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.subject_name
+  normalize: []
+  original_fieldset: dll
+  short: Subject name of the code signer
+  type: keyword
+Target.dll.Ext.code_signature.trusted:
+  dashed_name: Target-dll-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: Target.dll.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  original_fieldset: dll
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+Target.dll.Ext.code_signature.valid:
+  dashed_name: Target-dll-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: Target.dll.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  original_fieldset: dll
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 Target.dll.Ext.compile_time:
   dashed_name: Target-dll-Ext-compile-time
   description: Timestamp from when the module was compiled.
@@ -323,74 +401,6 @@ Target.dll.Ext.mapped_size:
   original_fieldset: dll
   short: The size of this module's memory mapping, in bytes.
   type: long
-Target.dll.code_signature.exists:
-  dashed_name: Target-dll-code-signature-exists
-  description: Boolean to capture if a signature is present.
-  example: 'true'
-  flat_name: Target.dll.code_signature.exists
-  level: core
-  name: exists
-  normalize: []
-  original_fieldset: code_signature
-  short: Boolean to capture if a signature is present.
-  type: boolean
-Target.dll.code_signature.status:
-  dashed_name: Target-dll-code-signature-status
-  description: 'Additional information about the certificate status.
-
-    This is useful for logging cryptographic errors with the certificate validity
-    or trust status. Leave unpopulated if the validity or trust of the certificate
-    was unchecked.'
-  example: ERROR_UNTRUSTED_ROOT
-  flat_name: Target.dll.code_signature.status
-  ignore_above: 1024
-  level: extended
-  name: status
-  normalize: []
-  original_fieldset: code_signature
-  short: Additional information about the certificate status.
-  type: keyword
-Target.dll.code_signature.subject_name:
-  dashed_name: Target-dll-code-signature-subject-name
-  description: Subject name of the code signer
-  example: Microsoft Corporation
-  flat_name: Target.dll.code_signature.subject_name
-  ignore_above: 1024
-  level: core
-  name: subject_name
-  normalize: []
-  original_fieldset: code_signature
-  short: Subject name of the code signer
-  type: keyword
-Target.dll.code_signature.trusted:
-  dashed_name: Target-dll-code-signature-trusted
-  description: 'Stores the trust status of the certificate chain.
-
-    Validating the trust of the certificate chain may be complicated, and this field
-    should only be populated by tools that actively check the status.'
-  example: 'true'
-  flat_name: Target.dll.code_signature.trusted
-  level: extended
-  name: trusted
-  normalize: []
-  original_fieldset: code_signature
-  short: Stores the trust status of the certificate chain.
-  type: boolean
-Target.dll.code_signature.valid:
-  dashed_name: Target-dll-code-signature-valid
-  description: 'Boolean to capture if the digital signature is verified against the
-    binary content.
-
-    Leave unpopulated if a certificate was unchecked.'
-  example: 'true'
-  flat_name: Target.dll.code_signature.valid
-  level: extended
-  name: valid
-  normalize: []
-  original_fieldset: code_signature
-  short: Boolean to capture if the digital signature is verified against the binary
-    content.
-  type: boolean
 Target.dll.hash.md5:
   dashed_name: Target-dll-hash-md5
   description: MD5 hash.

--- a/generated/alerts/ecs/subset/malware_event/ecs_flat.yml
+++ b/generated/alerts/ecs/subset/malware_event/ecs_flat.yml
@@ -198,6 +198,84 @@ Target.dll.Ext:
   original_fieldset: dll
   short: Object for all custom defined fields to live in.
   type: object
+Target.dll.Ext.code_signature:
+  dashed_name: Target-dll-Ext-code-signature
+  description: Nested version of ECS code_signature fieldset.
+  flat_name: Target.dll.Ext.code_signature
+  level: custom
+  name: Ext.code_signature
+  normalize: []
+  original_fieldset: dll
+  short: Nested version of ECS code_signature fieldset.
+  type: nested
+Target.dll.Ext.code_signature.exists:
+  dashed_name: Target-dll-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: Target.dll.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  original_fieldset: dll
+  short: Boolean to capture if a signature is present.
+  type: boolean
+Target.dll.Ext.code_signature.status:
+  dashed_name: Target-dll-Ext-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: Target.dll.Ext.code_signature.status
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.status
+  normalize: []
+  original_fieldset: dll
+  short: Additional information about the certificate status.
+  type: keyword
+Target.dll.Ext.code_signature.subject_name:
+  dashed_name: Target-dll-Ext-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: Target.dll.Ext.code_signature.subject_name
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.subject_name
+  normalize: []
+  original_fieldset: dll
+  short: Subject name of the code signer
+  type: keyword
+Target.dll.Ext.code_signature.trusted:
+  dashed_name: Target-dll-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: Target.dll.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  original_fieldset: dll
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+Target.dll.Ext.code_signature.valid:
+  dashed_name: Target-dll-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: Target.dll.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  original_fieldset: dll
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 Target.dll.Ext.compile_time:
   dashed_name: Target-dll-Ext-compile-time
   description: Timestamp from when the module was compiled.
@@ -324,74 +402,6 @@ Target.dll.Ext.mapped_size:
   original_fieldset: dll
   short: The size of this module's memory mapping, in bytes.
   type: long
-Target.dll.code_signature.exists:
-  dashed_name: Target-dll-code-signature-exists
-  description: Boolean to capture if a signature is present.
-  example: 'true'
-  flat_name: Target.dll.code_signature.exists
-  level: core
-  name: exists
-  normalize: []
-  original_fieldset: code_signature
-  short: Boolean to capture if a signature is present.
-  type: boolean
-Target.dll.code_signature.status:
-  dashed_name: Target-dll-code-signature-status
-  description: 'Additional information about the certificate status.
-
-    This is useful for logging cryptographic errors with the certificate validity
-    or trust status. Leave unpopulated if the validity or trust of the certificate
-    was unchecked.'
-  example: ERROR_UNTRUSTED_ROOT
-  flat_name: Target.dll.code_signature.status
-  ignore_above: 1024
-  level: extended
-  name: status
-  normalize: []
-  original_fieldset: code_signature
-  short: Additional information about the certificate status.
-  type: keyword
-Target.dll.code_signature.subject_name:
-  dashed_name: Target-dll-code-signature-subject-name
-  description: Subject name of the code signer
-  example: Microsoft Corporation
-  flat_name: Target.dll.code_signature.subject_name
-  ignore_above: 1024
-  level: core
-  name: subject_name
-  normalize: []
-  original_fieldset: code_signature
-  short: Subject name of the code signer
-  type: keyword
-Target.dll.code_signature.trusted:
-  dashed_name: Target-dll-code-signature-trusted
-  description: 'Stores the trust status of the certificate chain.
-
-    Validating the trust of the certificate chain may be complicated, and this field
-    should only be populated by tools that actively check the status.'
-  example: 'true'
-  flat_name: Target.dll.code_signature.trusted
-  level: extended
-  name: trusted
-  normalize: []
-  original_fieldset: code_signature
-  short: Stores the trust status of the certificate chain.
-  type: boolean
-Target.dll.code_signature.valid:
-  dashed_name: Target-dll-code-signature-valid
-  description: 'Boolean to capture if the digital signature is verified against the
-    binary content.
-
-    Leave unpopulated if a certificate was unchecked.'
-  example: 'true'
-  flat_name: Target.dll.code_signature.valid
-  level: extended
-  name: valid
-  normalize: []
-  original_fieldset: code_signature
-  short: Boolean to capture if the digital signature is verified against the binary
-    content.
-  type: boolean
 Target.dll.hash.md5:
   dashed_name: Target-dll-hash-md5
   description: MD5 hash.

--- a/generated/alerts/elasticsearch/7/template.json
+++ b/generated/alerts/elasticsearch/7/template.json
@@ -108,6 +108,28 @@
             "properties": {
               "Ext": {
                 "properties": {
+                  "code_signature": {
+                    "properties": {
+                      "exists": {
+                        "type": "boolean"
+                      },
+                      "status": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "subject_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "trusted": {
+                        "type": "boolean"
+                      },
+                      "valid": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "nested"
+                  },
                   "compile_time": {
                     "type": "date"
                   },
@@ -162,27 +184,6 @@
                   }
                 },
                 "type": "object"
-              },
-              "code_signature": {
-                "properties": {
-                  "exists": {
-                    "type": "boolean"
-                  },
-                  "status": {
-                    "ignore_above": 1024,
-                    "type": "keyword"
-                  },
-                  "subject_name": {
-                    "ignore_above": 1024,
-                    "type": "keyword"
-                  },
-                  "trusted": {
-                    "type": "boolean"
-                  },
-                  "valid": {
-                    "type": "boolean"
-                  }
-                }
               },
               "hash": {
                 "properties": {

--- a/package/endpoint/dataset/alerts/fields/fields.yml
+++ b/package/endpoint/dataset/alerts/fields/fields.yml
@@ -147,6 +147,53 @@
     object_type: keyword
     description: Object for all custom defined fields to live in.
     default_field: false
+  - name: dll.Ext.code_signature
+    level: custom
+    type: nested
+    description: Nested version of ECS code_signature fieldset.
+    default_field: false
+  - name: dll.Ext.code_signature.exists
+    level: custom
+    type: boolean
+    description: Boolean to capture if a signature is present.
+    example: 'true'
+    default_field: false
+  - name: dll.Ext.code_signature.status
+    level: custom
+    type: keyword
+    ignore_above: 1024
+    description: 'Additional information about the certificate status.
+
+      This is useful for logging cryptographic errors with the certificate validity
+      or trust status. Leave unpopulated if the validity or trust of the certificate
+      was unchecked.'
+    example: ERROR_UNTRUSTED_ROOT
+    default_field: false
+  - name: dll.Ext.code_signature.subject_name
+    level: custom
+    type: keyword
+    ignore_above: 1024
+    description: Subject name of the code signer
+    example: Microsoft Corporation
+    default_field: false
+  - name: dll.Ext.code_signature.trusted
+    level: custom
+    type: boolean
+    description: 'Stores the trust status of the certificate chain.
+
+      Validating the trust of the certificate chain may be complicated, and this
+      field should only be populated by tools that actively check the status.'
+    example: 'true'
+    default_field: false
+  - name: dll.Ext.code_signature.valid
+    level: custom
+    type: boolean
+    description: 'Boolean to capture if the digital signature is verified against
+      the binary content.
+
+      Leave unpopulated if a certificate was unchecked.'
+    example: 'true'
+    default_field: false
   - name: dll.Ext.compile_time
     level: custom
     type: date
@@ -212,48 +259,6 @@
     level: custom
     type: long
     description: The size of this module's memory mapping, in bytes.
-    default_field: false
-  - name: dll.code_signature.exists
-    level: core
-    type: boolean
-    description: Boolean to capture if a signature is present.
-    example: 'true'
-    default_field: false
-  - name: dll.code_signature.status
-    level: extended
-    type: keyword
-    ignore_above: 1024
-    description: 'Additional information about the certificate status.
-
-      This is useful for logging cryptographic errors with the certificate validity
-      or trust status. Leave unpopulated if the validity or trust of the certificate
-      was unchecked.'
-    example: ERROR_UNTRUSTED_ROOT
-    default_field: false
-  - name: dll.code_signature.subject_name
-    level: core
-    type: keyword
-    ignore_above: 1024
-    description: Subject name of the code signer
-    example: Microsoft Corporation
-    default_field: false
-  - name: dll.code_signature.trusted
-    level: extended
-    type: boolean
-    description: 'Stores the trust status of the certificate chain.
-
-      Validating the trust of the certificate chain may be complicated, and this
-      field should only be populated by tools that actively check the status.'
-    example: 'true'
-    default_field: false
-  - name: dll.code_signature.valid
-    level: extended
-    type: boolean
-    description: 'Boolean to capture if the digital signature is verified against
-      the binary content.
-
-      Leave unpopulated if a certificate was unchecked.'
-    example: 'true'
     default_field: false
   - name: dll.hash.md5
     level: extended

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -197,6 +197,84 @@ Target.dll.Ext:
   original_fieldset: dll
   short: Object for all custom defined fields to live in.
   type: object
+Target.dll.Ext.code_signature:
+  dashed_name: Target-dll-Ext-code-signature
+  description: Nested version of ECS code_signature fieldset.
+  flat_name: Target.dll.Ext.code_signature
+  level: custom
+  name: Ext.code_signature
+  normalize: []
+  original_fieldset: dll
+  short: Nested version of ECS code_signature fieldset.
+  type: nested
+Target.dll.Ext.code_signature.exists:
+  dashed_name: Target-dll-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: Target.dll.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  original_fieldset: dll
+  short: Boolean to capture if a signature is present.
+  type: boolean
+Target.dll.Ext.code_signature.status:
+  dashed_name: Target-dll-Ext-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: Target.dll.Ext.code_signature.status
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.status
+  normalize: []
+  original_fieldset: dll
+  short: Additional information about the certificate status.
+  type: keyword
+Target.dll.Ext.code_signature.subject_name:
+  dashed_name: Target-dll-Ext-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: Target.dll.Ext.code_signature.subject_name
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.subject_name
+  normalize: []
+  original_fieldset: dll
+  short: Subject name of the code signer
+  type: keyword
+Target.dll.Ext.code_signature.trusted:
+  dashed_name: Target-dll-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: Target.dll.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  original_fieldset: dll
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+Target.dll.Ext.code_signature.valid:
+  dashed_name: Target-dll-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: Target.dll.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  original_fieldset: dll
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 Target.dll.Ext.compile_time:
   dashed_name: Target-dll-Ext-compile-time
   description: Timestamp from when the module was compiled.
@@ -323,74 +401,6 @@ Target.dll.Ext.mapped_size:
   original_fieldset: dll
   short: The size of this module's memory mapping, in bytes.
   type: long
-Target.dll.code_signature.exists:
-  dashed_name: Target-dll-code-signature-exists
-  description: Boolean to capture if a signature is present.
-  example: 'true'
-  flat_name: Target.dll.code_signature.exists
-  level: core
-  name: exists
-  normalize: []
-  original_fieldset: code_signature
-  short: Boolean to capture if a signature is present.
-  type: boolean
-Target.dll.code_signature.status:
-  dashed_name: Target-dll-code-signature-status
-  description: 'Additional information about the certificate status.
-
-    This is useful for logging cryptographic errors with the certificate validity
-    or trust status. Leave unpopulated if the validity or trust of the certificate
-    was unchecked.'
-  example: ERROR_UNTRUSTED_ROOT
-  flat_name: Target.dll.code_signature.status
-  ignore_above: 1024
-  level: extended
-  name: status
-  normalize: []
-  original_fieldset: code_signature
-  short: Additional information about the certificate status.
-  type: keyword
-Target.dll.code_signature.subject_name:
-  dashed_name: Target-dll-code-signature-subject-name
-  description: Subject name of the code signer
-  example: Microsoft Corporation
-  flat_name: Target.dll.code_signature.subject_name
-  ignore_above: 1024
-  level: core
-  name: subject_name
-  normalize: []
-  original_fieldset: code_signature
-  short: Subject name of the code signer
-  type: keyword
-Target.dll.code_signature.trusted:
-  dashed_name: Target-dll-code-signature-trusted
-  description: 'Stores the trust status of the certificate chain.
-
-    Validating the trust of the certificate chain may be complicated, and this field
-    should only be populated by tools that actively check the status.'
-  example: 'true'
-  flat_name: Target.dll.code_signature.trusted
-  level: extended
-  name: trusted
-  normalize: []
-  original_fieldset: code_signature
-  short: Stores the trust status of the certificate chain.
-  type: boolean
-Target.dll.code_signature.valid:
-  dashed_name: Target-dll-code-signature-valid
-  description: 'Boolean to capture if the digital signature is verified against the
-    binary content.
-
-    Leave unpopulated if a certificate was unchecked.'
-  example: 'true'
-  flat_name: Target.dll.code_signature.valid
-  level: extended
-  name: valid
-  normalize: []
-  original_fieldset: code_signature
-  short: Boolean to capture if the digital signature is verified against the binary
-    content.
-  type: boolean
 Target.dll.hash.md5:
   dashed_name: Target-dll-hash-md5
   description: MD5 hash.


### PR DESCRIPTION
https://github.com/elastic/endpoint-package/pull/33 was meant to change over all `code_signature` fields to `Ext.code_signature`, but missed one at `target.dll.code_signature`.  This PR fixes that.