### PR TITLE
Adding pipeline and event.ingested field

### DIFF
--- a/custom_subsets/elastic_endpoint/file/file.yaml
+++ b/custom_subsets/elastic_endpoint/file/file.yaml
@@ -41,6 +41,7 @@ fields:
       outcome: {}
       sequence: {}
       type: {}
+      ingested: {}
   agent:
     fields:
       version: {}

--- a/custom_subsets/elastic_endpoint/file/unquarantine.yaml
+++ b/custom_subsets/elastic_endpoint/file/unquarantine.yaml
@@ -40,6 +40,7 @@ fields:
       outcome: {}
       sequence: {}
       type: {}
+      ingested: {}
       Ext:
         fields:
           correlation:

--- a/custom_subsets/elastic_endpoint/library/library.yaml
+++ b/custom_subsets/elastic_endpoint/library/library.yaml
@@ -40,6 +40,7 @@ fields:
       module: {}
       sequence: {}
       type: {}
+      ingested: {}
   agent:
     fields:
       version: {}

--- a/custom_subsets/elastic_endpoint/metadata/metadata.yaml
+++ b/custom_subsets/elastic_endpoint/metadata/metadata.yaml
@@ -19,6 +19,8 @@ fields:
       module: {}
       action: {}
       dataset: {}
+      ingested: {}
+      sequence: {}
   Endpoint:
     fields:
       status: {}

--- a/custom_subsets/elastic_endpoint/metrics/metrics.yaml
+++ b/custom_subsets/elastic_endpoint/metrics/metrics.yaml
@@ -46,3 +46,4 @@ fields:
       module: {}
       sequence: {}
       type: {}
+      ingested: {}

--- a/custom_subsets/elastic_endpoint/network/network.yaml
+++ b/custom_subsets/elastic_endpoint/network/network.yaml
@@ -40,6 +40,7 @@ fields:
       module: {}
       sequence: {}
       type: {}
+      ingested: {}
   agent:
     fields:
       version: {}

--- a/custom_subsets/elastic_endpoint/policy/policy.yaml
+++ b/custom_subsets/elastic_endpoint/policy/policy.yaml
@@ -26,6 +26,8 @@ fields:
       module: {}
       action: {}
       dataset: {}
+      ingested: {}
+      sequence: {}
   host:
     fields:
       id: {}

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -40,6 +40,7 @@ fields:
       module: {}
       sequence: {}
       type: {}
+      ingested: {}
   agent:
     fields:
       version: {}

--- a/custom_subsets/elastic_endpoint/registry/registry.yaml
+++ b/custom_subsets/elastic_endpoint/registry/registry.yaml
@@ -40,6 +40,7 @@ fields:
       module: {}
       sequence: {}
       type: {}
+      ingested: {}
   agent:
     fields:
       version: {}

--- a/custom_subsets/elastic_endpoint/security/security.yaml
+++ b/custom_subsets/elastic_endpoint/security/security.yaml
@@ -40,6 +40,7 @@ fields:
       module: {}
       sequence: {}
       type: {}
+      ingested: {}
   agent:
     fields:
       version: {}

