### PR TITLE
[7.9] Adding header comments on missing files (#71)

### DIFF
--- a/scripts/saved_object_decoder/so_decoder.py
+++ b/scripts/saved_object_decoder/so_decoder.py
@@ -1,3 +1,9 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License;
+# you may not use this file except in compliance with the Elastic License.
+#
+
 import json
 import argparse
 import os


### PR DESCRIPTION
Backports the following commits to 7.9:
 - Adding header comments on missing files (#71)