### PR TITLE
Bump the kibana constraint

### DIFF
--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -24,8 +24,8 @@ config_templates:
 conditions:
   kibana:
     # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
-    # >= 7.9.0 && < 8.0.0
-    version: "^7.9.0"
+    # >= <the version below> && < 8.0.0
+    version: "^7.10.0"
 
 icons:
   - src: "/img/security-logo-color-64px.svg"


### PR DESCRIPTION
We will always release a package for each `minor` stack release version (even if nothing changed between releases). If we don't do this we'll get into weird versioning issues between stack releases.