--- a/generated/file/ecs/ecs_flat.yml
+++ b/generated/file/ecs/ecs_flat.yml
@@ -348,6 +348,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/file/ecs/subset/file/ecs_flat.yml
+++ b/generated/file/ecs/subset/file/ecs_flat.yml
@@ -318,6 +318,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/file/ecs/subset/unquarantine/ecs_flat.yml
+++ b/generated/file/ecs/subset/unquarantine/ecs_flat.yml
@@ -348,6 +348,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/file/elasticsearch/7/template.json
+++ b/generated/file/elasticsearch/7/template.json
@@ -94,6 +94,9 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "ingested": {
+            "type": "date"
+          },
           "kind": {
             "ignore_above": 1024,
             "type": "keyword"

--- a/generated/library/ecs/ecs_flat.yml
+++ b/generated/library/ecs/ecs_flat.yml
@@ -398,6 +398,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/library/ecs/subset/library/ecs_flat.yml
+++ b/generated/library/ecs/subset/library/ecs_flat.yml
@@ -398,6 +398,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/library/elasticsearch/7/template.json
+++ b/generated/library/elasticsearch/7/template.json
@@ -118,6 +118,9 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "ingested": {
+            "type": "date"
+          },
           "kind": {
             "ignore_above": 1024,
             "type": "keyword"

--- a/generated/metadata/ecs/ecs_flat.yml
+++ b/generated/metadata/ecs/ecs_flat.yml
@@ -400,6 +400,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable
@@ -486,6 +503,19 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.sequence:
+  dashed_name: event-sequence
+  description: 'Sequence number of the event.
+
+    The sequence number is a value published by some event sources, to make the exact
+    ordering of events unambiguous, regardless of the timestamp precision.'
+  flat_name: event.sequence
+  format: string
+  level: extended
+  name: sequence
+  normalize: []
+  short: Sequence number of the event.
+  type: long
 event.type:
   allowed_values:
   - description: The access event type is used for the subset of events within a category

--- a/generated/metadata/ecs/subset/metadata/ecs_flat.yml
+++ b/generated/metadata/ecs/subset/metadata/ecs_flat.yml
@@ -400,6 +400,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable
@@ -486,6 +503,19 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.sequence:
+  dashed_name: event-sequence
+  description: 'Sequence number of the event.
+
+    The sequence number is a value published by some event sources, to make the exact
+    ordering of events unambiguous, regardless of the timestamp precision.'
+  flat_name: event.sequence
+  format: string
+  level: extended
+  name: sequence
+  normalize: []
+  short: Sequence number of the event.
+  type: long
 event.type:
   allowed_values:
   - description: The access event type is used for the subset of events within a category

--- a/generated/metadata/elasticsearch/7/template.json
+++ b/generated/metadata/elasticsearch/7/template.json
@@ -123,6 +123,9 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "ingested": {
+            "type": "date"
+          },
           "kind": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -130,6 +133,9 @@
           "module": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "sequence": {
+            "type": "long"
           },
           "type": {
             "ignore_above": 1024,

--- a/generated/metrics/ecs/ecs_flat.yml
+++ b/generated/metrics/ecs/ecs_flat.yml
@@ -501,6 +501,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/metrics/ecs/subset/metrics/ecs_flat.yml
+++ b/generated/metrics/ecs/subset/metrics/ecs_flat.yml
@@ -501,6 +501,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/metrics/elasticsearch/7/template.json
+++ b/generated/metrics/elasticsearch/7/template.json
@@ -158,6 +158,9 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "ingested": {
+            "type": "date"
+          },
           "kind": {
             "ignore_above": 1024,
             "type": "keyword"

--- a/generated/network/ecs/ecs_flat.yml
+++ b/generated/network/ecs/ecs_flat.yml
@@ -542,6 +542,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/network/ecs/subset/network/ecs_flat.yml
+++ b/generated/network/ecs/subset/network/ecs_flat.yml
@@ -542,6 +542,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/network/elasticsearch/7/template.json
+++ b/generated/network/elasticsearch/7/template.json
@@ -155,6 +155,9 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "ingested": {
+            "type": "date"
+          },
           "kind": {
             "ignore_above": 1024,
             "type": "keyword"

--- a/generated/policy/ecs/ecs_flat.yml
+++ b/generated/policy/ecs/ecs_flat.yml
@@ -629,6 +629,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable
@@ -715,6 +732,19 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.sequence:
+  dashed_name: event-sequence
+  description: 'Sequence number of the event.
+
+    The sequence number is a value published by some event sources, to make the exact
+    ordering of events unambiguous, regardless of the timestamp precision.'
+  flat_name: event.sequence
+  format: string
+  level: extended
+  name: sequence
+  normalize: []
+  short: Sequence number of the event.
+  type: long
 event.type:
   allowed_values:
   - description: The access event type is used for the subset of events within a category

--- a/generated/policy/ecs/subset/policy/ecs_flat.yml
+++ b/generated/policy/ecs/subset/policy/ecs_flat.yml
@@ -629,6 +629,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable
@@ -715,6 +732,19 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.sequence:
+  dashed_name: event-sequence
+  description: 'Sequence number of the event.
+
+    The sequence number is a value published by some event sources, to make the exact
+    ordering of events unambiguous, regardless of the timestamp precision.'
+  flat_name: event.sequence
+  format: string
+  level: extended
+  name: sequence
+  normalize: []
+  short: Sequence number of the event.
+  type: long
 event.type:
   allowed_values:
   - description: The access event type is used for the subset of events within a category

--- a/generated/policy/elasticsearch/7/template.json
+++ b/generated/policy/elasticsearch/7/template.json
@@ -224,6 +224,9 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "ingested": {
+            "type": "date"
+          },
           "kind": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -231,6 +234,9 @@
           "module": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "sequence": {
+            "type": "long"
           },
           "type": {
             "ignore_above": 1024,

--- a/generated/process/ecs/ecs_flat.yml
+++ b/generated/process/ecs/ecs_flat.yml
@@ -318,6 +318,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/process/ecs/subset/process/ecs_flat.yml
+++ b/generated/process/ecs/subset/process/ecs_flat.yml
@@ -318,6 +318,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/process/elasticsearch/7/template.json
+++ b/generated/process/elasticsearch/7/template.json
@@ -80,6 +80,9 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "ingested": {
+            "type": "date"
+          },
           "kind": {
             "ignore_above": 1024,
             "type": "keyword"

--- a/generated/registry/ecs/ecs_flat.yml
+++ b/generated/registry/ecs/ecs_flat.yml
@@ -318,6 +318,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/registry/ecs/subset/registry/ecs_flat.yml
+++ b/generated/registry/ecs/subset/registry/ecs_flat.yml
@@ -318,6 +318,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/registry/elasticsearch/7/template.json
+++ b/generated/registry/elasticsearch/7/template.json
@@ -80,6 +80,9 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "ingested": {
+            "type": "date"
+          },
           "kind": {
             "ignore_above": 1024,
             "type": "keyword"

--- a/generated/security/ecs/ecs_flat.yml
+++ b/generated/security/ecs/ecs_flat.yml
@@ -318,6 +318,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/security/ecs/subset/security/ecs_flat.yml
+++ b/generated/security/ecs/subset/security/ecs_flat.yml
@@ -318,6 +318,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/generated/security/elasticsearch/7/template.json
+++ b/generated/security/elasticsearch/7/template.json
@@ -80,6 +80,9 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "ingested": {
+            "type": "date"
+          },
           "kind": {
             "ignore_above": 1024,
             "type": "keyword"

--- a/package/endpoint/dataset/alerts/elasticsearch/ingest_pipeline/default.json
+++ b/package/endpoint/dataset/alerts/elasticsearch/ingest_pipeline/default.json
@@ -1,0 +1,12 @@
+{
+  "description": "Pipeline for setting event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{ _ingest.timestamp }}",
+        "ignore_failure": true
+      }
+    }
+  ]
+}

--- a/package/endpoint/dataset/file/elasticsearch/ingest_pipeline/default.json
+++ b/package/endpoint/dataset/file/elasticsearch/ingest_pipeline/default.json
@@ -1,0 +1,12 @@
+{
+  "description": "Pipeline for setting event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{ _ingest.timestamp }}",
+        "ignore_failure": true
+      }
+    }
+  ]
+}

--- a/package/endpoint/dataset/file/fields/fields.yml
+++ b/package/endpoint/dataset/file/fields/fields.yml
@@ -196,6 +196,19 @@
     ignore_above: 1024
     description: Unique ID to describe the event.
     example: 8a4f500d
+  - name: ingested
+    level: core
+    type: date
+    description: 'Timestamp when an event arrived in the central data store.
+
+      This is different from `@timestamp`, which is when the event originally occurred.  It''s
+      also different from `event.created`, which is meant to capture the first time
+      an agent saw the event.
+
+      In normal conditions, assuming no tampering, the timestamps should chronologically
+      look like this: `@timestamp` < `event.created` < `event.ingested`.'
+    example: '2016-05-23T08:05:35.101Z'
+    default_field: false
   - name: kind
     level: core
     type: keyword

--- a/package/endpoint/dataset/library/elasticsearch/ingest_pipeline/default.json
+++ b/package/endpoint/dataset/library/elasticsearch/ingest_pipeline/default.json
@@ -1,0 +1,12 @@
+{
+  "description": "Pipeline for setting event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{ _ingest.timestamp }}",
+        "ignore_failure": true
+      }
+    }
+  ]
+}

