### PR TITLE
[7.9] adding github owner (#61)

### DIFF
--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -31,3 +31,6 @@ icons:
   - src: "/img/security-logo-color-64px.svg"
     size: "16x16"
     type: "image/svg+xml"
+
+owner:
+  github: elastic/endpoint-data-visibility-team


### PR DESCRIPTION
Backports the following commits to 7.9:
 - adding github owner (#61)