### PR TITLE
Adding paths to staging and snapshot

### DIFF
--- a/package-registry.config.yml
+++ b/package-registry.config.yml
@@ -1,4 +1,6 @@
 package_paths:
   - /packages/production
+  - /packages/staging
+  - /packages/snapshot
   - /packages/endpoint-package
 dev_mode: true


### PR DESCRIPTION
These changes don't really do anything for now. Eventually we might switch over to using the `staging` registry in which case we'll want these paths.