--- a/package/endpoint/dataset/library/fields/fields.yml
+++ b/package/endpoint/dataset/library/fields/fields.yml
@@ -245,6 +245,19 @@
     ignore_above: 1024
     description: Unique ID to describe the event.
     example: 8a4f500d
+  - name: ingested
+    level: core
+    type: date
+    description: 'Timestamp when an event arrived in the central data store.
+
+      This is different from `@timestamp`, which is when the event originally occurred.  It''s
+      also different from `event.created`, which is meant to capture the first time
+      an agent saw the event.
+
+      In normal conditions, assuming no tampering, the timestamps should chronologically
+      look like this: `@timestamp` < `event.created` < `event.ingested`.'
+    example: '2016-05-23T08:05:35.101Z'
+    default_field: false
   - name: kind
     level: core
     type: keyword

--- a/package/endpoint/dataset/metadata/elasticsearch/ingest_pipeline/default.json
+++ b/package/endpoint/dataset/metadata/elasticsearch/ingest_pipeline/default.json
@@ -1,0 +1,12 @@
+{
+  "description": "Pipeline for setting event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{ _ingest.timestamp }}",
+        "ignore_failure": true
+      }
+    }
+  ]
+}

--- a/package/endpoint/dataset/metadata/fields/fields.yml
+++ b/package/endpoint/dataset/metadata/fields/fields.yml
@@ -232,6 +232,19 @@
     ignore_above: 1024
     description: Unique ID to describe the event.
     example: 8a4f500d
