### PR TITLE
Adding prettierignore file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+**/endpoint/**/*.yml
+**/endpoint/**/*.yaml


### PR DESCRIPTION
This will instruct prettier to ignore yaml files in the endpoint package directory so it doesn't mess with the `elastic-package` tool's formatting