+  - name: ingested
+    level: core
+    type: date
+    description: 'Timestamp when an event arrived in the central data store.
+
+      This is different from `@timestamp`, which is when the event originally occurred.  It''s
+      also different from `event.created`, which is meant to capture the first time
+      an agent saw the event.
+
+      In normal conditions, assuming no tampering, the timestamps should chronologically
+      look like this: `@timestamp` < `event.created` < `event.ingested`.'
+    example: '2016-05-23T08:05:35.101Z'
+    default_field: false
   - name: kind
     level: core
     type: keyword
@@ -258,6 +271,14 @@
       events of a given source (e.g. Apache logs), `event.module` should contain
       the name of this module.'
     example: apache
+  - name: sequence
+    level: extended
+    type: long
+    format: string
+    description: 'Sequence number of the event.
+
+      The sequence number is a value published by some event sources, to make the
+      exact ordering of events unambiguous, regardless of the timestamp precision.'
   - name: type
     level: core
     type: keyword

--- a/package/endpoint/dataset/metrics/elasticsearch/ingest_pipeline/default.json
+++ b/package/endpoint/dataset/metrics/elasticsearch/ingest_pipeline/default.json
@@ -1,0 +1,12 @@
+{
+  "description": "Pipeline for setting event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{ _ingest.timestamp }}",
+        "ignore_failure": true
+      }
+    }
+  ]
+}

--- a/package/endpoint/dataset/metrics/fields/fields.yml
+++ b/package/endpoint/dataset/metrics/fields/fields.yml
@@ -270,6 +270,19 @@
     ignore_above: 1024
     description: Unique ID to describe the event.
     example: 8a4f500d
+  - name: ingested
+    level: core
+    type: date
+    description: 'Timestamp when an event arrived in the central data store.
+
+      This is different from `@timestamp`, which is when the event originally occurred.  It''s
+      also different from `event.created`, which is meant to capture the first time
+      an agent saw the event.
+
+      In normal conditions, assuming no tampering, the timestamps should chronologically
+      look like this: `@timestamp` < `event.created` < `event.ingested`.'
+    example: '2016-05-23T08:05:35.101Z'
+    default_field: false
   - name: kind
     level: core
     type: keyword

--- a/package/endpoint/dataset/network/elasticsearch/ingest_pipeline/default.json
+++ b/package/endpoint/dataset/network/elasticsearch/ingest_pipeline/default.json
@@ -1,0 +1,12 @@
+{
+  "description": "Pipeline for setting event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{ _ingest.timestamp }}",
+        "ignore_failure": true
+      }
+    }
+  ]
+}

--- a/package/endpoint/dataset/network/fields/fields.yml
+++ b/package/endpoint/dataset/network/fields/fields.yml
@@ -338,6 +338,19 @@
     ignore_above: 1024
     description: Unique ID to describe the event.
     example: 8a4f500d
+  - name: ingested
+    level: core
+    type: date
+    description: 'Timestamp when an event arrived in the central data store.
+
+      This is different from `@timestamp`, which is when the event originally occurred.  It''s
+      also different from `event.created`, which is meant to capture the first time
+      an agent saw the event.
+
+      In normal conditions, assuming no tampering, the timestamps should chronologically
+      look like this: `@timestamp` < `event.created` < `event.ingested`.'
+    example: '2016-05-23T08:05:35.101Z'
+    default_field: false
   - name: kind
     level: core
     type: keyword

--- a/package/endpoint/dataset/policy/elasticsearch/ingest_pipeline/default.json
+++ b/package/endpoint/dataset/policy/elasticsearch/ingest_pipeline/default.json
@@ -1,0 +1,12 @@
+{
+  "description": "Pipeline for setting event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{ _ingest.timestamp }}",
+        "ignore_failure": true
+      }
+    }
+  ]
+}

--- a/package/endpoint/dataset/policy/fields/fields.yml
+++ b/package/endpoint/dataset/policy/fields/fields.yml
@@ -353,6 +353,19 @@
     ignore_above: 1024
     description: Unique ID to describe the event.
     example: 8a4f500d
+  - name: ingested
+    level: core
+    type: date
+    description: 'Timestamp when an event arrived in the central data store.
+
+      This is different from `@timestamp`, which is when the event originally occurred.  It''s
+      also different from `event.created`, which is meant to capture the first time
+      an agent saw the event.
+
+      In normal conditions, assuming no tampering, the timestamps should chronologically
+      look like this: `@timestamp` < `event.created` < `event.ingested`.'
+    example: '2016-05-23T08:05:35.101Z'
+    default_field: false
   - name: kind
     level: core
     type: keyword
@@ -379,6 +392,14 @@
       events of a given source (e.g. Apache logs), `event.module` should contain
       the name of this module.'
     example: apache
+  - name: sequence
+    level: extended
+    type: long
+    format: string
+    description: 'Sequence number of the event.
+
+      The sequence number is a value published by some event sources, to make the
+      exact ordering of events unambiguous, regardless of the timestamp precision.'
   - name: type
     level: core
     type: keyword

--- a/package/endpoint/dataset/process/elasticsearch/ingest_pipeline/default.json
+++ b/package/endpoint/dataset/process/elasticsearch/ingest_pipeline/default.json
@@ -1,0 +1,12 @@
+{
+  "description": "Pipeline for setting event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{ _ingest.timestamp }}",
+        "ignore_failure": true
+      }
+    }
+  ]
+}

--- a/package/endpoint/dataset/process/fields/fields.yml
+++ b/package/endpoint/dataset/process/fields/fields.yml
@@ -179,6 +179,19 @@
     ignore_above: 1024
     description: Unique ID to describe the event.
     example: 8a4f500d
+  - name: ingested
+    level: core
+    type: date
+    description: 'Timestamp when an event arrived in the central data store.
+
+      This is different from `@timestamp`, which is when the event originally occurred.  It''s
+      also different from `event.created`, which is meant to capture the first time
+      an agent saw the event.
+
+      In normal conditions, assuming no tampering, the timestamps should chronologically
+      look like this: `@timestamp` < `event.created` < `event.ingested`.'
+    example: '2016-05-23T08:05:35.101Z'
+    default_field: false
   - name: kind
     level: core
     type: keyword

--- a/package/endpoint/dataset/registry/elasticsearch/ingest_pipeline/default.json
+++ b/package/endpoint/dataset/registry/elasticsearch/ingest_pipeline/default.json
@@ -1,0 +1,12 @@
+{
+  "description": "Pipeline for setting event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{ _ingest.timestamp }}",
+        "ignore_failure": true
+      }
+    }
+  ]
+}

--- a/package/endpoint/dataset/registry/fields/fields.yml
+++ b/package/endpoint/dataset/registry/fields/fields.yml
@@ -179,6 +179,19 @@
     ignore_above: 1024
     description: Unique ID to describe the event.
     example: 8a4f500d
+  - name: ingested
+    level: core
+    type: date
+    description: 'Timestamp when an event arrived in the central data store.
+
+      This is different from `@timestamp`, which is when the event originally occurred.  It''s
+      also different from `event.created`, which is meant to capture the first time
+      an agent saw the event.
+
+      In normal conditions, assuming no tampering, the timestamps should chronologically
+      look like this: `@timestamp` < `event.created` < `event.ingested`.'
+    example: '2016-05-23T08:05:35.101Z'
+    default_field: false
   - name: kind
     level: core
     type: keyword

--- a/package/endpoint/dataset/security/elasticsearch/ingest_pipeline/default.json
+++ b/package/endpoint/dataset/security/elasticsearch/ingest_pipeline/default.json
@@ -1,0 +1,12 @@
+{
+  "description": "Pipeline for setting event.ingested",
+  "processors": [
+    {
+      "set": {
+        "field": "event.ingested",
+        "value": "{{ _ingest.timestamp }}",
+        "ignore_failure": true
+      }
+    }
+  ]
+}

--- a/package/endpoint/dataset/security/fields/fields.yml
+++ b/package/endpoint/dataset/security/fields/fields.yml
@@ -179,6 +179,19 @@
     ignore_above: 1024
     description: Unique ID to describe the event.
     example: 8a4f500d
+  - name: ingested
+    level: core
+    type: date
+    description: 'Timestamp when an event arrived in the central data store.
+
+      This is different from `@timestamp`, which is when the event originally occurred.  It''s
+      also different from `event.created`, which is meant to capture the first time
+      an agent saw the event.
+
+      In normal conditions, assuming no tampering, the timestamps should chronologically
+      look like this: `@timestamp` < `event.created` < `event.ingested`.'
+    example: '2016-05-23T08:05:35.101Z'
+    default_field: false
   - name: kind
     level: core
     type: keyword

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -318,6 +318,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/schemas/v1/file/unquarantine.yaml
+++ b/schemas/v1/file/unquarantine.yaml
@@ -348,6 +348,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -398,6 +398,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/schemas/v1/metadata/metadata.yaml
+++ b/schemas/v1/metadata/metadata.yaml
@@ -400,6 +400,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable
@@ -486,6 +503,19 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.sequence:
+  dashed_name: event-sequence
+  description: 'Sequence number of the event.
+
+    The sequence number is a value published by some event sources, to make the exact
+    ordering of events unambiguous, regardless of the timestamp precision.'
+  flat_name: event.sequence
+  format: string
+  level: extended
+  name: sequence
+  normalize: []
+  short: Sequence number of the event.
+  type: long
 event.type:
   allowed_values:
   - description: The access event type is used for the subset of events within a category

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -501,6 +501,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/schemas/v1/network/network.yaml
+++ b/schemas/v1/network/network.yaml
@@ -542,6 +542,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -629,6 +629,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable
@@ -715,6 +732,19 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.sequence:
+  dashed_name: event-sequence
+  description: 'Sequence number of the event.
+
+    The sequence number is a value published by some event sources, to make the exact
+    ordering of events unambiguous, regardless of the timestamp precision.'
+  flat_name: event.sequence
+  format: string
+  level: extended
+  name: sequence
+  normalize: []
+  short: Sequence number of the event.
+  type: long
 event.type:
   allowed_values:
   - description: The access event type is used for the subset of events within a category

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -318,6 +318,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/schemas/v1/registry/registry.yaml
+++ b/schemas/v1/registry/registry.yaml
@@ -318,6 +318,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable

--- a/schemas/v1/security/security.yaml
+++ b/schemas/v1/security/security.yaml
@@ -318,6 +318,23 @@ event.id:
   normalize: []
   short: Unique ID to describe the event.
   type: keyword
+event.ingested:
+  dashed_name: event-ingested
+  description: 'Timestamp when an event arrived in the central data store.
+
+    This is different from `@timestamp`, which is when the event originally occurred.  It''s
+    also different from `event.created`, which is meant to capture the first time
+    an agent saw the event.
+
+    In normal conditions, assuming no tampering, the timestamps should chronologically
+    look like this: `@timestamp` < `event.created` < `event.ingested`.'
+  example: '2016-05-23T08:05:35.101Z'
+  flat_name: event.ingested
+  level: core
+  name: ingested
+  normalize: []
+  short: Timestamp when an event arrived in the central data store.
+  type: date
 event.kind:
   allowed_values:
   - description: 'This value indicates an event that describes an alert or notable


### PR DESCRIPTION
This PR adds a pipeline to set the `event.ingested` field for all docs that are sent by the endpoint.

![image](https://user-images.githubusercontent.com/56361221/87977376-a3cc3700-ca9c-11ea-88e4-ae09e95e6795.png)

https://github.com/elastic/endpoint-app-team/issues/597

I also added `event.sequence` to a couple schemas that were missing it.