### PR TITLE
Updating ECS version to 1.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,9 +119,7 @@ clean:
 
 
 $(REAL_ECS_DIR):
-	#git clone --branch mmain-fix-short-desc https://github.com/jonathan-buttner/ecs.git $(REAL_ECS_DIR)
 	git clone --branch master https://github.com/elastic/ecs.git $(REAL_ECS_DIR)
-
 
 .PHONY: setup-tools
 setup-tools:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 # we are intentionally pinning the ECS version here, when ecs releases a new version 
 # we'll discuss whether we need to release a new package and bump the version here
-ECS_GIT_REF ?= v1.5.0
+ECS_GIT_REF ?= v1.6.0
 
 # This variable specifies to location of the package-storage repo. It is used for automatically creating a PR
 # to release a new endpoint package. This can be overridden with the location on your file system using the config.mk
@@ -119,7 +119,8 @@ clean:
 
 
 $(REAL_ECS_DIR):
-	git clone --branch mmain-fix-short-desc https://github.com/jonathan-buttner/ecs.git $(REAL_ECS_DIR)
+	#git clone --branch mmain-fix-short-desc https://github.com/jonathan-buttner/ecs.git $(REAL_ECS_DIR)
+	git clone --branch master https://github.com/elastic/ecs.git $(REAL_ECS_DIR)
 
 
 .PHONY: setup-tools

--- a/custom_schemas/custom_call_stack.yml
+++ b/custom_schemas/custom_call_stack.yml
@@ -28,6 +28,7 @@
       type: keyword
       description: >
         Base address of the memory region containing `instruction_pointer`.  Corresponds to `MEMORY_BASIC_INFORMATION.BaseAddress`
+      short: Base address of the memory region containing `instruction_pointer`.
 
     - name: memory_section.size
       level: custom
@@ -52,3 +53,4 @@
       type: keyword
       description: >
         The relative virtual address of `instruction_pointer`.  Computed as `instruction_pointer - MEMORY_BASIC_INFORMATION.AllocationBase`.
+      short: The relative virtual address of `instruction_pointer`.

--- a/custom_schemas/custom_elastic.yml
+++ b/custom_schemas/custom_elastic.yml
@@ -14,6 +14,7 @@
       description: >
         The agent fields contain data about the Elastic Agent. The Elastic Agent is the management agent
         that manages other agents or process on the host.
+      short: The agent fields contain data about the Elastic Agent.
 
     - name: agent.id
       level: custom

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -91,6 +91,7 @@
       description: >
         the overall status of event collection, this is correlated to the status of concerned actions 
         but not a simple sum of the actions
+      short: the overall status of event collection
 
     - name: policy.applied.configurations.logging
       level: custom
@@ -108,6 +109,7 @@
       description: >
         the overall status of logging, this is correlated to the status of concerned actions but 
         not a simple sum of the actions
+      short: the overall status of logging
 
     - name: policy.applied.configurations.malware
       level: custom
@@ -125,6 +127,7 @@
       description: >
         the overall status of malware, this is correlated to the status of concerned actions 
         but not a simple sum of the actions
+      short: the overall status of malware
 
     - name: policy.applied.configurations.streaming
       level: custom
@@ -142,6 +145,7 @@
       description: >
         the overall status of data streaming, this is correlated to the status of concerned actions 
         but not a simple sum of the actions
+      short: overall status of data streaming
 
     - name: policy.applied.artifacts
       level: custom
@@ -246,6 +250,7 @@
         This field defines an elasticsearch histogram field (https://www.elastic.co/guide/en/elasticsearch/reference/current/histogram.html#histogram)
         The values field includes 20 buckets (each bucket is 5%) representing the cpu usage
         The counts field includes 20 buckets of how many times the endpoint's cpu usage fell into each bucket
+      short: CPU histogram
 
     - name: metrics.memory
       level: custom

--- a/custom_schemas/custom_file.yml
+++ b/custom_schemas/custom_file.yml
@@ -140,7 +140,6 @@
         Validating the trust of the certificate chain may be complicated, and this field should only be populated
         by tools that actively check the status.
 
-
     - name: Ext.code_signature.status
       level: custom
       type: keyword

--- a/custom_schemas/custom_macro.yml
+++ b/custom_schemas/custom_macro.yml
@@ -70,6 +70,7 @@
       type: long
       description: >
         Identifies the character encoding used for this macro.  https://docs.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
+      short: Identifies the character encoding used for this macro.
 
     - name: file_extension
       level: custom

--- a/custom_schemas/custom_os.yml
+++ b/custom_schemas/custom_os.yml
@@ -23,4 +23,5 @@
       description: >
         A string value or phrase that further aid to classify or qualify the operating system (OS). 
         For example the distribution for a Linux OS will be entered in this field.
+      short: A string value or phrase that further aid to classify or qualify the operating system (OS).
       example: Ubuntu

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -143,11 +143,11 @@
       level: custom
       type: object
       description: >
-        The field set containing parent process info in case of any ppid spoofing.
+        The field set containing process info in case of any pid spoofing. This is mainly useful for process.parent.
 
     - name: Ext.real.pid
       level: custom
       type: long
+      short: The real pid of the process if ppid spoofing is happening.
       description: >
-        The ppid of the process that actually spawned the current process, in case of
-        ppid spoofing.
+        For process.parent this will be the ppid of the process that actually spawned the current process.

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -13,6 +13,7 @@
     top_level: true
     expected:
       - Target
+      - { at: Target.process, as: parent }
   type: group
   fields:
     - name: Ext
@@ -138,74 +139,13 @@
         Leave unpopulated if the validity or trust of the certificate was unchecked.
       example: ERROR_UNTRUSTED_ROOT
 
-    - name: parent
-      level: custom
-      type: object
-      description: >
-        Extended "process.parent" field set.
-
-    - name: parent.Ext
-      level: custom
-      type: object
-      description: Object for all custom defined fields to live in.
-
-    - name: parent.Ext.code_signature
-      level: custom
-      type: nested
-      description: Nested version of ECS code_signature fieldset.
-
-    - name: parent.Ext.code_signature.exists
-      level: custom
-      type: boolean
-      description: Boolean to capture if a signature is present.
-      example: "true"
-
-    - name: parent.Ext.code_signature.subject_name
-      level: custom
-      type: keyword
-      description: Subject name of the code signer
-      example: Microsoft Corporation
-
-    - name: parent.Ext.code_signature.valid
-      level: custom
-      type: boolean
-      short: Boolean to capture if the digital signature is verified against the binary content.
-      example: "true"
-      description: >
-        Boolean to capture if the digital signature is verified against the binary content.
-
-        Leave unpopulated if a certificate was unchecked.
-
-    - name: parent.Ext.code_signature.trusted
-      level: custom
-      type: boolean
-      short: Stores the trust status of the certificate chain.
-      example: "true"
-      description: >
-        Stores the trust status of the certificate chain.
-
-        Validating the trust of the certificate chain may be complicated, and this field should only be populated
-        by tools that actively check the status.
-
-
-    - name: parent.Ext.code_signature.status
-      level: custom
-      type: keyword
-      short: Additional information about the certificate status.
-      description: >
-        Additional information about the certificate status.
-
-        This is useful for logging cryptographic errors with the certificate validity or trust status.
-        Leave unpopulated if the validity or trust of the certificate was unchecked.
-      example: ERROR_UNTRUSTED_ROOT
-
-    - name: parent.Ext.real
+    - name: Ext.real
       level: custom
       type: object
       description: >
         The field set containing parent process info in case of any ppid spoofing.
 
-    - name: parent.Ext.real.pid
+    - name: Ext.real.pid
       level: custom
       type: long
       description: >

--- a/generated/alerts/ecs/ecs_flat.yml
+++ b/generated/alerts/ecs/ecs_flat.yml
@@ -1091,22 +1091,12 @@ Target.process.name:
   original_fieldset: process
   short: Process name.
   type: keyword
-Target.process.parent:
-  dashed_name: Target-process-parent
-  description: Extended "process.parent" field set.
-  flat_name: Target.process.parent
-  level: custom
-  name: parent
-  normalize: []
-  original_fieldset: process
-  short: Extended "process.parent" field set.
-  type: object
 Target.process.parent.Ext:
   dashed_name: Target-process-parent-Ext
   description: Object for all custom defined fields to live in.
   flat_name: Target.process.parent.Ext
   level: custom
-  name: parent.Ext
+  name: Ext
   normalize: []
   original_fieldset: process
   short: Object for all custom defined fields to live in.
@@ -1116,7 +1106,7 @@ Target.process.parent.Ext.code_signature:
   description: Nested version of ECS code_signature fieldset.
   flat_name: Target.process.parent.Ext.code_signature
   level: custom
-  name: parent.Ext.code_signature
+  name: Ext.code_signature
   normalize: []
   original_fieldset: process
   short: Nested version of ECS code_signature fieldset.
@@ -1127,7 +1117,7 @@ Target.process.parent.Ext.code_signature.exists:
   example: 'true'
   flat_name: Target.process.parent.Ext.code_signature.exists
   level: custom
-  name: parent.Ext.code_signature.exists
+  name: Ext.code_signature.exists
   normalize: []
   original_fieldset: process
   short: Boolean to capture if a signature is present.
@@ -1143,7 +1133,7 @@ Target.process.parent.Ext.code_signature.status:
   flat_name: Target.process.parent.Ext.code_signature.status
   ignore_above: 1024
   level: custom
-  name: parent.Ext.code_signature.status
+  name: Ext.code_signature.status
   normalize: []
   original_fieldset: process
   short: Additional information about the certificate status.
@@ -1155,7 +1145,7 @@ Target.process.parent.Ext.code_signature.subject_name:
   flat_name: Target.process.parent.Ext.code_signature.subject_name
   ignore_above: 1024
   level: custom
-  name: parent.Ext.code_signature.subject_name
+  name: Ext.code_signature.subject_name
   normalize: []
   original_fieldset: process
   short: Subject name of the code signer
@@ -1169,7 +1159,7 @@ Target.process.parent.Ext.code_signature.trusted:
   example: 'true'
   flat_name: Target.process.parent.Ext.code_signature.trusted
   level: custom
-  name: parent.Ext.code_signature.trusted
+  name: Ext.code_signature.trusted
   normalize: []
   original_fieldset: process
   short: Stores the trust status of the certificate chain.
@@ -1183,7 +1173,7 @@ Target.process.parent.Ext.code_signature.valid:
   example: 'true'
   flat_name: Target.process.parent.Ext.code_signature.valid
   level: custom
-  name: parent.Ext.code_signature.valid
+  name: Ext.code_signature.valid
   normalize: []
   original_fieldset: process
   short: Boolean to capture if the digital signature is verified against the binary
@@ -1194,7 +1184,7 @@ Target.process.parent.Ext.real:
   description: The field set containing parent process info in case of any ppid spoofing.
   flat_name: Target.process.parent.Ext.real
   level: custom
-  name: parent.Ext.real
+  name: Ext.real
   normalize: []
   original_fieldset: process
   short: The field set containing parent process info in case of any ppid spoofing.
@@ -1205,7 +1195,7 @@ Target.process.parent.Ext.real.pid:
     in case of ppid spoofing.
   flat_name: Target.process.parent.Ext.real.pid
   level: custom
-  name: parent.Ext.real.pid
+  name: Ext.real.pid
   normalize: []
   original_fieldset: process
   short: The ppid of the process that actually spawned the current process, in case
@@ -1213,18 +1203,19 @@ Target.process.parent.Ext.real.pid:
   type: long
 Target.process.parent.args:
   dashed_name: Target-process-parent-args
-  description: 'Array of process arguments.
+  description: 'Array of process arguments, starting with the absolute path to the
+    executable.
 
     May be filtered to protect sensitive information.'
   example:
-  - ssh
+  - /usr/bin/ssh
   - -l
   - user
   - 10.0.0.16
   flat_name: Target.process.parent.args
   ignore_above: 1024
   level: extended
-  name: parent.args
+  name: args
   normalize:
   - array
   original_fieldset: process
@@ -1240,7 +1231,7 @@ Target.process.parent.args_count:
   example: 4
   flat_name: Target.process.parent.args_count
   level: extended
-  name: parent.args_count
+  name: args_count
   normalize: []
   original_fieldset: process
   short: Length of the process.args array.
@@ -1260,7 +1251,7 @@ Target.process.parent.command_line:
     name: text
     norms: false
     type: text
-  name: parent.command_line
+  name: command_line
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
@@ -1280,7 +1271,7 @@ Target.process.parent.entity_id:
   flat_name: Target.process.parent.entity_id
   ignore_above: 1024
   level: extended
-  name: parent.entity_id
+  name: entity_id
   normalize: []
   original_fieldset: process
   short: Unique identifier for the process.
@@ -1297,7 +1288,7 @@ Target.process.parent.executable:
     name: text
     norms: false
     type: text
-  name: parent.executable
+  name: executable
   normalize: []
   original_fieldset: process
   short: Absolute path to the process executable.
@@ -1311,7 +1302,7 @@ Target.process.parent.exit_code:
   example: 137
   flat_name: Target.process.parent.exit_code
   level: extended
-  name: parent.exit_code
+  name: exit_code
   normalize: []
   original_fieldset: process
   short: The exit code of the process.
@@ -1374,7 +1365,7 @@ Target.process.parent.name:
     name: text
     norms: false
     type: text
-  name: parent.name
+  name: name
   normalize: []
   original_fieldset: process
   short: Process name.
@@ -1385,7 +1376,7 @@ Target.process.parent.pgid:
   flat_name: Target.process.parent.pgid
   format: string
   level: extended
-  name: parent.pgid
+  name: pgid
   normalize: []
   original_fieldset: process
   short: Identifier of the group of processes the process belongs to.
@@ -1397,7 +1388,7 @@ Target.process.parent.pid:
   flat_name: Target.process.parent.pid
   format: string
   level: core
-  name: parent.pid
+  name: pid
   normalize: []
   original_fieldset: process
   short: Process id.
@@ -1409,7 +1400,7 @@ Target.process.parent.ppid:
   flat_name: Target.process.parent.ppid
   format: string
   level: extended
-  name: parent.ppid
+  name: ppid
   normalize: []
   original_fieldset: process
   short: Parent process' pid.
@@ -1420,7 +1411,7 @@ Target.process.parent.start:
   example: '2016-05-23T08:05:34.853Z'
   flat_name: Target.process.parent.start
   level: extended
-  name: parent.start
+  name: start
   normalize: []
   original_fieldset: process
   short: The time the process started.
@@ -1432,7 +1423,7 @@ Target.process.parent.thread.id:
   flat_name: Target.process.parent.thread.id
   format: string
   level: extended
-  name: parent.thread.id
+  name: thread.id
   normalize: []
   original_fieldset: process
   short: Thread ID.
@@ -1444,7 +1435,7 @@ Target.process.parent.thread.name:
   flat_name: Target.process.parent.thread.name
   ignore_above: 1024
   level: extended
-  name: parent.thread.name
+  name: thread.name
   normalize: []
   original_fieldset: process
   short: Thread name.
@@ -1463,7 +1454,7 @@ Target.process.parent.title:
     name: text
     norms: false
     type: text
-  name: parent.title
+  name: title
   normalize: []
   original_fieldset: process
   short: Process title.
@@ -1474,7 +1465,7 @@ Target.process.parent.uptime:
   example: 1325
   flat_name: Target.process.parent.uptime
   level: extended
-  name: parent.uptime
+  name: uptime
   normalize: []
   original_fieldset: process
   short: Seconds the process has been up.
@@ -1491,7 +1482,7 @@ Target.process.parent.working_directory:
     name: text
     norms: false
     type: text
-  name: parent.working_directory
+  name: working_directory
   normalize: []
   original_fieldset: process
   short: The working directory of the process.
@@ -1645,8 +1636,7 @@ Target.process.thread.Ext.call_stack.memory_section.address:
   name: memory_section.address
   normalize: []
   original_fieldset: call_stack
-  short: Base address of the memory region containing `instruction_pointer`.  Corresponds
-    to `MEMORY_BASIC_INFORMATION.BaseAddress`
+  short: Base address of the memory region containing `instruction_pointer`.
   type: keyword
 Target.process.thread.Ext.call_stack.memory_section.protection:
   dashed_name: Target-process-thread-Ext-call-stack-memory-section-protection
@@ -1693,8 +1683,7 @@ Target.process.thread.Ext.call_stack.rva:
   name: rva
   normalize: []
   original_fieldset: call_stack
-  short: The relative virtual address of `instruction_pointer`.  Computed as `instruction_pointer
-    - MEMORY_BASIC_INFORMATION.AllocationBase`.
+  short: The relative virtual address of `instruction_pointer`.
   type: keyword
 Target.process.thread.Ext.call_stack.symbol_info:
   dashed_name: Target-process-thread-Ext-call-stack-symbol-info
@@ -2033,7 +2022,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -2443,8 +2432,7 @@ elastic.agent:
   level: custom
   name: agent
   normalize: []
-  short: The agent fields contain data about the Elastic Agent. The Elastic Agent
-    is the management agent that manages other agents or process on the host.
+  short: The agent fields contain data about the Elastic Agent.
   type: object
 elastic.agent.id:
   dashed_name: elastic-agent-id
@@ -3134,7 +3122,7 @@ file.Ext.macro.code_page:
   name: code_page
   normalize: []
   original_fieldset: macro
-  short: Identifies the character encoding used for this macro.  https://docs.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
+  short: Identifies the character encoding used for this macro.
   type: long
 file.Ext.macro.collection:
   dashed_name: file-Ext-macro-collection
@@ -4242,8 +4230,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -4527,14 +4514,14 @@ host.user.hash:
   type: keyword
 host.user.id:
   dashed_name: host-user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: host.user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
   original_fieldset: user
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 host.user.name:
   dashed_name: host-user-name
@@ -5113,22 +5100,14 @@ process.name:
   normalize: []
   short: Process name.
   type: keyword
-process.parent:
-  dashed_name: process-parent
-  description: Extended "process.parent" field set.
-  flat_name: process.parent
-  level: custom
-  name: parent
-  normalize: []
-  short: Extended "process.parent" field set.
-  type: object
 process.parent.Ext:
   dashed_name: process-parent-Ext
   description: Object for all custom defined fields to live in.
   flat_name: process.parent.Ext
   level: custom
-  name: parent.Ext
+  name: Ext
   normalize: []
+  original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
 process.parent.Ext.code_signature:
@@ -5136,8 +5115,9 @@ process.parent.Ext.code_signature:
   description: Nested version of ECS code_signature fieldset.
   flat_name: process.parent.Ext.code_signature
   level: custom
-  name: parent.Ext.code_signature
+  name: Ext.code_signature
   normalize: []
+  original_fieldset: process
   short: Nested version of ECS code_signature fieldset.
   type: nested
 process.parent.Ext.code_signature.exists:
@@ -5146,8 +5126,9 @@ process.parent.Ext.code_signature.exists:
   example: 'true'
   flat_name: process.parent.Ext.code_signature.exists
   level: custom
-  name: parent.Ext.code_signature.exists
+  name: Ext.code_signature.exists
   normalize: []
+  original_fieldset: process
   short: Boolean to capture if a signature is present.
   type: boolean
 process.parent.Ext.code_signature.status:
@@ -5161,8 +5142,9 @@ process.parent.Ext.code_signature.status:
   flat_name: process.parent.Ext.code_signature.status
   ignore_above: 1024
   level: custom
-  name: parent.Ext.code_signature.status
+  name: Ext.code_signature.status
   normalize: []
+  original_fieldset: process
   short: Additional information about the certificate status.
   type: keyword
 process.parent.Ext.code_signature.subject_name:
@@ -5172,8 +5154,9 @@ process.parent.Ext.code_signature.subject_name:
   flat_name: process.parent.Ext.code_signature.subject_name
   ignore_above: 1024
   level: custom
-  name: parent.Ext.code_signature.subject_name
+  name: Ext.code_signature.subject_name
   normalize: []
+  original_fieldset: process
   short: Subject name of the code signer
   type: keyword
 process.parent.Ext.code_signature.trusted:
@@ -5185,8 +5168,9 @@ process.parent.Ext.code_signature.trusted:
   example: 'true'
   flat_name: process.parent.Ext.code_signature.trusted
   level: custom
-  name: parent.Ext.code_signature.trusted
+  name: Ext.code_signature.trusted
   normalize: []
+  original_fieldset: process
   short: Stores the trust status of the certificate chain.
   type: boolean
 process.parent.Ext.code_signature.valid:
@@ -5198,8 +5182,9 @@ process.parent.Ext.code_signature.valid:
   example: 'true'
   flat_name: process.parent.Ext.code_signature.valid
   level: custom
-  name: parent.Ext.code_signature.valid
+  name: Ext.code_signature.valid
   normalize: []
+  original_fieldset: process
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
@@ -5208,8 +5193,9 @@ process.parent.Ext.real:
   description: The field set containing parent process info in case of any ppid spoofing.
   flat_name: process.parent.Ext.real
   level: custom
-  name: parent.Ext.real
+  name: Ext.real
   normalize: []
+  original_fieldset: process
   short: The field set containing parent process info in case of any ppid spoofing.
   type: object
 process.parent.Ext.real.pid:
@@ -5218,27 +5204,30 @@ process.parent.Ext.real.pid:
     in case of ppid spoofing.
   flat_name: process.parent.Ext.real.pid
   level: custom
-  name: parent.Ext.real.pid
+  name: Ext.real.pid
   normalize: []
+  original_fieldset: process
   short: The ppid of the process that actually spawned the current process, in case
     of ppid spoofing.
   type: long
 process.parent.args:
   dashed_name: process-parent-args
-  description: 'Array of process arguments.
+  description: 'Array of process arguments, starting with the absolute path to the
+    executable.
 
     May be filtered to protect sensitive information.'
   example:
-  - ssh
+  - /usr/bin/ssh
   - -l
   - user
   - 10.0.0.16
   flat_name: process.parent.args
   ignore_above: 1024
   level: extended
-  name: parent.args
+  name: args
   normalize:
   - array
+  original_fieldset: process
   short: Array of process arguments.
   type: keyword
 process.parent.args_count:
@@ -5251,8 +5240,9 @@ process.parent.args_count:
   example: 4
   flat_name: process.parent.args_count
   level: extended
-  name: parent.args_count
+  name: args_count
   normalize: []
+  original_fieldset: process
   short: Length of the process.args array.
   type: long
 process.parent.command_line:
@@ -5270,8 +5260,9 @@ process.parent.command_line:
     name: text
     norms: false
     type: text
-  name: parent.command_line
+  name: command_line
   normalize: []
+  original_fieldset: process
   short: Full command line that started the process.
   type: keyword
 process.parent.entity_id:
@@ -5289,8 +5280,9 @@ process.parent.entity_id:
   flat_name: process.parent.entity_id
   ignore_above: 1024
   level: extended
-  name: parent.entity_id
+  name: entity_id
   normalize: []
+  original_fieldset: process
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
@@ -5305,8 +5297,9 @@ process.parent.executable:
     name: text
     norms: false
     type: text
-  name: parent.executable
+  name: executable
   normalize: []
+  original_fieldset: process
   short: Absolute path to the process executable.
   type: keyword
 process.parent.exit_code:
@@ -5318,8 +5311,9 @@ process.parent.exit_code:
   example: 137
   flat_name: process.parent.exit_code
   level: extended
-  name: parent.exit_code
+  name: exit_code
   normalize: []
+  original_fieldset: process
   short: The exit code of the process.
   type: long
 process.parent.hash.md5:
@@ -5380,8 +5374,9 @@ process.parent.name:
     name: text
     norms: false
     type: text
-  name: parent.name
+  name: name
   normalize: []
+  original_fieldset: process
   short: Process name.
   type: keyword
 process.parent.pgid:
@@ -5390,8 +5385,9 @@ process.parent.pgid:
   flat_name: process.parent.pgid
   format: string
   level: extended
-  name: parent.pgid
+  name: pgid
   normalize: []
+  original_fieldset: process
   short: Identifier of the group of processes the process belongs to.
   type: long
 process.parent.pid:
@@ -5401,8 +5397,9 @@ process.parent.pid:
   flat_name: process.parent.pid
   format: string
   level: core
-  name: parent.pid
+  name: pid
   normalize: []
+  original_fieldset: process
   short: Process id.
   type: long
 process.parent.ppid:
@@ -5412,8 +5409,9 @@ process.parent.ppid:
   flat_name: process.parent.ppid
   format: string
   level: extended
-  name: parent.ppid
+  name: ppid
   normalize: []
+  original_fieldset: process
   short: Parent process' pid.
   type: long
 process.parent.start:
@@ -5422,8 +5420,9 @@ process.parent.start:
   example: '2016-05-23T08:05:34.853Z'
   flat_name: process.parent.start
   level: extended
-  name: parent.start
+  name: start
   normalize: []
+  original_fieldset: process
   short: The time the process started.
   type: date
 process.parent.thread.id:
@@ -5433,8 +5432,9 @@ process.parent.thread.id:
   flat_name: process.parent.thread.id
   format: string
   level: extended
-  name: parent.thread.id
+  name: thread.id
   normalize: []
+  original_fieldset: process
   short: Thread ID.
   type: long
 process.parent.thread.name:
@@ -5444,8 +5444,9 @@ process.parent.thread.name:
   flat_name: process.parent.thread.name
   ignore_above: 1024
   level: extended
-  name: parent.thread.name
+  name: thread.name
   normalize: []
+  original_fieldset: process
   short: Thread name.
   type: keyword
 process.parent.title:
@@ -5462,8 +5463,9 @@ process.parent.title:
     name: text
     norms: false
     type: text
-  name: parent.title
+  name: title
   normalize: []
+  original_fieldset: process
   short: Process title.
   type: keyword
 process.parent.uptime:
@@ -5472,8 +5474,9 @@ process.parent.uptime:
   example: 1325
   flat_name: process.parent.uptime
   level: extended
-  name: parent.uptime
+  name: uptime
   normalize: []
+  original_fieldset: process
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
@@ -5488,8 +5491,9 @@ process.parent.working_directory:
     name: text
     norms: false
     type: text
-  name: parent.working_directory
+  name: working_directory
   normalize: []
+  original_fieldset: process
   short: The working directory of the process.
   type: keyword
 process.pe.company:
@@ -5636,8 +5640,7 @@ process.thread.Ext.call_stack.memory_section.address:
   name: memory_section.address
   normalize: []
   original_fieldset: call_stack
-  short: Base address of the memory region containing `instruction_pointer`.  Corresponds
-    to `MEMORY_BASIC_INFORMATION.BaseAddress`
+  short: Base address of the memory region containing `instruction_pointer`.
   type: keyword
 process.thread.Ext.call_stack.memory_section.protection:
   dashed_name: process-thread-Ext-call-stack-memory-section-protection
@@ -5684,8 +5687,7 @@ process.thread.Ext.call_stack.rva:
   name: rva
   normalize: []
   original_fieldset: call_stack
-  short: The relative virtual address of `instruction_pointer`.  Computed as `instruction_pointer
-    - MEMORY_BASIC_INFORMATION.AllocationBase`.
+  short: The relative virtual address of `instruction_pointer`.
   type: keyword
 process.thread.Ext.call_stack.symbol_info:
   dashed_name: process-thread-Ext-call-stack-symbol-info
@@ -6106,9 +6108,8 @@ threat.framework:
   type: keyword
 threat.tactic.id:
   dashed_name: threat-tactic-id
-  description: The id of tactic used by this threat. You can use the Mitre ATT&CK
-    Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-    )
+  description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )"
   example: TA0040
   flat_name: threat.tactic.id
   ignore_above: 1024
@@ -6120,9 +6121,8 @@ threat.tactic.id:
   type: keyword
 threat.tactic.name:
   dashed_name: threat-tactic-name
-  description: Name of the type of tactic used by this threat. You can use the Mitre
-    ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-    )
+  description: "Name of the type of tactic used by this threat. You can use a MITRE\
+    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
   example: impact
   flat_name: threat.tactic.name
   ignore_above: 1024
@@ -6134,9 +6134,9 @@ threat.tactic.name:
   type: keyword
 threat.tactic.reference:
   dashed_name: threat-tactic-reference
-  description: The reference url of tactic used by this threat. You can use the Mitre
-    ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-    )
+  description: "The reference url of tactic used by this threat. You can use a MITRE\
+    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+    \ )"
   example: https://attack.mitre.org/tactics/TA0040/
   flat_name: threat.tactic.reference
   ignore_above: 1024
@@ -6144,13 +6144,12 @@ threat.tactic.reference:
   name: tactic.reference
   normalize:
   - array
-  short: Threat tactic url reference.
+  short: Threat tactic URL reference.
   type: keyword
 threat.technique.id:
   dashed_name: threat-technique-id
-  description: The id of technique used by this tactic. You can use the Mitre ATT&CK
-    Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-    )
+  description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
   example: T1499
   flat_name: threat.technique.id
   ignore_above: 1024
@@ -6162,10 +6161,9 @@ threat.technique.id:
   type: keyword
 threat.technique.name:
   dashed_name: threat-technique-name
-  description: The name of technique used by this tactic. You can use the Mitre ATT&CK
-    Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-    )
-  example: endpoint denial of service
+  description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
+  example: Endpoint Denial of Service
   flat_name: threat.technique.name
   ignore_above: 1024
   level: extended
@@ -6181,9 +6179,9 @@ threat.technique.name:
   type: keyword
 threat.technique.reference:
   dashed_name: threat-technique-reference
-  description: The reference url of technique used by this tactic. You can use the
-    Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-    )
+  description: "The reference url of technique used by this threat. You can use a\
+    \ MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
+    \ )"
   example: https://attack.mitre.org/techniques/T1499/
   flat_name: threat.technique.reference
   ignore_above: 1024
@@ -6191,7 +6189,7 @@ threat.technique.reference:
   name: technique.reference
   normalize:
   - array
-  short: Threat technique reference.
+  short: Threat technique URL reference.
   type: keyword
 user.Ext:
   dashed_name: user-Ext
@@ -6362,13 +6360,13 @@ user.hash:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/alerts/ecs/ecs_flat.yml
+++ b/generated/alerts/ecs/ecs_flat.yml
@@ -1181,25 +1181,26 @@ Target.process.parent.Ext.code_signature.valid:
   type: boolean
 Target.process.parent.Ext.real:
   dashed_name: Target-process-parent-Ext-real
-  description: The field set containing parent process info in case of any ppid spoofing.
+  description: The field set containing process info in case of any pid spoofing.
+    This is mainly useful for process.parent.
   flat_name: Target.process.parent.Ext.real
   level: custom
   name: Ext.real
   normalize: []
   original_fieldset: process
-  short: The field set containing parent process info in case of any ppid spoofing.
+  short: The field set containing process info in case of any pid spoofing. This is
+    mainly useful for process.parent.
   type: object
 Target.process.parent.Ext.real.pid:
   dashed_name: Target-process-parent-Ext-real-pid
-  description: The ppid of the process that actually spawned the current process,
-    in case of ppid spoofing.
+  description: For process.parent this will be the ppid of the process that actually
+    spawned the current process.
   flat_name: Target.process.parent.Ext.real.pid
   level: custom
   name: Ext.real.pid
   normalize: []
   original_fieldset: process
-  short: The ppid of the process that actually spawned the current process, in case
-    of ppid spoofing.
+  short: The real pid of the process if ppid spoofing is happening.
   type: long
 Target.process.parent.args:
   dashed_name: Target-process-parent-args
@@ -5190,25 +5191,26 @@ process.parent.Ext.code_signature.valid:
   type: boolean
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
-  description: The field set containing parent process info in case of any ppid spoofing.
+  description: The field set containing process info in case of any pid spoofing.
+    This is mainly useful for process.parent.
   flat_name: process.parent.Ext.real
   level: custom
   name: Ext.real
   normalize: []
   original_fieldset: process
-  short: The field set containing parent process info in case of any ppid spoofing.
+  short: The field set containing process info in case of any pid spoofing. This is
+    mainly useful for process.parent.
   type: object
 process.parent.Ext.real.pid:
   dashed_name: process-parent-Ext-real-pid
-  description: The ppid of the process that actually spawned the current process,
-    in case of ppid spoofing.
+  description: For process.parent this will be the ppid of the process that actually
+    spawned the current process.
   flat_name: process.parent.Ext.real.pid
   level: custom
   name: Ext.real.pid
   normalize: []
   original_fieldset: process
-  short: The ppid of the process that actually spawned the current process, in case
-    of ppid spoofing.
+  short: The real pid of the process if ppid spoofing is happening.
   type: long
 process.parent.args:
   dashed_name: process-parent-args

--- a/generated/alerts/ecs/subset/malware_event/ecs_flat.yml
+++ b/generated/alerts/ecs/subset/malware_event/ecs_flat.yml
@@ -1105,22 +1105,12 @@ Target.process.name:
   original_fieldset: process
   short: Process name.
   type: keyword
-Target.process.parent:
-  dashed_name: Target-process-parent
-  description: Extended "process.parent" field set.
-  flat_name: Target.process.parent
-  level: custom
-  name: parent
-  normalize: []
-  original_fieldset: process
-  short: Extended "process.parent" field set.
-  type: object
 Target.process.parent.Ext:
   dashed_name: Target-process-parent-Ext
   description: Object for all custom defined fields to live in.
   flat_name: Target.process.parent.Ext
   level: custom
-  name: parent.Ext
+  name: Ext
   normalize: []
   original_fieldset: process
   short: Object for all custom defined fields to live in.
@@ -1130,7 +1120,7 @@ Target.process.parent.Ext.code_signature:
   description: Nested version of ECS code_signature fieldset.
   flat_name: Target.process.parent.Ext.code_signature
   level: custom
-  name: parent.Ext.code_signature
+  name: Ext.code_signature
   normalize: []
   original_fieldset: process
   short: Nested version of ECS code_signature fieldset.
@@ -1141,7 +1131,7 @@ Target.process.parent.Ext.code_signature.exists:
   example: 'true'
   flat_name: Target.process.parent.Ext.code_signature.exists
   level: custom
-  name: parent.Ext.code_signature.exists
+  name: Ext.code_signature.exists
   normalize: []
   original_fieldset: process
   short: Boolean to capture if a signature is present.
@@ -1158,7 +1148,7 @@ Target.process.parent.Ext.code_signature.status:
   flat_name: Target.process.parent.Ext.code_signature.status
   ignore_above: 1024
   level: custom
-  name: parent.Ext.code_signature.status
+  name: Ext.code_signature.status
   normalize: []
   original_fieldset: process
   short: Additional information about the certificate status.
@@ -1171,7 +1161,7 @@ Target.process.parent.Ext.code_signature.subject_name:
   flat_name: Target.process.parent.Ext.code_signature.subject_name
   ignore_above: 1024
   level: custom
-  name: parent.Ext.code_signature.subject_name
+  name: Ext.code_signature.subject_name
   normalize: []
   original_fieldset: process
   short: Subject name of the code signer
@@ -1186,7 +1176,7 @@ Target.process.parent.Ext.code_signature.trusted:
   exceptionable: true
   flat_name: Target.process.parent.Ext.code_signature.trusted
   level: custom
-  name: parent.Ext.code_signature.trusted
+  name: Ext.code_signature.trusted
   normalize: []
   original_fieldset: process
   short: Stores the trust status of the certificate chain.
@@ -1201,7 +1191,7 @@ Target.process.parent.Ext.code_signature.valid:
   exceptionable: true
   flat_name: Target.process.parent.Ext.code_signature.valid
   level: custom
-  name: parent.Ext.code_signature.valid
+  name: Ext.code_signature.valid
   normalize: []
   original_fieldset: process
   short: Boolean to capture if the digital signature is verified against the binary
@@ -1212,7 +1202,7 @@ Target.process.parent.Ext.real:
   description: The field set containing parent process info in case of any ppid spoofing.
   flat_name: Target.process.parent.Ext.real
   level: custom
-  name: parent.Ext.real
+  name: Ext.real
   normalize: []
   original_fieldset: process
   short: The field set containing parent process info in case of any ppid spoofing.
@@ -1223,7 +1213,7 @@ Target.process.parent.Ext.real.pid:
     in case of ppid spoofing.
   flat_name: Target.process.parent.Ext.real.pid
   level: custom
-  name: parent.Ext.real.pid
+  name: Ext.real.pid
   normalize: []
   original_fieldset: process
   short: The ppid of the process that actually spawned the current process, in case
@@ -1231,18 +1221,19 @@ Target.process.parent.Ext.real.pid:
   type: long
 Target.process.parent.args:
   dashed_name: Target-process-parent-args
-  description: 'Array of process arguments.
+  description: 'Array of process arguments, starting with the absolute path to the
+    executable.
 
     May be filtered to protect sensitive information.'
   example:
-  - ssh
+  - /usr/bin/ssh
   - -l
   - user
   - 10.0.0.16
   flat_name: Target.process.parent.args
   ignore_above: 1024
   level: extended
-  name: parent.args
+  name: args
   normalize:
   - array
   original_fieldset: process
@@ -1258,7 +1249,7 @@ Target.process.parent.args_count:
   example: 4
   flat_name: Target.process.parent.args_count
   level: extended
-  name: parent.args_count
+  name: args_count
   normalize: []
   original_fieldset: process
   short: Length of the process.args array.
@@ -1279,7 +1270,7 @@ Target.process.parent.command_line:
     name: text
     norms: false
     type: text
-  name: parent.command_line
+  name: command_line
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
@@ -1299,7 +1290,7 @@ Target.process.parent.entity_id:
   flat_name: Target.process.parent.entity_id
   ignore_above: 1024
   level: extended
-  name: parent.entity_id
+  name: entity_id
   normalize: []
   original_fieldset: process
   short: Unique identifier for the process.
@@ -1317,7 +1308,7 @@ Target.process.parent.executable:
     name: text
     norms: false
     type: text
-  name: parent.executable
+  name: executable
   normalize: []
   original_fieldset: process
   short: Absolute path to the process executable.
@@ -1331,7 +1322,7 @@ Target.process.parent.exit_code:
   example: 137
   flat_name: Target.process.parent.exit_code
   level: extended
-  name: parent.exit_code
+  name: exit_code
   normalize: []
   original_fieldset: process
   short: The exit code of the process.
@@ -1399,7 +1390,7 @@ Target.process.parent.name:
     name: text
     norms: false
     type: text
-  name: parent.name
+  name: name
   normalize: []
   original_fieldset: process
   short: Process name.
@@ -1411,7 +1402,7 @@ Target.process.parent.pgid:
   flat_name: Target.process.parent.pgid
   format: string
   level: extended
-  name: parent.pgid
+  name: pgid
   normalize: []
   original_fieldset: process
   short: Identifier of the group of processes the process belongs to.
@@ -1423,7 +1414,7 @@ Target.process.parent.pid:
   flat_name: Target.process.parent.pid
   format: string
   level: core
-  name: parent.pid
+  name: pid
   normalize: []
   original_fieldset: process
   short: Process id.
@@ -1435,7 +1426,7 @@ Target.process.parent.ppid:
   flat_name: Target.process.parent.ppid
   format: string
   level: extended
-  name: parent.ppid
+  name: ppid
   normalize: []
   original_fieldset: process
   short: Parent process' pid.
@@ -1446,7 +1437,7 @@ Target.process.parent.start:
   example: '2016-05-23T08:05:34.853Z'
   flat_name: Target.process.parent.start
   level: extended
-  name: parent.start
+  name: start
   normalize: []
   original_fieldset: process
   short: The time the process started.
@@ -1458,7 +1449,7 @@ Target.process.parent.thread.id:
   flat_name: Target.process.parent.thread.id
   format: string
   level: extended
-  name: parent.thread.id
+  name: thread.id
   normalize: []
   original_fieldset: process
   short: Thread ID.
@@ -1470,7 +1461,7 @@ Target.process.parent.thread.name:
   flat_name: Target.process.parent.thread.name
   ignore_above: 1024
   level: extended
-  name: parent.thread.name
+  name: thread.name
   normalize: []
   original_fieldset: process
   short: Thread name.
@@ -1489,7 +1480,7 @@ Target.process.parent.title:
     name: text
     norms: false
     type: text
-  name: parent.title
+  name: title
   normalize: []
   original_fieldset: process
   short: Process title.
@@ -1500,7 +1491,7 @@ Target.process.parent.uptime:
   example: 1325
   flat_name: Target.process.parent.uptime
   level: extended
-  name: parent.uptime
+  name: uptime
   normalize: []
   original_fieldset: process
   short: Seconds the process has been up.
@@ -1518,7 +1509,7 @@ Target.process.parent.working_directory:
     name: text
     norms: false
     type: text
-  name: parent.working_directory
+  name: working_directory
   normalize: []
   original_fieldset: process
   short: The working directory of the process.
@@ -1678,8 +1669,7 @@ Target.process.thread.Ext.call_stack.memory_section.address:
   name: memory_section.address
   normalize: []
   original_fieldset: call_stack
-  short: Base address of the memory region containing `instruction_pointer`.  Corresponds
-    to `MEMORY_BASIC_INFORMATION.BaseAddress`
+  short: Base address of the memory region containing `instruction_pointer`.
   type: keyword
 Target.process.thread.Ext.call_stack.memory_section.protection:
   dashed_name: Target-process-thread-Ext-call-stack-memory-section-protection
@@ -1726,8 +1716,7 @@ Target.process.thread.Ext.call_stack.rva:
   name: rva
   normalize: []
   original_fieldset: call_stack
-  short: The relative virtual address of `instruction_pointer`.  Computed as `instruction_pointer
-    - MEMORY_BASIC_INFORMATION.AllocationBase`.
+  short: The relative virtual address of `instruction_pointer`.
   type: keyword
 Target.process.thread.Ext.call_stack.symbol_info:
   dashed_name: Target-process-thread-Ext-call-stack-symbol-info
@@ -2068,7 +2057,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -2480,8 +2469,7 @@ elastic.agent:
   level: custom
   name: agent
   normalize: []
-  short: The agent fields contain data about the Elastic Agent. The Elastic Agent
-    is the management agent that manages other agents or process on the host.
+  short: The agent fields contain data about the Elastic Agent.
   type: object
 elastic.agent.id:
   dashed_name: elastic-agent-id
@@ -3185,7 +3173,7 @@ file.Ext.macro.code_page:
   name: code_page
   normalize: []
   original_fieldset: macro
-  short: Identifies the character encoding used for this macro.  https://docs.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
+  short: Identifies the character encoding used for this macro.
   type: long
 file.Ext.macro.collection:
   dashed_name: file-Ext-macro-collection
@@ -4326,8 +4314,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -4618,14 +4605,14 @@ host.user.hash:
   type: keyword
 host.user.id:
   dashed_name: host-user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: host.user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
   original_fieldset: user
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 host.user.name:
   dashed_name: host-user-name
@@ -5217,22 +5204,14 @@ process.name:
   normalize: []
   short: Process name.
   type: keyword
-process.parent:
-  dashed_name: process-parent
-  description: Extended "process.parent" field set.
-  flat_name: process.parent
-  level: custom
-  name: parent
-  normalize: []
-  short: Extended "process.parent" field set.
-  type: object
 process.parent.Ext:
   dashed_name: process-parent-Ext
   description: Object for all custom defined fields to live in.
   flat_name: process.parent.Ext
   level: custom
-  name: parent.Ext
+  name: Ext
   normalize: []
+  original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
 process.parent.Ext.code_signature:
@@ -5240,8 +5219,9 @@ process.parent.Ext.code_signature:
   description: Nested version of ECS code_signature fieldset.
   flat_name: process.parent.Ext.code_signature
   level: custom
-  name: parent.Ext.code_signature
+  name: Ext.code_signature
   normalize: []
+  original_fieldset: process
   short: Nested version of ECS code_signature fieldset.
   type: nested
 process.parent.Ext.code_signature.exists:
@@ -5250,8 +5230,9 @@ process.parent.Ext.code_signature.exists:
   example: 'true'
   flat_name: process.parent.Ext.code_signature.exists
   level: custom
-  name: parent.Ext.code_signature.exists
+  name: Ext.code_signature.exists
   normalize: []
+  original_fieldset: process
   short: Boolean to capture if a signature is present.
   type: boolean
 process.parent.Ext.code_signature.status:
@@ -5266,8 +5247,9 @@ process.parent.Ext.code_signature.status:
   flat_name: process.parent.Ext.code_signature.status
   ignore_above: 1024
   level: custom
-  name: parent.Ext.code_signature.status
+  name: Ext.code_signature.status
   normalize: []
+  original_fieldset: process
   short: Additional information about the certificate status.
   type: keyword
 process.parent.Ext.code_signature.subject_name:
@@ -5278,8 +5260,9 @@ process.parent.Ext.code_signature.subject_name:
   flat_name: process.parent.Ext.code_signature.subject_name
   ignore_above: 1024
   level: custom
-  name: parent.Ext.code_signature.subject_name
+  name: Ext.code_signature.subject_name
   normalize: []
+  original_fieldset: process
   short: Subject name of the code signer
   type: keyword
 process.parent.Ext.code_signature.trusted:
@@ -5292,8 +5275,9 @@ process.parent.Ext.code_signature.trusted:
   exceptionable: true
   flat_name: process.parent.Ext.code_signature.trusted
   level: custom
-  name: parent.Ext.code_signature.trusted
+  name: Ext.code_signature.trusted
   normalize: []
+  original_fieldset: process
   short: Stores the trust status of the certificate chain.
   type: boolean
 process.parent.Ext.code_signature.valid:
@@ -5306,8 +5290,9 @@ process.parent.Ext.code_signature.valid:
   exceptionable: true
   flat_name: process.parent.Ext.code_signature.valid
   level: custom
-  name: parent.Ext.code_signature.valid
+  name: Ext.code_signature.valid
   normalize: []
+  original_fieldset: process
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
@@ -5316,8 +5301,9 @@ process.parent.Ext.real:
   description: The field set containing parent process info in case of any ppid spoofing.
   flat_name: process.parent.Ext.real
   level: custom
-  name: parent.Ext.real
+  name: Ext.real
   normalize: []
+  original_fieldset: process
   short: The field set containing parent process info in case of any ppid spoofing.
   type: object
 process.parent.Ext.real.pid:
@@ -5326,27 +5312,30 @@ process.parent.Ext.real.pid:
     in case of ppid spoofing.
   flat_name: process.parent.Ext.real.pid
   level: custom
-  name: parent.Ext.real.pid
+  name: Ext.real.pid
   normalize: []
+  original_fieldset: process
   short: The ppid of the process that actually spawned the current process, in case
     of ppid spoofing.
   type: long
 process.parent.args:
   dashed_name: process-parent-args
-  description: 'Array of process arguments.
+  description: 'Array of process arguments, starting with the absolute path to the
+    executable.
 
     May be filtered to protect sensitive information.'
   example:
-  - ssh
+  - /usr/bin/ssh
   - -l
   - user
   - 10.0.0.16
   flat_name: process.parent.args
   ignore_above: 1024
   level: extended
-  name: parent.args
+  name: args
   normalize:
   - array
+  original_fieldset: process
   short: Array of process arguments.
   type: keyword
 process.parent.args_count:
@@ -5359,8 +5348,9 @@ process.parent.args_count:
   example: 4
   flat_name: process.parent.args_count
   level: extended
-  name: parent.args_count
+  name: args_count
   normalize: []
+  original_fieldset: process
   short: Length of the process.args array.
   type: long
 process.parent.command_line:
@@ -5379,8 +5369,9 @@ process.parent.command_line:
     name: text
     norms: false
     type: text
-  name: parent.command_line
+  name: command_line
   normalize: []
+  original_fieldset: process
   short: Full command line that started the process.
   type: keyword
 process.parent.entity_id:
@@ -5398,8 +5389,9 @@ process.parent.entity_id:
   flat_name: process.parent.entity_id
   ignore_above: 1024
   level: extended
-  name: parent.entity_id
+  name: entity_id
   normalize: []
+  original_fieldset: process
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
@@ -5415,8 +5407,9 @@ process.parent.executable:
     name: text
     norms: false
     type: text
-  name: parent.executable
+  name: executable
   normalize: []
+  original_fieldset: process
   short: Absolute path to the process executable.
   type: keyword
 process.parent.exit_code:
@@ -5428,8 +5421,9 @@ process.parent.exit_code:
   example: 137
   flat_name: process.parent.exit_code
   level: extended
-  name: parent.exit_code
+  name: exit_code
   normalize: []
+  original_fieldset: process
   short: The exit code of the process.
   type: long
 process.parent.hash.md5:
@@ -5495,8 +5489,9 @@ process.parent.name:
     name: text
     norms: false
     type: text
-  name: parent.name
+  name: name
   normalize: []
+  original_fieldset: process
   short: Process name.
   type: keyword
 process.parent.pgid:
@@ -5506,8 +5501,9 @@ process.parent.pgid:
   flat_name: process.parent.pgid
   format: string
   level: extended
-  name: parent.pgid
+  name: pgid
   normalize: []
+  original_fieldset: process
   short: Identifier of the group of processes the process belongs to.
   type: long
 process.parent.pid:
@@ -5517,8 +5513,9 @@ process.parent.pid:
   flat_name: process.parent.pid
   format: string
   level: core
-  name: parent.pid
+  name: pid
   normalize: []
+  original_fieldset: process
   short: Process id.
   type: long
 process.parent.ppid:
@@ -5528,8 +5525,9 @@ process.parent.ppid:
   flat_name: process.parent.ppid
   format: string
   level: extended
-  name: parent.ppid
+  name: ppid
   normalize: []
+  original_fieldset: process
   short: Parent process' pid.
   type: long
 process.parent.start:
@@ -5538,8 +5536,9 @@ process.parent.start:
   example: '2016-05-23T08:05:34.853Z'
   flat_name: process.parent.start
   level: extended
-  name: parent.start
+  name: start
   normalize: []
+  original_fieldset: process
   short: The time the process started.
   type: date
 process.parent.thread.id:
@@ -5549,8 +5548,9 @@ process.parent.thread.id:
   flat_name: process.parent.thread.id
   format: string
   level: extended
-  name: parent.thread.id
+  name: thread.id
   normalize: []
+  original_fieldset: process
   short: Thread ID.
   type: long
 process.parent.thread.name:
@@ -5560,8 +5560,9 @@ process.parent.thread.name:
   flat_name: process.parent.thread.name
   ignore_above: 1024
   level: extended
-  name: parent.thread.name
+  name: thread.name
   normalize: []
+  original_fieldset: process
   short: Thread name.
   type: keyword
 process.parent.title:
@@ -5578,8 +5579,9 @@ process.parent.title:
     name: text
     norms: false
     type: text
-  name: parent.title
+  name: title
   normalize: []
+  original_fieldset: process
   short: Process title.
   type: keyword
 process.parent.uptime:
@@ -5588,8 +5590,9 @@ process.parent.uptime:
   example: 1325
   flat_name: process.parent.uptime
   level: extended
-  name: parent.uptime
+  name: uptime
   normalize: []
+  original_fieldset: process
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
@@ -5605,8 +5608,9 @@ process.parent.working_directory:
     name: text
     norms: false
     type: text
-  name: parent.working_directory
+  name: working_directory
   normalize: []
+  original_fieldset: process
   short: The working directory of the process.
   type: keyword
 process.pe.company:
@@ -5759,8 +5763,7 @@ process.thread.Ext.call_stack.memory_section.address:
   name: memory_section.address
   normalize: []
   original_fieldset: call_stack
-  short: Base address of the memory region containing `instruction_pointer`.  Corresponds
-    to `MEMORY_BASIC_INFORMATION.BaseAddress`
+  short: Base address of the memory region containing `instruction_pointer`.
   type: keyword
 process.thread.Ext.call_stack.memory_section.protection:
   dashed_name: process-thread-Ext-call-stack-memory-section-protection
@@ -5807,8 +5810,7 @@ process.thread.Ext.call_stack.rva:
   name: rva
   normalize: []
   original_fieldset: call_stack
-  short: The relative virtual address of `instruction_pointer`.  Computed as `instruction_pointer
-    - MEMORY_BASIC_INFORMATION.AllocationBase`.
+  short: The relative virtual address of `instruction_pointer`.
   type: keyword
 process.thread.Ext.call_stack.symbol_info:
   dashed_name: process-thread-Ext-call-stack-symbol-info
@@ -6231,9 +6233,8 @@ threat.framework:
   type: keyword
 threat.tactic.id:
   dashed_name: threat-tactic-id
-  description: The id of tactic used by this threat. You can use the Mitre ATT&CK
-    Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-    )
+  description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )"
   example: TA0040
   flat_name: threat.tactic.id
   ignore_above: 1024
@@ -6245,9 +6246,8 @@ threat.tactic.id:
   type: keyword
 threat.tactic.name:
   dashed_name: threat-tactic-name
-  description: Name of the type of tactic used by this threat. You can use the Mitre
-    ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-    )
+  description: "Name of the type of tactic used by this threat. You can use a MITRE\
+    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
   example: impact
   flat_name: threat.tactic.name
   ignore_above: 1024
@@ -6259,9 +6259,9 @@ threat.tactic.name:
   type: keyword
 threat.tactic.reference:
   dashed_name: threat-tactic-reference
-  description: The reference url of tactic used by this threat. You can use the Mitre
-    ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-    )
+  description: "The reference url of tactic used by this threat. You can use a MITRE\
+    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+    \ )"
   example: https://attack.mitre.org/tactics/TA0040/
   flat_name: threat.tactic.reference
   ignore_above: 1024
@@ -6269,13 +6269,12 @@ threat.tactic.reference:
   name: tactic.reference
   normalize:
   - array
-  short: Threat tactic url reference.
+  short: Threat tactic URL reference.
   type: keyword
 threat.technique.id:
   dashed_name: threat-technique-id
-  description: The id of technique used by this tactic. You can use the Mitre ATT&CK
-    Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-    )
+  description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
   example: T1499
   flat_name: threat.technique.id
   ignore_above: 1024
@@ -6287,10 +6286,9 @@ threat.technique.id:
   type: keyword
 threat.technique.name:
   dashed_name: threat-technique-name
-  description: The name of technique used by this tactic. You can use the Mitre ATT&CK
-    Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-    )
-  example: endpoint denial of service
+  description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
+  example: Endpoint Denial of Service
   flat_name: threat.technique.name
   ignore_above: 1024
   level: extended
@@ -6306,9 +6304,9 @@ threat.technique.name:
   type: keyword
 threat.technique.reference:
   dashed_name: threat-technique-reference
-  description: The reference url of technique used by this tactic. You can use the
-    Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-    )
+  description: "The reference url of technique used by this threat. You can use a\
+    \ MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
+    \ )"
   example: https://attack.mitre.org/techniques/T1499/
   flat_name: threat.technique.reference
   ignore_above: 1024
@@ -6316,7 +6314,7 @@ threat.technique.reference:
   name: technique.reference
   normalize:
   - array
-  short: Threat technique reference.
+  short: Threat technique URL reference.
   type: keyword
 user.Ext:
   dashed_name: user-Ext
@@ -6487,13 +6485,13 @@ user.hash:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/alerts/ecs/subset/malware_event/ecs_flat.yml
+++ b/generated/alerts/ecs/subset/malware_event/ecs_flat.yml
@@ -1199,25 +1199,26 @@ Target.process.parent.Ext.code_signature.valid:
   type: boolean
 Target.process.parent.Ext.real:
   dashed_name: Target-process-parent-Ext-real
-  description: The field set containing parent process info in case of any ppid spoofing.
+  description: The field set containing process info in case of any pid spoofing.
+    This is mainly useful for process.parent.
   flat_name: Target.process.parent.Ext.real
   level: custom
   name: Ext.real
   normalize: []
   original_fieldset: process
-  short: The field set containing parent process info in case of any ppid spoofing.
+  short: The field set containing process info in case of any pid spoofing. This is
+    mainly useful for process.parent.
   type: object
 Target.process.parent.Ext.real.pid:
   dashed_name: Target-process-parent-Ext-real-pid
-  description: The ppid of the process that actually spawned the current process,
-    in case of ppid spoofing.
+  description: For process.parent this will be the ppid of the process that actually
+    spawned the current process.
   flat_name: Target.process.parent.Ext.real.pid
   level: custom
   name: Ext.real.pid
   normalize: []
   original_fieldset: process
-  short: The ppid of the process that actually spawned the current process, in case
-    of ppid spoofing.
+  short: The real pid of the process if ppid spoofing is happening.
   type: long
 Target.process.parent.args:
   dashed_name: Target-process-parent-args
@@ -5298,25 +5299,26 @@ process.parent.Ext.code_signature.valid:
   type: boolean
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
-  description: The field set containing parent process info in case of any ppid spoofing.
+  description: The field set containing process info in case of any pid spoofing.
+    This is mainly useful for process.parent.
   flat_name: process.parent.Ext.real
   level: custom
   name: Ext.real
   normalize: []
   original_fieldset: process
-  short: The field set containing parent process info in case of any ppid spoofing.
+  short: The field set containing process info in case of any pid spoofing. This is
+    mainly useful for process.parent.
   type: object
 process.parent.Ext.real.pid:
   dashed_name: process-parent-Ext-real-pid
-  description: The ppid of the process that actually spawned the current process,
-    in case of ppid spoofing.
+  description: For process.parent this will be the ppid of the process that actually
+    spawned the current process.
   flat_name: process.parent.Ext.real.pid
   level: custom
   name: Ext.real.pid
   normalize: []
   original_fieldset: process
-  short: The ppid of the process that actually spawned the current process, in case
-    of ppid spoofing.
+  short: The real pid of the process if ppid spoofing is happening.
   type: long
 process.parent.args:
   dashed_name: process-parent-args

--- a/generated/alerts/elasticsearch/7/template.json
+++ b/generated/alerts/elasticsearch/7/template.json
@@ -4,7 +4,7 @@
   ],
   "mappings": {
     "_meta": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "date_detection": false,
     "dynamic_templates": [
@@ -598,8 +598,7 @@
                     "ignore_above": 1024,
                     "type": "keyword"
                   }
-                },
-                "type": "object"
+                }
               },
               "pe": {
                 "properties": {
@@ -2030,8 +2029,7 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               }
-            },
-            "type": "object"
+            }
           },
           "pe": {
             "properties": {

--- a/generated/file/ecs/ecs_flat.yml
+++ b/generated/file/ecs/ecs_flat.yml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -1036,8 +1036,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -1284,13 +1283,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/file/ecs/subset/file/ecs_flat.yml
+++ b/generated/file/ecs/subset/file/ecs_flat.yml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -1006,8 +1006,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -1254,13 +1253,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/file/ecs/subset/unquarantine/ecs_flat.yml
+++ b/generated/file/ecs/subset/unquarantine/ecs_flat.yml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -829,8 +829,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family

--- a/generated/file/elasticsearch/7/template.json
+++ b/generated/file/elasticsearch/7/template.json
@@ -4,7 +4,7 @@
   ],
   "mappings": {
     "_meta": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "date_detection": false,
     "dynamic_templates": [

--- a/generated/library/ecs/ecs_flat.yml
+++ b/generated/library/ecs/ecs_flat.yml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -946,8 +946,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -1194,13 +1193,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/library/ecs/subset/library/ecs_flat.yml
+++ b/generated/library/ecs/subset/library/ecs_flat.yml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -946,8 +946,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -1194,13 +1193,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/library/elasticsearch/7/template.json
+++ b/generated/library/elasticsearch/7/template.json
@@ -4,7 +4,7 @@
   ],
   "mappings": {
     "_meta": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "date_detection": false,
     "dynamic_templates": [

--- a/generated/metadata/ecs/ecs_flat.yml
+++ b/generated/metadata/ecs/ecs_flat.yml
@@ -109,7 +109,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -183,8 +183,7 @@ elastic.agent:
   level: custom
   name: agent
   normalize: []
-  short: The agent fields contain data about the Elastic Agent. The Elastic Agent
-    is the management agent that manages other agents or process on the host.
+  short: The agent fields contain data about the Elastic Agent.
   type: object
 elastic.agent.id:
   dashed_name: elastic-agent-id
@@ -764,8 +763,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family

--- a/generated/metadata/ecs/subset/metadata/ecs_flat.yml
+++ b/generated/metadata/ecs/subset/metadata/ecs_flat.yml
@@ -109,7 +109,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -183,8 +183,7 @@ elastic.agent:
   level: custom
   name: agent
   normalize: []
-  short: The agent fields contain data about the Elastic Agent. The Elastic Agent
-    is the management agent that manages other agents or process on the host.
+  short: The agent fields contain data about the Elastic Agent.
   type: object
 elastic.agent.id:
   dashed_name: elastic-agent-id
@@ -764,8 +763,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family

--- a/generated/metadata/elasticsearch/7/template.json
+++ b/generated/metadata/elasticsearch/7/template.json
@@ -4,7 +4,7 @@
   ],
   "mappings": {
     "_meta": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "date_detection": false,
     "dynamic_templates": [

--- a/generated/metrics/ecs/ecs_flat.yml
+++ b/generated/metrics/ecs/ecs_flat.yml
@@ -54,10 +54,7 @@ Endpoint.metrics.cpu.endpoint.histogram:
   level: custom
   name: metrics.cpu.endpoint.histogram
   normalize: []
-  short: This field defines an elasticsearch histogram field (https://www.elastic.co/guide/en/elasticsearch/reference/current/histogram.html#histogram)
-    The values field includes 20 buckets (each bucket is 5%) representing the cpu
-    usage The counts field includes 20 buckets of how many times the endpoint's cpu
-    usage fell into each bucket
+  short: CPU histogram
   type: histogram
 Endpoint.metrics.cpu.endpoint.latest:
   dashed_name: Endpoint-metrics-cpu-endpoint-latest
@@ -245,7 +242,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -900,8 +897,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family

--- a/generated/metrics/ecs/subset/metrics/ecs_flat.yml
+++ b/generated/metrics/ecs/subset/metrics/ecs_flat.yml
@@ -54,10 +54,7 @@ Endpoint.metrics.cpu.endpoint.histogram:
   level: custom
   name: metrics.cpu.endpoint.histogram
   normalize: []
-  short: This field defines an elasticsearch histogram field (https://www.elastic.co/guide/en/elasticsearch/reference/current/histogram.html#histogram)
-    The values field includes 20 buckets (each bucket is 5%) representing the cpu
-    usage The counts field includes 20 buckets of how many times the endpoint's cpu
-    usage fell into each bucket
+  short: CPU histogram
   type: histogram
 Endpoint.metrics.cpu.endpoint.latest:
   dashed_name: Endpoint-metrics-cpu-endpoint-latest
@@ -245,7 +242,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -900,8 +897,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family

--- a/generated/metrics/elasticsearch/7/template.json
+++ b/generated/metrics/elasticsearch/7/template.json
@@ -4,7 +4,7 @@
   ],
   "mappings": {
     "_meta": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "date_detection": false,
     "dynamic_templates": [

--- a/generated/network/ecs/ecs_flat.yml
+++ b/generated/network/ecs/ecs_flat.yml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -222,9 +222,7 @@ destination.geo.region_name:
   type: keyword
 destination.ip:
   dashed_name: destination-ip
-  description: 'IP address of the destination.
-
-    Can be one or multiple IPv4 or IPv6 addresses.'
+  description: IP address of the destination (IPv4 or IPv6).
   flat_name: destination.ip
   level: core
   name: ip
@@ -255,12 +253,12 @@ destination.registered_domain:
   dashed_name: destination-registered-domain
   description: 'The highest registered destination domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: destination.registered_domain
   ignore_above: 1024
   level: extended
@@ -271,7 +269,7 @@ destination.registered_domain:
 destination.top_level_domain:
   dashed_name: destination-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -323,7 +321,7 @@ dns.question.name:
     characters should be represented as escaped base 10 integers (\DDD). Back slashes
     and quotes should be escaped. Tabs, carriage returns, and line feeds should be
     converted to \t, \r, and \n respectively.'
-  example: www.google.com
+  example: www.example.com
   flat_name: dns.question.name
   ignore_above: 1024
   level: extended
@@ -335,12 +333,12 @@ dns.question.registered_domain:
   dashed_name: dns-question-registered-domain
   description: 'The highest registered domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: dns.question.registered_domain
   ignore_above: 1024
   level: extended
@@ -365,7 +363,7 @@ dns.question.subdomain:
 dns.question.top_level_domain:
   dashed_name: dns-question-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -1050,8 +1048,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -1605,9 +1602,7 @@ source.geo.region_name:
   type: keyword
 source.ip:
   dashed_name: source-ip
-  description: 'IP address of the source.
-
-    Can be one or multiple IPv4 or IPv6 addresses.'
+  description: IP address of the source (IPv4 or IPv6).
   flat_name: source.ip
   level: core
   name: ip
@@ -1638,12 +1633,12 @@ source.registered_domain:
   dashed_name: source-registered-domain
   description: 'The highest registered source domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: source.registered_domain
   ignore_above: 1024
   level: extended
@@ -1654,7 +1649,7 @@ source.registered_domain:
 source.top_level_domain:
   dashed_name: source-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -1720,13 +1715,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/network/ecs/subset/network/ecs_flat.yml
+++ b/generated/network/ecs/subset/network/ecs_flat.yml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -222,9 +222,7 @@ destination.geo.region_name:
   type: keyword
 destination.ip:
   dashed_name: destination-ip
-  description: 'IP address of the destination.
-
-    Can be one or multiple IPv4 or IPv6 addresses.'
+  description: IP address of the destination (IPv4 or IPv6).
   flat_name: destination.ip
   level: core
   name: ip
@@ -255,12 +253,12 @@ destination.registered_domain:
   dashed_name: destination-registered-domain
   description: 'The highest registered destination domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: destination.registered_domain
   ignore_above: 1024
   level: extended
@@ -271,7 +269,7 @@ destination.registered_domain:
 destination.top_level_domain:
   dashed_name: destination-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -323,7 +321,7 @@ dns.question.name:
     characters should be represented as escaped base 10 integers (\DDD). Back slashes
     and quotes should be escaped. Tabs, carriage returns, and line feeds should be
     converted to \t, \r, and \n respectively.'
-  example: www.google.com
+  example: www.example.com
   flat_name: dns.question.name
   ignore_above: 1024
   level: extended
@@ -335,12 +333,12 @@ dns.question.registered_domain:
   dashed_name: dns-question-registered-domain
   description: 'The highest registered domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: dns.question.registered_domain
   ignore_above: 1024
   level: extended
@@ -365,7 +363,7 @@ dns.question.subdomain:
 dns.question.top_level_domain:
   dashed_name: dns-question-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -1050,8 +1048,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -1605,9 +1602,7 @@ source.geo.region_name:
   type: keyword
 source.ip:
   dashed_name: source-ip
-  description: 'IP address of the source.
-
-    Can be one or multiple IPv4 or IPv6 addresses.'
+  description: IP address of the source (IPv4 or IPv6).
   flat_name: source.ip
   level: core
   name: ip
@@ -1638,12 +1633,12 @@ source.registered_domain:
   dashed_name: source-registered-domain
   description: 'The highest registered source domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: source.registered_domain
   ignore_above: 1024
   level: extended
@@ -1654,7 +1649,7 @@ source.registered_domain:
 source.top_level_domain:
   dashed_name: source-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -1720,13 +1715,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/network/elasticsearch/7/template.json
+++ b/generated/network/elasticsearch/7/template.json
@@ -4,7 +4,7 @@
   ],
   "mappings": {
     "_meta": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "date_detection": false,
     "dynamic_templates": [

--- a/generated/policy/ecs/ecs_flat.yml
+++ b/generated/policy/ecs/ecs_flat.yml
@@ -221,8 +221,7 @@ Endpoint.policy.applied.configurations.events.status:
   level: custom
   name: policy.applied.configurations.events.status
   normalize: []
-  short: the overall status of event collection, this is correlated to the status
-    of concerned actions  but not a simple sum of the actions
+  short: the overall status of event collection
   type: keyword
 Endpoint.policy.applied.configurations.logging:
   dashed_name: Endpoint-policy-applied-configurations-logging
@@ -252,8 +251,7 @@ Endpoint.policy.applied.configurations.logging.status:
   level: custom
   name: policy.applied.configurations.logging.status
   normalize: []
-  short: the overall status of logging, this is correlated to the status of concerned
-    actions but  not a simple sum of the actions
+  short: the overall status of logging
   type: keyword
 Endpoint.policy.applied.configurations.malware:
   dashed_name: Endpoint-policy-applied-configurations-malware
@@ -283,8 +281,7 @@ Endpoint.policy.applied.configurations.malware.status:
   level: custom
   name: policy.applied.configurations.malware.status
   normalize: []
-  short: the overall status of malware, this is correlated to the status of concerned
-    actions  but not a simple sum of the actions
+  short: the overall status of malware
   type: keyword
 Endpoint.policy.applied.configurations.streaming:
   dashed_name: Endpoint-policy-applied-configurations-streaming
@@ -314,8 +311,7 @@ Endpoint.policy.applied.configurations.streaming.status:
   level: custom
   name: policy.applied.configurations.streaming.status
   normalize: []
-  short: the overall status of data streaming, this is correlated to the status of
-    concerned actions  but not a simple sum of the actions
+  short: overall status of data streaming
   type: keyword
 Endpoint.policy.applied.id:
   dashed_name: Endpoint-policy-applied-id
@@ -384,7 +380,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -1017,8 +1013,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family

--- a/generated/policy/ecs/subset/policy/ecs_flat.yml
+++ b/generated/policy/ecs/subset/policy/ecs_flat.yml
@@ -221,8 +221,7 @@ Endpoint.policy.applied.configurations.events.status:
   level: custom
   name: policy.applied.configurations.events.status
   normalize: []
-  short: the overall status of event collection, this is correlated to the status
-    of concerned actions  but not a simple sum of the actions
+  short: the overall status of event collection
   type: keyword
 Endpoint.policy.applied.configurations.logging:
   dashed_name: Endpoint-policy-applied-configurations-logging
@@ -252,8 +251,7 @@ Endpoint.policy.applied.configurations.logging.status:
   level: custom
   name: policy.applied.configurations.logging.status
   normalize: []
-  short: the overall status of logging, this is correlated to the status of concerned
-    actions but  not a simple sum of the actions
+  short: the overall status of logging
   type: keyword
 Endpoint.policy.applied.configurations.malware:
   dashed_name: Endpoint-policy-applied-configurations-malware
@@ -283,8 +281,7 @@ Endpoint.policy.applied.configurations.malware.status:
   level: custom
   name: policy.applied.configurations.malware.status
   normalize: []
-  short: the overall status of malware, this is correlated to the status of concerned
-    actions  but not a simple sum of the actions
+  short: the overall status of malware
   type: keyword
 Endpoint.policy.applied.configurations.streaming:
   dashed_name: Endpoint-policy-applied-configurations-streaming
@@ -314,8 +311,7 @@ Endpoint.policy.applied.configurations.streaming.status:
   level: custom
   name: policy.applied.configurations.streaming.status
   normalize: []
-  short: the overall status of data streaming, this is correlated to the status of
-    concerned actions  but not a simple sum of the actions
+  short: overall status of data streaming
   type: keyword
 Endpoint.policy.applied.id:
   dashed_name: Endpoint-policy-applied-id
@@ -384,7 +380,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -1017,8 +1013,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family

--- a/generated/policy/elasticsearch/7/template.json
+++ b/generated/policy/elasticsearch/7/template.json
@@ -4,7 +4,7 @@
   ],
   "mappings": {
     "_meta": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "date_detection": false,
     "dynamic_templates": [

--- a/generated/process/ecs/ecs_flat.yml
+++ b/generated/process/ecs/ecs_flat.yml
@@ -1094,25 +1094,26 @@ process.parent.Ext:
   type: object
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
-  description: The field set containing parent process info in case of any ppid spoofing.
+  description: The field set containing process info in case of any pid spoofing.
+    This is mainly useful for process.parent.
   flat_name: process.parent.Ext.real
   level: custom
   name: Ext.real
   normalize: []
   original_fieldset: process
-  short: The field set containing parent process info in case of any ppid spoofing.
+  short: The field set containing process info in case of any pid spoofing. This is
+    mainly useful for process.parent.
   type: object
 process.parent.Ext.real.pid:
   dashed_name: process-parent-Ext-real-pid
-  description: The ppid of the process that actually spawned the current process,
-    in case of ppid spoofing.
+  description: For process.parent this will be the ppid of the process that actually
+    spawned the current process.
   flat_name: process.parent.Ext.real.pid
   level: custom
   name: Ext.real.pid
   normalize: []
   original_fieldset: process
-  short: The ppid of the process that actually spawned the current process, in case
-    of ppid spoofing.
+  short: The real pid of the process if ppid spoofing is happening.
   type: long
 process.parent.entity_id:
   dashed_name: process-parent-entity-id

--- a/generated/process/ecs/ecs_flat.yml
+++ b/generated/process/ecs/ecs_flat.yml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -725,8 +725,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -1083,22 +1082,14 @@ process.name:
   normalize: []
   short: Process name.
   type: keyword
-process.parent:
-  dashed_name: process-parent
-  description: Extended "process.parent" field set.
-  flat_name: process.parent
-  level: custom
-  name: parent
-  normalize: []
-  short: Extended "process.parent" field set.
-  type: object
 process.parent.Ext:
   dashed_name: process-parent-Ext
   description: Object for all custom defined fields to live in.
   flat_name: process.parent.Ext
   level: custom
-  name: parent.Ext
+  name: Ext
   normalize: []
+  original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
 process.parent.Ext.real:
@@ -1106,8 +1097,9 @@ process.parent.Ext.real:
   description: The field set containing parent process info in case of any ppid spoofing.
   flat_name: process.parent.Ext.real
   level: custom
-  name: parent.Ext.real
+  name: Ext.real
   normalize: []
+  original_fieldset: process
   short: The field set containing parent process info in case of any ppid spoofing.
   type: object
 process.parent.Ext.real.pid:
@@ -1116,8 +1108,9 @@ process.parent.Ext.real.pid:
     in case of ppid spoofing.
   flat_name: process.parent.Ext.real.pid
   level: custom
-  name: parent.Ext.real.pid
+  name: Ext.real.pid
   normalize: []
+  original_fieldset: process
   short: The ppid of the process that actually spawned the current process, in case
     of ppid spoofing.
   type: long
@@ -1136,8 +1129,9 @@ process.parent.entity_id:
   flat_name: process.parent.entity_id
   ignore_above: 1024
   level: extended
-  name: parent.entity_id
+  name: entity_id
   normalize: []
+  original_fieldset: process
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
@@ -1152,8 +1146,9 @@ process.parent.executable:
     name: text
     norms: false
     type: text
-  name: parent.executable
+  name: executable
   normalize: []
+  original_fieldset: process
   short: Absolute path to the process executable.
   type: keyword
 process.parent.name:
@@ -1170,8 +1165,9 @@ process.parent.name:
     name: text
     norms: false
     type: text
-  name: parent.name
+  name: name
   normalize: []
+  original_fieldset: process
   short: Process name.
   type: keyword
 process.parent.pid:
@@ -1181,8 +1177,9 @@ process.parent.pid:
   flat_name: process.parent.pid
   format: string
   level: core
-  name: parent.pid
+  name: pid
   normalize: []
+  original_fieldset: process
   short: Process id.
   type: long
 process.pe.original_file_name:
@@ -1271,13 +1268,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/process/ecs/subset/process/ecs_flat.yml
+++ b/generated/process/ecs/subset/process/ecs_flat.yml
@@ -1094,25 +1094,26 @@ process.parent.Ext:
   type: object
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
-  description: The field set containing parent process info in case of any ppid spoofing.
+  description: The field set containing process info in case of any pid spoofing.
+    This is mainly useful for process.parent.
   flat_name: process.parent.Ext.real
   level: custom
   name: Ext.real
   normalize: []
   original_fieldset: process
-  short: The field set containing parent process info in case of any ppid spoofing.
+  short: The field set containing process info in case of any pid spoofing. This is
+    mainly useful for process.parent.
   type: object
 process.parent.Ext.real.pid:
   dashed_name: process-parent-Ext-real-pid
-  description: The ppid of the process that actually spawned the current process,
-    in case of ppid spoofing.
+  description: For process.parent this will be the ppid of the process that actually
+    spawned the current process.
   flat_name: process.parent.Ext.real.pid
   level: custom
   name: Ext.real.pid
   normalize: []
   original_fieldset: process
-  short: The ppid of the process that actually spawned the current process, in case
-    of ppid spoofing.
+  short: The real pid of the process if ppid spoofing is happening.
   type: long
 process.parent.entity_id:
   dashed_name: process-parent-entity-id

--- a/generated/process/ecs/subset/process/ecs_flat.yml
+++ b/generated/process/ecs/subset/process/ecs_flat.yml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -725,8 +725,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -1083,22 +1082,14 @@ process.name:
   normalize: []
   short: Process name.
   type: keyword
-process.parent:
-  dashed_name: process-parent
-  description: Extended "process.parent" field set.
-  flat_name: process.parent
-  level: custom
-  name: parent
-  normalize: []
-  short: Extended "process.parent" field set.
-  type: object
 process.parent.Ext:
   dashed_name: process-parent-Ext
   description: Object for all custom defined fields to live in.
   flat_name: process.parent.Ext
   level: custom
-  name: parent.Ext
+  name: Ext
   normalize: []
+  original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
 process.parent.Ext.real:
@@ -1106,8 +1097,9 @@ process.parent.Ext.real:
   description: The field set containing parent process info in case of any ppid spoofing.
   flat_name: process.parent.Ext.real
   level: custom
-  name: parent.Ext.real
+  name: Ext.real
   normalize: []
+  original_fieldset: process
   short: The field set containing parent process info in case of any ppid spoofing.
   type: object
 process.parent.Ext.real.pid:
@@ -1116,8 +1108,9 @@ process.parent.Ext.real.pid:
     in case of ppid spoofing.
   flat_name: process.parent.Ext.real.pid
   level: custom
-  name: parent.Ext.real.pid
+  name: Ext.real.pid
   normalize: []
+  original_fieldset: process
   short: The ppid of the process that actually spawned the current process, in case
     of ppid spoofing.
   type: long
@@ -1136,8 +1129,9 @@ process.parent.entity_id:
   flat_name: process.parent.entity_id
   ignore_above: 1024
   level: extended
-  name: parent.entity_id
+  name: entity_id
   normalize: []
+  original_fieldset: process
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
@@ -1152,8 +1146,9 @@ process.parent.executable:
     name: text
     norms: false
     type: text
-  name: parent.executable
+  name: executable
   normalize: []
+  original_fieldset: process
   short: Absolute path to the process executable.
   type: keyword
 process.parent.name:
@@ -1170,8 +1165,9 @@ process.parent.name:
     name: text
     norms: false
     type: text
-  name: parent.name
+  name: name
   normalize: []
+  original_fieldset: process
   short: Process name.
   type: keyword
 process.parent.pid:
@@ -1181,8 +1177,9 @@ process.parent.pid:
   flat_name: process.parent.pid
   format: string
   level: core
-  name: parent.pid
+  name: pid
   normalize: []
+  original_fieldset: process
   short: Process id.
   type: long
 process.pe.original_file_name:
@@ -1271,13 +1268,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/process/elasticsearch/7/template.json
+++ b/generated/process/elasticsearch/7/template.json
@@ -4,7 +4,7 @@
   ],
   "mappings": {
     "_meta": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "date_detection": false,
     "dynamic_templates": [
@@ -364,8 +364,7 @@
               "pid": {
                 "type": "long"
               }
-            },
-            "type": "object"
+            }
           },
           "pe": {
             "properties": {

--- a/generated/registry/ecs/ecs_flat.yml
+++ b/generated/registry/ecs/ecs_flat.yml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -725,8 +725,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -950,7 +949,8 @@ registry.data.strings:
   ignore_above: 1024
   level: core
   name: data.strings
-  normalize: []
+  normalize:
+  - array
   short: List of strings representing what was written to the registry.
   type: keyword
 registry.hive:
@@ -1050,13 +1050,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/registry/ecs/subset/registry/ecs_flat.yml
+++ b/generated/registry/ecs/subset/registry/ecs_flat.yml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -725,8 +725,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -950,7 +949,8 @@ registry.data.strings:
   ignore_above: 1024
   level: core
   name: data.strings
-  normalize: []
+  normalize:
+  - array
   short: List of strings representing what was written to the registry.
   type: keyword
 registry.hive:
@@ -1050,13 +1050,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/registry/elasticsearch/7/template.json
+++ b/generated/registry/elasticsearch/7/template.json
@@ -4,7 +4,7 @@
   ],
   "mappings": {
     "_meta": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "date_detection": false,
     "dynamic_templates": [

--- a/generated/security/ecs/ecs_flat.yml
+++ b/generated/security/ecs/ecs_flat.yml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -725,8 +725,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -973,13 +972,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/security/ecs/subset/security/ecs_flat.yml
+++ b/generated/security/ecs/subset/security/ecs_flat.yml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -725,8 +725,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -973,13 +972,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/generated/security/elasticsearch/7/template.json
+++ b/generated/security/elasticsearch/7/template.json
@@ -4,7 +4,7 @@
   ],
   "mappings": {
     "_meta": {
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     "date_detection": false,
     "dynamic_templates": [

--- a/package/endpoint/dataset/alerts/fields/fields.yml
+++ b/package/endpoint/dataset/alerts/fields/fields.yml
@@ -655,11 +655,6 @@
       Sometimes called program name or similar.'
     example: ssh
     default_field: false
-  - name: process.parent
-    level: custom
-    type: object
-    description: Extended "process.parent" field set.
-    default_field: false
   - name: process.parent.Ext
     level: custom
     type: object
@@ -728,11 +723,12 @@
     level: extended
     type: keyword
     ignore_above: 1024
-    description: 'Array of process arguments.
+    description: 'Array of process arguments, starting with the absolute path to the
+      executable.
 
       May be filtered to protect sensitive information.'
     example:
-    - ssh
+    - /usr/bin/ssh
     - -l
     - user
     - 10.0.0.16
@@ -1228,7 +1224,7 @@
     ignore_above: 1024
     description: 'Type of the agent.
 
-      The agent type stays always the same and should be given by the agent used.
+      The agent type always stays the same and should be given by the agent used.
       In case of Filebeat the agent would always be Filebeat also if two Filebeat
       instances are run on the same machine.'
     example: filebeat
@@ -2579,7 +2575,7 @@
     level: core
     type: keyword
     ignore_above: 1024
-    description: Unique identifiers of the user.
+    description: Unique identifier of the user.
   - name: user.name
     level: core
     type: keyword
@@ -2921,11 +2917,6 @@
 
       Sometimes called program name or similar.'
     example: ssh
-  - name: parent
-    level: custom
-    type: object
-    description: Extended "process.parent" field set.
-    default_field: false
   - name: parent.Ext
     level: custom
     type: object
@@ -2994,11 +2985,12 @@
     level: extended
     type: keyword
     ignore_above: 1024
-    description: 'Array of process arguments.
+    description: 'Array of process arguments, starting with the absolute path to the
+      executable.
 
       May be filtered to protect sensitive information.'
     example:
-    - ssh
+    - /usr/bin/ssh
     - -l
     - user
     - 10.0.0.16
@@ -3533,14 +3525,13 @@
 - name: threat
   title: Threat
   group: 2
-  description: 'Fields to classify events and alerts according to a threat taxonomy
-    such as the Mitre ATT&CK framework.
-
-    These fields are for users to classify alerts from all of their sources (e.g.
-    IDS, NGFW, etc.) within a common taxonomy. The threat.tactic.* are meant to capture
-    the high level category of the threat (e.g. "impact"). The threat.technique.*
-    fields are meant to capture which kind of approach is used by this detected threat,
-    to accomplish the goal (e.g. "endpoint denial of service").'
+  description: "Fields to classify events and alerts according to a threat taxonomy
+    such as the MITRE ATT&CK® framework.\nThese fields are for users to classify alerts
+    from all of their sources (e.g. IDS, NGFW, etc.) within a common taxonomy. The
+    threat.tactic.* are meant to capture the high level category of the threat (e.g.
+    \"impact\"). The threat.technique.* fields are meant to capture which kind of
+    approach is used by this detected threat, to accomplish the goal (e.g. \"endpoint
+    denial of service\")."
   type: group
   fields:
   - name: framework
@@ -3556,33 +3547,29 @@
     level: extended
     type: keyword
     ignore_above: 1024
-    description: The id of tactic used by this threat. You can use the Mitre ATT&CK
-      Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-      )
+    description: "The id of tactic used by this threat. You can use a MITRE ATT&CK®
+      tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )"
     example: TA0040
   - name: tactic.name
     level: extended
     type: keyword
     ignore_above: 1024
-    description: Name of the type of tactic used by this threat. You can use the Mitre
-      ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-      )
+    description: "Name of the type of tactic used by this threat. You can use a MITRE
+      ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
     example: impact
   - name: tactic.reference
     level: extended
     type: keyword
     ignore_above: 1024
-    description: The reference url of tactic used by this threat. You can use the
-      Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-      )
+    description: "The reference url of tactic used by this threat. You can use a MITRE
+      ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )"
     example: https://attack.mitre.org/tactics/TA0040/
   - name: technique.id
     level: extended
     type: keyword
     ignore_above: 1024
-    description: The id of technique used by this tactic. You can use the Mitre ATT&CK
-      Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-      )
+    description: "The id of technique used by this threat. You can use a MITRE ATT&CK®
+      technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
     example: T1499
   - name: technique.name
     level: extended
@@ -3593,17 +3580,16 @@
       type: text
       norms: false
       default_field: false
-    description: The name of technique used by this tactic. You can use the Mitre
-      ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-      )
-    example: endpoint denial of service
+    description: "The name of technique used by this threat. You can use a MITRE ATT&CK®
+      technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
+    example: Endpoint Denial of Service
   - name: technique.reference
     level: extended
     type: keyword
     ignore_above: 1024
-    description: The reference url of technique used by this tactic. You can use the
-      Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-      )
+    description: "The reference url of technique used by this threat. You can use
+      a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1499/
+      )"
     example: https://attack.mitre.org/techniques/T1499/
 - name: user
   title: User
@@ -3712,7 +3698,7 @@
     level: core
     type: keyword
     ignore_above: 1024
-    description: Unique identifiers of the user.
+    description: Unique identifier of the user.
   - name: name
     level: core
     type: keyword

--- a/package/endpoint/dataset/alerts/fields/fields.yml
+++ b/package/endpoint/dataset/alerts/fields/fields.yml
@@ -710,14 +710,14 @@
   - name: process.parent.Ext.real
     level: custom
     type: object
-    description: The field set containing parent process info in case of any ppid
-      spoofing.
+    description: The field set containing process info in case of any pid spoofing.
+      This is mainly useful for process.parent.
     default_field: false
   - name: process.parent.Ext.real.pid
     level: custom
     type: long
-    description: The ppid of the process that actually spawned the current process,
-      in case of ppid spoofing.
+    description: For process.parent this will be the ppid of the process that actually
+      spawned the current process.
     default_field: false
   - name: process.parent.args
     level: extended
@@ -2972,14 +2972,14 @@
   - name: parent.Ext.real
     level: custom
     type: object
-    description: The field set containing parent process info in case of any ppid
-      spoofing.
+    description: The field set containing process info in case of any pid spoofing.
+      This is mainly useful for process.parent.
     default_field: false
   - name: parent.Ext.real.pid
     level: custom
     type: long
-    description: The ppid of the process that actually spawned the current process,
-      in case of ppid spoofing.
+    description: For process.parent this will be the ppid of the process that actually
+      spawned the current process.
     default_field: false
   - name: parent.args
     level: extended

--- a/package/endpoint/dataset/file/fields/fields.yml
+++ b/package/endpoint/dataset/file/fields/fields.yml
@@ -53,7 +53,7 @@
     ignore_above: 1024
     description: 'Type of the agent.
 
-      The agent type stays always the same and should be given by the agent used.
+      The agent type always stays the same and should be given by the agent used.
       In case of Filebeat the agent would always be Filebeat also if two Filebeat
       instances are run on the same machine.'
     example: filebeat
@@ -689,7 +689,7 @@
     level: core
     type: keyword
     ignore_above: 1024
-    description: Unique identifiers of the user.
+    description: Unique identifier of the user.
   - name: name
     level: core
     type: keyword

--- a/package/endpoint/dataset/library/fields/fields.yml
+++ b/package/endpoint/dataset/library/fields/fields.yml
@@ -53,7 +53,7 @@
     ignore_above: 1024
     description: 'Type of the agent.
 
-      The agent type stays always the same and should be given by the agent used.
+      The agent type always stays the same and should be given by the agent used.
       In case of Filebeat the agent would always be Filebeat also if two Filebeat
       instances are run on the same machine.'
     example: filebeat
@@ -662,7 +662,7 @@
     level: core
     type: keyword
     ignore_above: 1024
-    description: Unique identifiers of the user.
+    description: Unique identifier of the user.
   - name: name
     level: core
     type: keyword

--- a/package/endpoint/dataset/metadata/fields/fields.yml
+++ b/package/endpoint/dataset/metadata/fields/fields.yml
@@ -94,7 +94,7 @@
     ignore_above: 1024
     description: 'Type of the agent.
 
-      The agent type stays always the same and should be given by the agent used.
+      The agent type always stays the same and should be given by the agent used.
       In case of Filebeat the agent would always be Filebeat also if two Filebeat
       instances are run on the same machine.'
     example: filebeat

--- a/package/endpoint/dataset/metadata_current/fields/fields.yml
+++ b/package/endpoint/dataset/metadata_current/fields/fields.yml
@@ -160,7 +160,7 @@
       ignore_above: 1024
       description: 'Type of the agent.
 
-        The agent type stays always the same and should be given by the agent used.
+        The agent type always stays the same and should be given by the agent used.
         In case of Filebeat the agent would always be Filebeat also if two Filebeat
         instances are run on the same machine.'
       example: filebeat

--- a/package/endpoint/dataset/metrics/fields/fields.yml
+++ b/package/endpoint/dataset/metrics/fields/fields.yml
@@ -178,7 +178,7 @@
     ignore_above: 1024
     description: 'Type of the agent.
 
-      The agent type stays always the same and should be given by the agent used.
+      The agent type always stays the same and should be given by the agent used.
       In case of Filebeat the agent would always be Filebeat also if two Filebeat
       instances are run on the same machine.'
     example: filebeat

--- a/package/endpoint/dataset/network/fields/fields.yml
+++ b/package/endpoint/dataset/network/fields/fields.yml
@@ -53,7 +53,7 @@
     ignore_above: 1024
     description: 'Type of the agent.
 
-      The agent type stays always the same and should be given by the agent used.
+      The agent type always stays the same and should be given by the agent used.
       In case of Filebeat the agent would always be Filebeat also if two Filebeat
       instances are run on the same machine.'
     example: filebeat
@@ -169,9 +169,7 @@
   - name: ip
     level: core
     type: ip
-    description: 'IP address of the destination.
-
-      Can be one or multiple IPv4 or IPv6 addresses.'
+    description: IP address of the destination (IPv4 or IPv6).
   - name: packets
     level: core
     type: long
@@ -188,19 +186,19 @@
     ignore_above: 1024
     description: 'The highest registered destination domain, stripped of the subdomain.
 
-      For example, the registered domain for "foo.google.com" is "google.com".
+      For example, the registered domain for "foo.example.com" is "example.com".
 
       This value can be determined precisely with a list like the public suffix list
       (http://publicsuffix.org). Trying to approximate this by simply taking the last
       two labels will not work well for TLDs such as "co.uk".'
-    example: google.com
+    example: example.com
   - name: top_level_domain
     level: extended
     type: keyword
     ignore_above: 1024
     description: 'The effective top level domain (eTLD), also known as the domain
       suffix, is the last part of the domain name. For example, the top level domain
-      for google.com is "com".
+      for example.com is "com".
 
       This value can be determined precisely with a list like the public suffix list
       (http://publicsuffix.org). Trying to approximate this by simply taking the last
@@ -243,19 +241,19 @@
       those characters should be represented as escaped base 10 integers (\DDD). Back
       slashes and quotes should be escaped. Tabs, carriage returns, and line feeds
       should be converted to \t, \r, and \n respectively.'
-    example: www.google.com
+    example: www.example.com
   - name: question.registered_domain
     level: extended
     type: keyword
     ignore_above: 1024
     description: 'The highest registered domain, stripped of the subdomain.
 
-      For example, the registered domain for "foo.google.com" is "google.com".
+      For example, the registered domain for "foo.example.com" is "example.com".
 
       This value can be determined precisely with a list like the public suffix list
       (http://publicsuffix.org). Trying to approximate this by simply taking the last
       two labels will not work well for TLDs such as "co.uk".'
-    example: google.com
+    example: example.com
   - name: question.subdomain
     level: extended
     type: keyword
@@ -271,7 +269,7 @@
     ignore_above: 1024
     description: 'The effective top level domain (eTLD), also known as the domain
       suffix, is the last part of the domain name. For example, the top level domain
-      for google.com is "com".
+      for example.com is "com".
 
       This value can be determined precisely with a list like the public suffix list
       (http://publicsuffix.org). Trying to approximate this by simply taking the last
@@ -908,9 +906,7 @@
   - name: ip
     level: core
     type: ip
-    description: 'IP address of the source.
-
-      Can be one or multiple IPv4 or IPv6 addresses.'
+    description: IP address of the source (IPv4 or IPv6).
   - name: packets
     level: core
     type: long
@@ -927,19 +923,19 @@
     ignore_above: 1024
     description: 'The highest registered source domain, stripped of the subdomain.
 
-      For example, the registered domain for "foo.google.com" is "google.com".
+      For example, the registered domain for "foo.example.com" is "example.com".
 
       This value can be determined precisely with a list like the public suffix list
       (http://publicsuffix.org). Trying to approximate this by simply taking the last
       two labels will not work well for TLDs such as "co.uk".'
-    example: google.com
+    example: example.com
   - name: top_level_domain
     level: extended
     type: keyword
     ignore_above: 1024
     description: 'The effective top level domain (eTLD), also known as the domain
       suffix, is the last part of the domain name. For example, the top level domain
-      for google.com is "com".
+      for example.com is "com".
 
       This value can be determined precisely with a list like the public suffix list
       (http://publicsuffix.org). Trying to approximate this by simply taking the last
@@ -988,7 +984,7 @@
     level: core
     type: keyword
     ignore_above: 1024
-    description: Unique identifiers of the user.
+    description: Unique identifier of the user.
   - name: name
     level: core
     type: keyword

--- a/package/endpoint/dataset/policy/fields/fields.yml
+++ b/package/endpoint/dataset/policy/fields/fields.yml
@@ -265,7 +265,7 @@
     ignore_above: 1024
     description: 'Type of the agent.
 
-      The agent type stays always the same and should be given by the agent used.
+      The agent type always stays the same and should be given by the agent used.
       In case of Filebeat the agent would always be Filebeat also if two Filebeat
       instances are run on the same machine.'
     example: filebeat

--- a/package/endpoint/dataset/process/fields/fields.yml
+++ b/package/endpoint/dataset/process/fields/fields.yml
@@ -53,7 +53,7 @@
     ignore_above: 1024
     description: 'Type of the agent.
 
-      The agent type stays always the same and should be given by the agent used.
+      The agent type always stays the same and should be given by the agent used.
       In case of Filebeat the agent would always be Filebeat also if two Filebeat
       instances are run on the same machine.'
     example: filebeat
@@ -566,11 +566,6 @@
 
       Sometimes called program name or similar.'
     example: ssh
-  - name: parent
-    level: custom
-    type: object
-    description: Extended "process.parent" field set.
-    default_field: false
   - name: parent.Ext
     level: custom
     type: object
@@ -696,7 +691,7 @@
     level: core
     type: keyword
     ignore_above: 1024
-    description: Unique identifiers of the user.
+    description: Unique identifier of the user.
   - name: name
     level: core
     type: keyword

--- a/package/endpoint/dataset/process/fields/fields.yml
+++ b/package/endpoint/dataset/process/fields/fields.yml
@@ -574,14 +574,14 @@
   - name: parent.Ext.real
     level: custom
     type: object
-    description: The field set containing parent process info in case of any ppid
-      spoofing.
+    description: The field set containing process info in case of any pid spoofing.
+      This is mainly useful for process.parent.
     default_field: false
   - name: parent.Ext.real.pid
     level: custom
     type: long
-    description: The ppid of the process that actually spawned the current process,
-      in case of ppid spoofing.
+    description: For process.parent this will be the ppid of the process that actually
+      spawned the current process.
     default_field: false
   - name: parent.entity_id
     level: extended

--- a/package/endpoint/dataset/registry/fields/fields.yml
+++ b/package/endpoint/dataset/registry/fields/fields.yml
@@ -53,7 +53,7 @@
     ignore_above: 1024
     description: 'Type of the agent.
 
-      The agent type stays always the same and should be given by the agent used.
+      The agent type always stays the same and should be given by the agent used.
       In case of Filebeat the agent would always be Filebeat also if two Filebeat
       instances are run on the same machine.'
     example: filebeat
@@ -561,7 +561,7 @@
     level: core
     type: keyword
     ignore_above: 1024
-    description: Unique identifiers of the user.
+    description: Unique identifier of the user.
   - name: name
     level: core
     type: keyword

--- a/package/endpoint/dataset/security/fields/fields.yml
+++ b/package/endpoint/dataset/security/fields/fields.yml
@@ -53,7 +53,7 @@
     ignore_above: 1024
     description: 'Type of the agent.
 
-      The agent type stays always the same and should be given by the agent used.
+      The agent type always stays the same and should be given by the agent used.
       In case of Filebeat the agent would always be Filebeat also if two Filebeat
       instances are run on the same machine.'
     example: filebeat
@@ -502,7 +502,7 @@
     level: core
     type: keyword
     ignore_above: 1024
-    description: Unique identifiers of the user.
+    description: Unique identifier of the user.
   - name: name
     level: core
     type: keyword

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -92,7 +92,6 @@ sent by the endpoint.
 | Target.process.hash.sha256 | SHA256 hash. | keyword |
 | Target.process.hash.sha512 | SHA512 hash. | keyword |
 | Target.process.name | Process name. Sometimes called program name or similar. | keyword |
-| Target.process.parent | Extended "process.parent" field set. | object |
 | Target.process.parent.Ext | Object for all custom defined fields to live in. | object |
 | Target.process.parent.Ext.code_signature | Nested version of ECS code_signature fieldset. | nested |
 | Target.process.parent.Ext.code_signature.exists | Boolean to capture if a signature is present. | boolean |
@@ -102,7 +101,7 @@ sent by the endpoint.
 | Target.process.parent.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | Target.process.parent.Ext.real | The field set containing parent process info in case of any ppid spoofing. | object |
 | Target.process.parent.Ext.real.pid | The ppid of the process that actually spawned the current process, in case of ppid spoofing. | long |
-| Target.process.parent.args | Array of process arguments. May be filtered to protect sensitive information. | keyword |
+| Target.process.parent.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | Target.process.parent.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
 | Target.process.parent.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | keyword |
 | Target.process.parent.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |
@@ -159,7 +158,7 @@ sent by the endpoint.
 | agent.ephemeral_id | Ephemeral identifier of this agent (if one exists). This id normally changes across restarts, but `agent.id` does not. | keyword |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
 | agent.name | Custom name of the agent. This is a name that can be given to an agent. This can be helpful if for example two Filebeat instances are running on the same host but a human readable separation is needed on which Filebeat instance data is coming from. If no name is given, the name is often left empty. | keyword |
-| agent.type | Type of the agent. The agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
+| agent.type | Type of the agent. The agent type always stays the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
 | agent.version | Version of the agent. | keyword |
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
@@ -334,7 +333,7 @@ sent by the endpoint.
 | host.user.group.id | Unique identifier for the group on the system/platform. | keyword |
 | host.user.group.name | Name of the group. | keyword |
 | host.user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
-| host.user.id | Unique identifiers of the user. | keyword |
+| host.user.id | Unique identifier of the user. | keyword |
 | host.user.name | Short name or login of the user. | keyword |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 | process.Ext | Object for all custom defined fields to live in. | object |
@@ -379,7 +378,6 @@ sent by the endpoint.
 | process.hash.sha256 | SHA256 hash. | keyword |
 | process.hash.sha512 | SHA512 hash. | keyword |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
-| process.parent | Extended "process.parent" field set. | object |
 | process.parent.Ext | Object for all custom defined fields to live in. | object |
 | process.parent.Ext.code_signature | Nested version of ECS code_signature fieldset. | nested |
 | process.parent.Ext.code_signature.exists | Boolean to capture if a signature is present. | boolean |
@@ -389,7 +387,7 @@ sent by the endpoint.
 | process.parent.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.parent.Ext.real | The field set containing parent process info in case of any ppid spoofing. | object |
 | process.parent.Ext.real.pid | The ppid of the process that actually spawned the current process, in case of ppid spoofing. | long |
-| process.parent.args | Array of process arguments. May be filtered to protect sensitive information. | keyword |
+| process.parent.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.parent.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
 | process.parent.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | keyword |
 | process.parent.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |
@@ -454,12 +452,12 @@ sent by the endpoint.
 | rule.uuid | A rule ID that is unique within the scope of a set or group of agents, observers, or other entities using the rule for detection of this event. | keyword |
 | rule.version | The version / revision of the rule being used for analysis. | keyword |
 | threat.framework | Name of the threat framework used to further categorize and classify the tactic and technique of the reported threat. Framework classification can be provided by detecting systems, evaluated at ingest time, or retrospectively tagged to events. | keyword |
-| threat.tactic.id | The id of tactic used by this threat. You can use the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/ ) | keyword |
-| threat.tactic.name | Name of the type of tactic used by this threat. You can use the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/ ) | keyword |
-| threat.tactic.reference | The reference url of tactic used by this threat. You can use the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/ ) | keyword |
-| threat.technique.id | The id of technique used by this tactic. You can use the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/ ) | keyword |
-| threat.technique.name | The name of technique used by this tactic. You can use the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/ ) | keyword |
-| threat.technique.reference | The reference url of technique used by this tactic. You can use the Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/ ) | keyword |
+| threat.tactic.id | The id of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ ) | keyword |
+| threat.tactic.name | Name of the type of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/) | keyword |
+| threat.tactic.reference | The reference url of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ ) | keyword |
+| threat.technique.id | The id of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1499/) | keyword |
+| threat.technique.name | The name of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1499/) | keyword |
+| threat.technique.reference | The reference url of technique used by this threat. You can use a MITRE ATT&CK® technique, for example. (ex. https://attack.mitre.org/techniques/T1499/ ) | keyword |
 | user.Ext | Object for all custom defined fields to live in. | object |
 | user.Ext.real | User info prior to any setuid operations. | object |
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
@@ -475,7 +473,7 @@ sent by the endpoint.
 | user.group.id | Unique identifier for the group on the system/platform. | keyword |
 | user.group.name | Name of the group. | keyword |
 | user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
-| user.id | Unique identifiers of the user. | keyword |
+| user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 
 
@@ -487,7 +485,7 @@ sent by the endpoint.
 |---|---|---|
 | @timestamp | Date/time when the event originated. This is the date/time extracted from the event, typically representing when the event was generated by the source. If the event source has no original timestamp, this value is typically populated by the first time the event was received by the pipeline. Required field for all events. | date |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
-| agent.type | Type of the agent. The agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
+| agent.type | Type of the agent. The agent type always stays the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
 | agent.version | Version of the agent. | keyword |
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
@@ -562,7 +560,7 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| user.id | Unique identifiers of the user. | keyword |
+| user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 
 
@@ -574,7 +572,7 @@ sent by the endpoint.
 |---|---|---|
 | @timestamp | Date/time when the event originated. This is the date/time extracted from the event, typically representing when the event was generated by the source. If the event source has no original timestamp, this value is typically populated by the first time the event was received by the pipeline. Required field for all events. | date |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
-| agent.type | Type of the agent. The agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
+| agent.type | Type of the agent. The agent type always stays the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
 | agent.version | Version of the agent. | keyword |
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
@@ -642,7 +640,7 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| user.id | Unique identifiers of the user. | keyword |
+| user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 
 
@@ -654,7 +652,7 @@ sent by the endpoint.
 |---|---|---|
 | @timestamp | Date/time when the event originated. This is the date/time extracted from the event, typically representing when the event was generated by the source. If the event source has no original timestamp, this value is typically populated by the first time the event was received by the pipeline. Required field for all events. | date |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
-| agent.type | Type of the agent. The agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
+| agent.type | Type of the agent. The agent type always stays the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
 | agent.version | Version of the agent. | keyword |
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
@@ -670,18 +668,18 @@ sent by the endpoint.
 | destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | destination.geo.region_iso_code | Region ISO code. | keyword |
 | destination.geo.region_name | Region name. | keyword |
-| destination.ip | IP address of the destination. Can be one or multiple IPv4 or IPv6 addresses. | ip |
+| destination.ip | IP address of the destination (IPv4 or IPv6). | ip |
 | destination.packets | Packets sent from the destination to the source. | long |
 | destination.port | Port of the destination. | long |
-| destination.registered_domain | The highest registered destination domain, stripped of the subdomain. For example, the registered domain for "foo.google.com" is "google.com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk". | keyword |
-| destination.top_level_domain | The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for google.com is "com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk". | keyword |
+| destination.registered_domain | The highest registered destination domain, stripped of the subdomain. For example, the registered domain for "foo.example.com" is "example.com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk". | keyword |
+| destination.top_level_domain | The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk". | keyword |
 | dns.Ext | Object for all custom defined fields to live in. | object |
 | dns.Ext.options | DNS options field, uint64, representing as a keyword to avoid overflows in ES | keyword |
 | dns.Ext.status | DNS status field, uint32 | long |
 | dns.question.name | The name being queried. If the name field contains non-printable characters (below 32 or above 126), those characters should be represented as escaped base 10 integers (\DDD). Back slashes and quotes should be escaped. Tabs, carriage returns, and line feeds should be converted to \t, \r, and \n respectively. | keyword |
-| dns.question.registered_domain | The highest registered domain, stripped of the subdomain. For example, the registered domain for "foo.google.com" is "google.com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk". | keyword |
+| dns.question.registered_domain | The highest registered domain, stripped of the subdomain. For example, the registered domain for "foo.example.com" is "example.com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk". | keyword |
 | dns.question.subdomain | The subdomain is all of the labels under the registered_domain. If the domain has multiple levels of subdomain, such as "sub2.sub1.example.com", the subdomain field should contain "sub2.sub1", with no trailing period. | keyword |
-| dns.question.top_level_domain | The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for google.com is "com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk". | keyword |
+| dns.question.top_level_domain | The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk". | keyword |
 | dns.question.type | The type of record being queried. | keyword |
 | dns.resolved_ip | Array containing all IPs seen in `answers.data`. The `answers` array can be difficult to use, because of the variety of data formats it can contain. Extracting all IP addresses seen in there to `dns.resolved_ip` makes it possible to index them as IP addresses, and makes them easier to visualize and query for. | ip |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
@@ -751,17 +749,17 @@ sent by the endpoint.
 | source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
 | source.geo.region_iso_code | Region ISO code. | keyword |
 | source.geo.region_name | Region name. | keyword |
-| source.ip | IP address of the source. Can be one or multiple IPv4 or IPv6 addresses. | ip |
+| source.ip | IP address of the source (IPv4 or IPv6). | ip |
 | source.packets | Packets sent from the source to the destination. | long |
 | source.port | Port of the source. | long |
-| source.registered_domain | The highest registered source domain, stripped of the subdomain. For example, the registered domain for "foo.google.com" is "google.com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk". | keyword |
-| source.top_level_domain | The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for google.com is "com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk". | keyword |
+| source.registered_domain | The highest registered source domain, stripped of the subdomain. For example, the registered domain for "foo.example.com" is "example.com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last two labels will not work well for TLDs such as "co.uk". | keyword |
+| source.top_level_domain | The effective top level domain (eTLD), also known as the domain suffix, is the last part of the domain name. For example, the top level domain for example.com is "com". This value can be determined precisely with a list like the public suffix list (http://publicsuffix.org). Trying to approximate this by simply taking the last label will not work well for effective TLDs such as "co.uk". | keyword |
 | user.Ext | Object for all custom defined fields to live in. | object |
 | user.Ext.real | User info prior to any setuid operations. | object |
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| user.id | Unique identifiers of the user. | keyword |
+| user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 
 
@@ -773,7 +771,7 @@ sent by the endpoint.
 |---|---|---|
 | @timestamp | Date/time when the event originated. This is the date/time extracted from the event, typically representing when the event was generated by the source. If the event source has no original timestamp, this value is typically populated by the first time the event was received by the pipeline. Required field for all events. | date |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
-| agent.type | Type of the agent. The agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
+| agent.type | Type of the agent. The agent type always stays the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
 | agent.version | Version of the agent. | keyword |
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
@@ -830,7 +828,6 @@ sent by the endpoint.
 | process.hash.sha1 | SHA1 hash. | keyword |
 | process.hash.sha256 | SHA256 hash. | keyword |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
-| process.parent | Extended "process.parent" field set. | object |
 | process.parent.Ext | Object for all custom defined fields to live in. | object |
 | process.parent.Ext.real | The field set containing parent process info in case of any ppid spoofing. | object |
 | process.parent.Ext.real.pid | The ppid of the process that actually spawned the current process, in case of ppid spoofing. | long |
@@ -846,7 +843,7 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| user.id | Unique identifiers of the user. | keyword |
+| user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 
 
@@ -858,7 +855,7 @@ sent by the endpoint.
 |---|---|---|
 | @timestamp | Date/time when the event originated. This is the date/time extracted from the event, typically representing when the event was generated by the source. If the event source has no original timestamp, this value is typically populated by the first time the event was received by the pipeline. Required field for all events. | date |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
-| agent.type | Type of the agent. The agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
+| agent.type | Type of the agent. The agent type always stays the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
 | agent.version | Version of the agent. | keyword |
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
@@ -913,7 +910,7 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| user.id | Unique identifiers of the user. | keyword |
+| user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 
 
@@ -925,7 +922,7 @@ sent by the endpoint.
 |---|---|---|
 | @timestamp | Date/time when the event originated. This is the date/time extracted from the event, typically representing when the event was generated by the source. If the event source has no original timestamp, this value is typically populated by the first time the event was received by the pipeline. Required field for all events. | date |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
-| agent.type | Type of the agent. The agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
+| agent.type | Type of the agent. The agent type always stays the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
 | agent.version | Version of the agent. | keyword |
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
@@ -974,7 +971,7 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| user.id | Unique identifiers of the user. | keyword |
+| user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 
 
@@ -998,7 +995,7 @@ sent by the endpoint.
 | Endpoint.status | The current status of the endpoint e.g. enrolled, unenrolled. | keyword |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
 | agent.name | Custom name of the agent. This is a name that can be given to an agent. This can be helpful if for example two Filebeat instances are running on the same host but a human readable separation is needed on which Filebeat instance data is coming from. If no name is given, the name is often left empty. | keyword |
-| agent.type | Type of the agent. The agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
+| agent.type | Type of the agent. The agent type always stays the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
 | agent.version | Version of the agent. | keyword |
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
@@ -1056,7 +1053,7 @@ Metrics documents contain performance information about the endpoint executable 
 | Endpoint.metrics.uptime.endpoint | Number of seconds since the endpoint was started | long |
 | Endpoint.metrics.uptime.system | Number of seconds since the system was started | long |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
-| agent.type | Type of the agent. The agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
+| agent.type | Type of the agent. The agent type always stays the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
 | agent.version | Version of the agent. | keyword |
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
@@ -1105,7 +1102,7 @@ Metrics documents contain performance information about the endpoint executable 
 | Endpoint.policy.applied.status | the status of the applied policy | keyword |
 | Endpoint.policy.applied.version | the version of this applied policy | keyword |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
-| agent.type | Type of the agent. The agent type stays always the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
+| agent.type | Type of the agent. The agent type always stays the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |
 | agent.version | Version of the agent. | keyword |
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -99,8 +99,8 @@ sent by the endpoint.
 | Target.process.parent.Ext.code_signature.subject_name | Subject name of the code signer | keyword |
 | Target.process.parent.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | Target.process.parent.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
-| Target.process.parent.Ext.real | The field set containing parent process info in case of any ppid spoofing. | object |
-| Target.process.parent.Ext.real.pid | The ppid of the process that actually spawned the current process, in case of ppid spoofing. | long |
+| Target.process.parent.Ext.real | The field set containing process info in case of any pid spoofing. This is mainly useful for process.parent. | object |
+| Target.process.parent.Ext.real.pid | For process.parent this will be the ppid of the process that actually spawned the current process. | long |
 | Target.process.parent.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | Target.process.parent.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
 | Target.process.parent.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | keyword |
@@ -385,8 +385,8 @@ sent by the endpoint.
 | process.parent.Ext.code_signature.subject_name | Subject name of the code signer | keyword |
 | process.parent.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | process.parent.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
-| process.parent.Ext.real | The field set containing parent process info in case of any ppid spoofing. | object |
-| process.parent.Ext.real.pid | The ppid of the process that actually spawned the current process, in case of ppid spoofing. | long |
+| process.parent.Ext.real | The field set containing process info in case of any pid spoofing. This is mainly useful for process.parent. | object |
+| process.parent.Ext.real.pid | For process.parent this will be the ppid of the process that actually spawned the current process. | long |
 | process.parent.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.parent.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
 | process.parent.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | keyword |
@@ -829,8 +829,8 @@ sent by the endpoint.
 | process.hash.sha256 | SHA256 hash. | keyword |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
 | process.parent.Ext | Object for all custom defined fields to live in. | object |
-| process.parent.Ext.real | The field set containing parent process info in case of any ppid spoofing. | object |
-| process.parent.Ext.real.pid | The ppid of the process that actually spawned the current process, in case of ppid spoofing. | long |
+| process.parent.Ext.real | The field set containing process info in case of any pid spoofing. This is mainly useful for process.parent. | object |
+| process.parent.Ext.real.pid | For process.parent this will be the ppid of the process that actually spawned the current process. | long |
 | process.parent.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |
 | process.parent.executable | Absolute path to the process executable. | keyword |
 | process.parent.name | Process name. Sometimes called program name or similar. | keyword |

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -1091,22 +1091,12 @@ Target.process.name:
   original_fieldset: process
   short: Process name.
   type: keyword
-Target.process.parent:
-  dashed_name: Target-process-parent
-  description: Extended "process.parent" field set.
-  flat_name: Target.process.parent
-  level: custom
-  name: parent
-  normalize: []
-  original_fieldset: process
-  short: Extended "process.parent" field set.
-  type: object
 Target.process.parent.Ext:
   dashed_name: Target-process-parent-Ext
   description: Object for all custom defined fields to live in.
   flat_name: Target.process.parent.Ext
   level: custom
-  name: parent.Ext
+  name: Ext
   normalize: []
   original_fieldset: process
   short: Object for all custom defined fields to live in.
@@ -1116,7 +1106,7 @@ Target.process.parent.Ext.code_signature:
   description: Nested version of ECS code_signature fieldset.
   flat_name: Target.process.parent.Ext.code_signature
   level: custom
-  name: parent.Ext.code_signature
+  name: Ext.code_signature
   normalize: []
   original_fieldset: process
   short: Nested version of ECS code_signature fieldset.
@@ -1127,7 +1117,7 @@ Target.process.parent.Ext.code_signature.exists:
   example: 'true'
   flat_name: Target.process.parent.Ext.code_signature.exists
   level: custom
-  name: parent.Ext.code_signature.exists
+  name: Ext.code_signature.exists
   normalize: []
   original_fieldset: process
   short: Boolean to capture if a signature is present.
@@ -1143,7 +1133,7 @@ Target.process.parent.Ext.code_signature.status:
   flat_name: Target.process.parent.Ext.code_signature.status
   ignore_above: 1024
   level: custom
-  name: parent.Ext.code_signature.status
+  name: Ext.code_signature.status
   normalize: []
   original_fieldset: process
   short: Additional information about the certificate status.
@@ -1155,7 +1145,7 @@ Target.process.parent.Ext.code_signature.subject_name:
   flat_name: Target.process.parent.Ext.code_signature.subject_name
   ignore_above: 1024
   level: custom
-  name: parent.Ext.code_signature.subject_name
+  name: Ext.code_signature.subject_name
   normalize: []
   original_fieldset: process
   short: Subject name of the code signer
@@ -1169,7 +1159,7 @@ Target.process.parent.Ext.code_signature.trusted:
   example: 'true'
   flat_name: Target.process.parent.Ext.code_signature.trusted
   level: custom
-  name: parent.Ext.code_signature.trusted
+  name: Ext.code_signature.trusted
   normalize: []
   original_fieldset: process
   short: Stores the trust status of the certificate chain.
@@ -1183,7 +1173,7 @@ Target.process.parent.Ext.code_signature.valid:
   example: 'true'
   flat_name: Target.process.parent.Ext.code_signature.valid
   level: custom
-  name: parent.Ext.code_signature.valid
+  name: Ext.code_signature.valid
   normalize: []
   original_fieldset: process
   short: Boolean to capture if the digital signature is verified against the binary
@@ -1194,7 +1184,7 @@ Target.process.parent.Ext.real:
   description: The field set containing parent process info in case of any ppid spoofing.
   flat_name: Target.process.parent.Ext.real
   level: custom
-  name: parent.Ext.real
+  name: Ext.real
   normalize: []
   original_fieldset: process
   short: The field set containing parent process info in case of any ppid spoofing.
@@ -1205,7 +1195,7 @@ Target.process.parent.Ext.real.pid:
     in case of ppid spoofing.
   flat_name: Target.process.parent.Ext.real.pid
   level: custom
-  name: parent.Ext.real.pid
+  name: Ext.real.pid
   normalize: []
   original_fieldset: process
   short: The ppid of the process that actually spawned the current process, in case
@@ -1213,18 +1203,19 @@ Target.process.parent.Ext.real.pid:
   type: long
 Target.process.parent.args:
   dashed_name: Target-process-parent-args
-  description: 'Array of process arguments.
+  description: 'Array of process arguments, starting with the absolute path to the
+    executable.
 
     May be filtered to protect sensitive information.'
   example:
-  - ssh
+  - /usr/bin/ssh
   - -l
   - user
   - 10.0.0.16
   flat_name: Target.process.parent.args
   ignore_above: 1024
   level: extended
-  name: parent.args
+  name: args
   normalize:
   - array
   original_fieldset: process
@@ -1240,7 +1231,7 @@ Target.process.parent.args_count:
   example: 4
   flat_name: Target.process.parent.args_count
   level: extended
-  name: parent.args_count
+  name: args_count
   normalize: []
   original_fieldset: process
   short: Length of the process.args array.
@@ -1260,7 +1251,7 @@ Target.process.parent.command_line:
     name: text
     norms: false
     type: text
-  name: parent.command_line
+  name: command_line
   normalize: []
   original_fieldset: process
   short: Full command line that started the process.
@@ -1280,7 +1271,7 @@ Target.process.parent.entity_id:
   flat_name: Target.process.parent.entity_id
   ignore_above: 1024
   level: extended
-  name: parent.entity_id
+  name: entity_id
   normalize: []
   original_fieldset: process
   short: Unique identifier for the process.
@@ -1297,7 +1288,7 @@ Target.process.parent.executable:
     name: text
     norms: false
     type: text
-  name: parent.executable
+  name: executable
   normalize: []
   original_fieldset: process
   short: Absolute path to the process executable.
@@ -1311,7 +1302,7 @@ Target.process.parent.exit_code:
   example: 137
   flat_name: Target.process.parent.exit_code
   level: extended
-  name: parent.exit_code
+  name: exit_code
   normalize: []
   original_fieldset: process
   short: The exit code of the process.
@@ -1374,7 +1365,7 @@ Target.process.parent.name:
     name: text
     norms: false
     type: text
-  name: parent.name
+  name: name
   normalize: []
   original_fieldset: process
   short: Process name.
@@ -1385,7 +1376,7 @@ Target.process.parent.pgid:
   flat_name: Target.process.parent.pgid
   format: string
   level: extended
-  name: parent.pgid
+  name: pgid
   normalize: []
   original_fieldset: process
   short: Identifier of the group of processes the process belongs to.
@@ -1397,7 +1388,7 @@ Target.process.parent.pid:
   flat_name: Target.process.parent.pid
   format: string
   level: core
-  name: parent.pid
+  name: pid
   normalize: []
   original_fieldset: process
   short: Process id.
@@ -1409,7 +1400,7 @@ Target.process.parent.ppid:
   flat_name: Target.process.parent.ppid
   format: string
   level: extended
-  name: parent.ppid
+  name: ppid
   normalize: []
   original_fieldset: process
   short: Parent process' pid.
@@ -1420,7 +1411,7 @@ Target.process.parent.start:
   example: '2016-05-23T08:05:34.853Z'
   flat_name: Target.process.parent.start
   level: extended
-  name: parent.start
+  name: start
   normalize: []
   original_fieldset: process
   short: The time the process started.
@@ -1432,7 +1423,7 @@ Target.process.parent.thread.id:
   flat_name: Target.process.parent.thread.id
   format: string
   level: extended
-  name: parent.thread.id
+  name: thread.id
   normalize: []
   original_fieldset: process
   short: Thread ID.
@@ -1444,7 +1435,7 @@ Target.process.parent.thread.name:
   flat_name: Target.process.parent.thread.name
   ignore_above: 1024
   level: extended
-  name: parent.thread.name
+  name: thread.name
   normalize: []
   original_fieldset: process
   short: Thread name.
@@ -1463,7 +1454,7 @@ Target.process.parent.title:
     name: text
     norms: false
     type: text
-  name: parent.title
+  name: title
   normalize: []
   original_fieldset: process
   short: Process title.
@@ -1474,7 +1465,7 @@ Target.process.parent.uptime:
   example: 1325
   flat_name: Target.process.parent.uptime
   level: extended
-  name: parent.uptime
+  name: uptime
   normalize: []
   original_fieldset: process
   short: Seconds the process has been up.
@@ -1491,7 +1482,7 @@ Target.process.parent.working_directory:
     name: text
     norms: false
     type: text
-  name: parent.working_directory
+  name: working_directory
   normalize: []
   original_fieldset: process
   short: The working directory of the process.
@@ -1645,8 +1636,7 @@ Target.process.thread.Ext.call_stack.memory_section.address:
   name: memory_section.address
   normalize: []
   original_fieldset: call_stack
-  short: Base address of the memory region containing `instruction_pointer`.  Corresponds
-    to `MEMORY_BASIC_INFORMATION.BaseAddress`
+  short: Base address of the memory region containing `instruction_pointer`.
   type: keyword
 Target.process.thread.Ext.call_stack.memory_section.protection:
   dashed_name: Target-process-thread-Ext-call-stack-memory-section-protection
@@ -1693,8 +1683,7 @@ Target.process.thread.Ext.call_stack.rva:
   name: rva
   normalize: []
   original_fieldset: call_stack
-  short: The relative virtual address of `instruction_pointer`.  Computed as `instruction_pointer
-    - MEMORY_BASIC_INFORMATION.AllocationBase`.
+  short: The relative virtual address of `instruction_pointer`.
   type: keyword
 Target.process.thread.Ext.call_stack.symbol_info:
   dashed_name: Target-process-thread-Ext-call-stack-symbol-info
@@ -2033,7 +2022,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -2443,8 +2432,7 @@ elastic.agent:
   level: custom
   name: agent
   normalize: []
-  short: The agent fields contain data about the Elastic Agent. The Elastic Agent
-    is the management agent that manages other agents or process on the host.
+  short: The agent fields contain data about the Elastic Agent.
   type: object
 elastic.agent.id:
   dashed_name: elastic-agent-id
@@ -3134,7 +3122,7 @@ file.Ext.macro.code_page:
   name: code_page
   normalize: []
   original_fieldset: macro
-  short: Identifies the character encoding used for this macro.  https://docs.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
+  short: Identifies the character encoding used for this macro.
   type: long
 file.Ext.macro.collection:
   dashed_name: file-Ext-macro-collection
@@ -4242,8 +4230,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -4527,14 +4514,14 @@ host.user.hash:
   type: keyword
 host.user.id:
   dashed_name: host-user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: host.user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
   original_fieldset: user
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 host.user.name:
   dashed_name: host-user-name
@@ -5113,22 +5100,14 @@ process.name:
   normalize: []
   short: Process name.
   type: keyword
-process.parent:
-  dashed_name: process-parent
-  description: Extended "process.parent" field set.
-  flat_name: process.parent
-  level: custom
-  name: parent
-  normalize: []
-  short: Extended "process.parent" field set.
-  type: object
 process.parent.Ext:
   dashed_name: process-parent-Ext
   description: Object for all custom defined fields to live in.
   flat_name: process.parent.Ext
   level: custom
-  name: parent.Ext
+  name: Ext
   normalize: []
+  original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
 process.parent.Ext.code_signature:
@@ -5136,8 +5115,9 @@ process.parent.Ext.code_signature:
   description: Nested version of ECS code_signature fieldset.
   flat_name: process.parent.Ext.code_signature
   level: custom
-  name: parent.Ext.code_signature
+  name: Ext.code_signature
   normalize: []
+  original_fieldset: process
   short: Nested version of ECS code_signature fieldset.
   type: nested
 process.parent.Ext.code_signature.exists:
@@ -5146,8 +5126,9 @@ process.parent.Ext.code_signature.exists:
   example: 'true'
   flat_name: process.parent.Ext.code_signature.exists
   level: custom
-  name: parent.Ext.code_signature.exists
+  name: Ext.code_signature.exists
   normalize: []
+  original_fieldset: process
   short: Boolean to capture if a signature is present.
   type: boolean
 process.parent.Ext.code_signature.status:
@@ -5161,8 +5142,9 @@ process.parent.Ext.code_signature.status:
   flat_name: process.parent.Ext.code_signature.status
   ignore_above: 1024
   level: custom
-  name: parent.Ext.code_signature.status
+  name: Ext.code_signature.status
   normalize: []
+  original_fieldset: process
   short: Additional information about the certificate status.
   type: keyword
 process.parent.Ext.code_signature.subject_name:
@@ -5172,8 +5154,9 @@ process.parent.Ext.code_signature.subject_name:
   flat_name: process.parent.Ext.code_signature.subject_name
   ignore_above: 1024
   level: custom
-  name: parent.Ext.code_signature.subject_name
+  name: Ext.code_signature.subject_name
   normalize: []
+  original_fieldset: process
   short: Subject name of the code signer
   type: keyword
 process.parent.Ext.code_signature.trusted:
@@ -5185,8 +5168,9 @@ process.parent.Ext.code_signature.trusted:
   example: 'true'
   flat_name: process.parent.Ext.code_signature.trusted
   level: custom
-  name: parent.Ext.code_signature.trusted
+  name: Ext.code_signature.trusted
   normalize: []
+  original_fieldset: process
   short: Stores the trust status of the certificate chain.
   type: boolean
 process.parent.Ext.code_signature.valid:
@@ -5198,8 +5182,9 @@ process.parent.Ext.code_signature.valid:
   example: 'true'
   flat_name: process.parent.Ext.code_signature.valid
   level: custom
-  name: parent.Ext.code_signature.valid
+  name: Ext.code_signature.valid
   normalize: []
+  original_fieldset: process
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
@@ -5208,8 +5193,9 @@ process.parent.Ext.real:
   description: The field set containing parent process info in case of any ppid spoofing.
   flat_name: process.parent.Ext.real
   level: custom
-  name: parent.Ext.real
+  name: Ext.real
   normalize: []
+  original_fieldset: process
   short: The field set containing parent process info in case of any ppid spoofing.
   type: object
 process.parent.Ext.real.pid:
@@ -5218,27 +5204,30 @@ process.parent.Ext.real.pid:
     in case of ppid spoofing.
   flat_name: process.parent.Ext.real.pid
   level: custom
-  name: parent.Ext.real.pid
+  name: Ext.real.pid
   normalize: []
+  original_fieldset: process
   short: The ppid of the process that actually spawned the current process, in case
     of ppid spoofing.
   type: long
 process.parent.args:
   dashed_name: process-parent-args
-  description: 'Array of process arguments.
+  description: 'Array of process arguments, starting with the absolute path to the
+    executable.
 
     May be filtered to protect sensitive information.'
   example:
-  - ssh
+  - /usr/bin/ssh
   - -l
   - user
   - 10.0.0.16
   flat_name: process.parent.args
   ignore_above: 1024
   level: extended
-  name: parent.args
+  name: args
   normalize:
   - array
+  original_fieldset: process
   short: Array of process arguments.
   type: keyword
 process.parent.args_count:
@@ -5251,8 +5240,9 @@ process.parent.args_count:
   example: 4
   flat_name: process.parent.args_count
   level: extended
-  name: parent.args_count
+  name: args_count
   normalize: []
+  original_fieldset: process
   short: Length of the process.args array.
   type: long
 process.parent.command_line:
@@ -5270,8 +5260,9 @@ process.parent.command_line:
     name: text
     norms: false
     type: text
-  name: parent.command_line
+  name: command_line
   normalize: []
+  original_fieldset: process
   short: Full command line that started the process.
   type: keyword
 process.parent.entity_id:
@@ -5289,8 +5280,9 @@ process.parent.entity_id:
   flat_name: process.parent.entity_id
   ignore_above: 1024
   level: extended
-  name: parent.entity_id
+  name: entity_id
   normalize: []
+  original_fieldset: process
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
@@ -5305,8 +5297,9 @@ process.parent.executable:
     name: text
     norms: false
     type: text
-  name: parent.executable
+  name: executable
   normalize: []
+  original_fieldset: process
   short: Absolute path to the process executable.
   type: keyword
 process.parent.exit_code:
@@ -5318,8 +5311,9 @@ process.parent.exit_code:
   example: 137
   flat_name: process.parent.exit_code
   level: extended
-  name: parent.exit_code
+  name: exit_code
   normalize: []
+  original_fieldset: process
   short: The exit code of the process.
   type: long
 process.parent.hash.md5:
@@ -5380,8 +5374,9 @@ process.parent.name:
     name: text
     norms: false
     type: text
-  name: parent.name
+  name: name
   normalize: []
+  original_fieldset: process
   short: Process name.
   type: keyword
 process.parent.pgid:
@@ -5390,8 +5385,9 @@ process.parent.pgid:
   flat_name: process.parent.pgid
   format: string
   level: extended
-  name: parent.pgid
+  name: pgid
   normalize: []
+  original_fieldset: process
   short: Identifier of the group of processes the process belongs to.
   type: long
 process.parent.pid:
@@ -5401,8 +5397,9 @@ process.parent.pid:
   flat_name: process.parent.pid
   format: string
   level: core
-  name: parent.pid
+  name: pid
   normalize: []
+  original_fieldset: process
   short: Process id.
   type: long
 process.parent.ppid:
@@ -5412,8 +5409,9 @@ process.parent.ppid:
   flat_name: process.parent.ppid
   format: string
   level: extended
-  name: parent.ppid
+  name: ppid
   normalize: []
+  original_fieldset: process
   short: Parent process' pid.
   type: long
 process.parent.start:
@@ -5422,8 +5420,9 @@ process.parent.start:
   example: '2016-05-23T08:05:34.853Z'
   flat_name: process.parent.start
   level: extended
-  name: parent.start
+  name: start
   normalize: []
+  original_fieldset: process
   short: The time the process started.
   type: date
 process.parent.thread.id:
@@ -5433,8 +5432,9 @@ process.parent.thread.id:
   flat_name: process.parent.thread.id
   format: string
   level: extended
-  name: parent.thread.id
+  name: thread.id
   normalize: []
+  original_fieldset: process
   short: Thread ID.
   type: long
 process.parent.thread.name:
@@ -5444,8 +5444,9 @@ process.parent.thread.name:
   flat_name: process.parent.thread.name
   ignore_above: 1024
   level: extended
-  name: parent.thread.name
+  name: thread.name
   normalize: []
+  original_fieldset: process
   short: Thread name.
   type: keyword
 process.parent.title:
@@ -5462,8 +5463,9 @@ process.parent.title:
     name: text
     norms: false
     type: text
-  name: parent.title
+  name: title
   normalize: []
+  original_fieldset: process
   short: Process title.
   type: keyword
 process.parent.uptime:
@@ -5472,8 +5474,9 @@ process.parent.uptime:
   example: 1325
   flat_name: process.parent.uptime
   level: extended
-  name: parent.uptime
+  name: uptime
   normalize: []
+  original_fieldset: process
   short: Seconds the process has been up.
   type: long
 process.parent.working_directory:
@@ -5488,8 +5491,9 @@ process.parent.working_directory:
     name: text
     norms: false
     type: text
-  name: parent.working_directory
+  name: working_directory
   normalize: []
+  original_fieldset: process
   short: The working directory of the process.
   type: keyword
 process.pe.company:
@@ -5636,8 +5640,7 @@ process.thread.Ext.call_stack.memory_section.address:
   name: memory_section.address
   normalize: []
   original_fieldset: call_stack
-  short: Base address of the memory region containing `instruction_pointer`.  Corresponds
-    to `MEMORY_BASIC_INFORMATION.BaseAddress`
+  short: Base address of the memory region containing `instruction_pointer`.
   type: keyword
 process.thread.Ext.call_stack.memory_section.protection:
   dashed_name: process-thread-Ext-call-stack-memory-section-protection
@@ -5684,8 +5687,7 @@ process.thread.Ext.call_stack.rva:
   name: rva
   normalize: []
   original_fieldset: call_stack
-  short: The relative virtual address of `instruction_pointer`.  Computed as `instruction_pointer
-    - MEMORY_BASIC_INFORMATION.AllocationBase`.
+  short: The relative virtual address of `instruction_pointer`.
   type: keyword
 process.thread.Ext.call_stack.symbol_info:
   dashed_name: process-thread-Ext-call-stack-symbol-info
@@ -6106,9 +6108,8 @@ threat.framework:
   type: keyword
 threat.tactic.id:
   dashed_name: threat-tactic-id
-  description: The id of tactic used by this threat. You can use the Mitre ATT&CK
-    Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-    )
+  description: "The id of tactic used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ )"
   example: TA0040
   flat_name: threat.tactic.id
   ignore_above: 1024
@@ -6120,9 +6121,8 @@ threat.tactic.id:
   type: keyword
 threat.tactic.name:
   dashed_name: threat-tactic-name
-  description: Name of the type of tactic used by this threat. You can use the Mitre
-    ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-    )
+  description: "Name of the type of tactic used by this threat. You can use a MITRE\
+    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/)"
   example: impact
   flat_name: threat.tactic.name
   ignore_above: 1024
@@ -6134,9 +6134,9 @@ threat.tactic.name:
   type: keyword
 threat.tactic.reference:
   dashed_name: threat-tactic-reference
-  description: The reference url of tactic used by this threat. You can use the Mitre
-    ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/tactics/TA0040/
-    )
+  description: "The reference url of tactic used by this threat. You can use a MITRE\
+    \ ATT&CK\xAE tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/\
+    \ )"
   example: https://attack.mitre.org/tactics/TA0040/
   flat_name: threat.tactic.reference
   ignore_above: 1024
@@ -6144,13 +6144,12 @@ threat.tactic.reference:
   name: tactic.reference
   normalize:
   - array
-  short: Threat tactic url reference.
+  short: Threat tactic URL reference.
   type: keyword
 threat.technique.id:
   dashed_name: threat-technique-id
-  description: The id of technique used by this tactic. You can use the Mitre ATT&CK
-    Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-    )
+  description: "The id of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
   example: T1499
   flat_name: threat.technique.id
   ignore_above: 1024
@@ -6162,10 +6161,9 @@ threat.technique.id:
   type: keyword
 threat.technique.name:
   dashed_name: threat-technique-name
-  description: The name of technique used by this tactic. You can use the Mitre ATT&CK
-    Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-    )
-  example: endpoint denial of service
+  description: "The name of technique used by this threat. You can use a MITRE ATT&CK\xAE\
+    \ technique, for example. (ex. https://attack.mitre.org/techniques/T1499/)"
+  example: Endpoint Denial of Service
   flat_name: threat.technique.name
   ignore_above: 1024
   level: extended
@@ -6181,9 +6179,9 @@ threat.technique.name:
   type: keyword
 threat.technique.reference:
   dashed_name: threat-technique-reference
-  description: The reference url of technique used by this tactic. You can use the
-    Mitre ATT&CK Matrix Tactic categorization, for example. (ex. https://attack.mitre.org/techniques/T1499/
-    )
+  description: "The reference url of technique used by this threat. You can use a\
+    \ MITRE ATT&CK\xAE technique, for example. (ex. https://attack.mitre.org/techniques/T1499/\
+    \ )"
   example: https://attack.mitre.org/techniques/T1499/
   flat_name: threat.technique.reference
   ignore_above: 1024
@@ -6191,7 +6189,7 @@ threat.technique.reference:
   name: technique.reference
   normalize:
   - array
-  short: Threat technique reference.
+  short: Threat technique URL reference.
   type: keyword
 user.Ext:
   dashed_name: user-Ext
@@ -6362,13 +6360,13 @@ user.hash:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -1181,25 +1181,26 @@ Target.process.parent.Ext.code_signature.valid:
   type: boolean
 Target.process.parent.Ext.real:
   dashed_name: Target-process-parent-Ext-real
-  description: The field set containing parent process info in case of any ppid spoofing.
+  description: The field set containing process info in case of any pid spoofing.
+    This is mainly useful for process.parent.
   flat_name: Target.process.parent.Ext.real
   level: custom
   name: Ext.real
   normalize: []
   original_fieldset: process
-  short: The field set containing parent process info in case of any ppid spoofing.
+  short: The field set containing process info in case of any pid spoofing. This is
+    mainly useful for process.parent.
   type: object
 Target.process.parent.Ext.real.pid:
   dashed_name: Target-process-parent-Ext-real-pid
-  description: The ppid of the process that actually spawned the current process,
-    in case of ppid spoofing.
+  description: For process.parent this will be the ppid of the process that actually
+    spawned the current process.
   flat_name: Target.process.parent.Ext.real.pid
   level: custom
   name: Ext.real.pid
   normalize: []
   original_fieldset: process
-  short: The ppid of the process that actually spawned the current process, in case
-    of ppid spoofing.
+  short: The real pid of the process if ppid spoofing is happening.
   type: long
 Target.process.parent.args:
   dashed_name: Target-process-parent-args
@@ -5190,25 +5191,26 @@ process.parent.Ext.code_signature.valid:
   type: boolean
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
-  description: The field set containing parent process info in case of any ppid spoofing.
+  description: The field set containing process info in case of any pid spoofing.
+    This is mainly useful for process.parent.
   flat_name: process.parent.Ext.real
   level: custom
   name: Ext.real
   normalize: []
   original_fieldset: process
-  short: The field set containing parent process info in case of any ppid spoofing.
+  short: The field set containing process info in case of any pid spoofing. This is
+    mainly useful for process.parent.
   type: object
 process.parent.Ext.real.pid:
   dashed_name: process-parent-Ext-real-pid
-  description: The ppid of the process that actually spawned the current process,
-    in case of ppid spoofing.
+  description: For process.parent this will be the ppid of the process that actually
+    spawned the current process.
   flat_name: process.parent.Ext.real.pid
   level: custom
   name: Ext.real.pid
   normalize: []
   original_fieldset: process
-  short: The ppid of the process that actually spawned the current process, in case
-    of ppid spoofing.
+  short: The real pid of the process if ppid spoofing is happening.
   type: long
 process.parent.args:
   dashed_name: process-parent-args

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -1006,8 +1006,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -1254,13 +1253,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/schemas/v1/file/unquarantine.yaml
+++ b/schemas/v1/file/unquarantine.yaml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -829,8 +829,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -946,8 +946,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -1194,13 +1193,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/schemas/v1/metadata/metadata.yaml
+++ b/schemas/v1/metadata/metadata.yaml
@@ -109,7 +109,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -183,8 +183,7 @@ elastic.agent:
   level: custom
   name: agent
   normalize: []
-  short: The agent fields contain data about the Elastic Agent. The Elastic Agent
-    is the management agent that manages other agents or process on the host.
+  short: The agent fields contain data about the Elastic Agent.
   type: object
 elastic.agent.id:
   dashed_name: elastic-agent-id
@@ -764,8 +763,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -54,10 +54,7 @@ Endpoint.metrics.cpu.endpoint.histogram:
   level: custom
   name: metrics.cpu.endpoint.histogram
   normalize: []
-  short: This field defines an elasticsearch histogram field (https://www.elastic.co/guide/en/elasticsearch/reference/current/histogram.html#histogram)
-    The values field includes 20 buckets (each bucket is 5%) representing the cpu
-    usage The counts field includes 20 buckets of how many times the endpoint's cpu
-    usage fell into each bucket
+  short: CPU histogram
   type: histogram
 Endpoint.metrics.cpu.endpoint.latest:
   dashed_name: Endpoint-metrics-cpu-endpoint-latest
@@ -245,7 +242,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -900,8 +897,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family

--- a/schemas/v1/network/network.yaml
+++ b/schemas/v1/network/network.yaml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -222,9 +222,7 @@ destination.geo.region_name:
   type: keyword
 destination.ip:
   dashed_name: destination-ip
-  description: 'IP address of the destination.
-
-    Can be one or multiple IPv4 or IPv6 addresses.'
+  description: IP address of the destination (IPv4 or IPv6).
   flat_name: destination.ip
   level: core
   name: ip
@@ -255,12 +253,12 @@ destination.registered_domain:
   dashed_name: destination-registered-domain
   description: 'The highest registered destination domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: destination.registered_domain
   ignore_above: 1024
   level: extended
@@ -271,7 +269,7 @@ destination.registered_domain:
 destination.top_level_domain:
   dashed_name: destination-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -323,7 +321,7 @@ dns.question.name:
     characters should be represented as escaped base 10 integers (\DDD). Back slashes
     and quotes should be escaped. Tabs, carriage returns, and line feeds should be
     converted to \t, \r, and \n respectively.'
-  example: www.google.com
+  example: www.example.com
   flat_name: dns.question.name
   ignore_above: 1024
   level: extended
@@ -335,12 +333,12 @@ dns.question.registered_domain:
   dashed_name: dns-question-registered-domain
   description: 'The highest registered domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: dns.question.registered_domain
   ignore_above: 1024
   level: extended
@@ -365,7 +363,7 @@ dns.question.subdomain:
 dns.question.top_level_domain:
   dashed_name: dns-question-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -1050,8 +1048,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -1605,9 +1602,7 @@ source.geo.region_name:
   type: keyword
 source.ip:
   dashed_name: source-ip
-  description: 'IP address of the source.
-
-    Can be one or multiple IPv4 or IPv6 addresses.'
+  description: IP address of the source (IPv4 or IPv6).
   flat_name: source.ip
   level: core
   name: ip
@@ -1638,12 +1633,12 @@ source.registered_domain:
   dashed_name: source-registered-domain
   description: 'The highest registered source domain, stripped of the subdomain.
 
-    For example, the registered domain for "foo.google.com" is "google.com".
+    For example, the registered domain for "foo.example.com" is "example.com".
 
     This value can be determined precisely with a list like the public suffix list
     (http://publicsuffix.org). Trying to approximate this by simply taking the last
     two labels will not work well for TLDs such as "co.uk".'
-  example: google.com
+  example: example.com
   flat_name: source.registered_domain
   ignore_above: 1024
   level: extended
@@ -1654,7 +1649,7 @@ source.registered_domain:
 source.top_level_domain:
   dashed_name: source-top-level-domain
   description: 'The effective top level domain (eTLD), also known as the domain suffix,
-    is the last part of the domain name. For example, the top level domain for google.com
+    is the last part of the domain name. For example, the top level domain for example.com
     is "com".
 
     This value can be determined precisely with a list like the public suffix list
@@ -1720,13 +1715,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -221,8 +221,7 @@ Endpoint.policy.applied.configurations.events.status:
   level: custom
   name: policy.applied.configurations.events.status
   normalize: []
-  short: the overall status of event collection, this is correlated to the status
-    of concerned actions  but not a simple sum of the actions
+  short: the overall status of event collection
   type: keyword
 Endpoint.policy.applied.configurations.logging:
   dashed_name: Endpoint-policy-applied-configurations-logging
@@ -252,8 +251,7 @@ Endpoint.policy.applied.configurations.logging.status:
   level: custom
   name: policy.applied.configurations.logging.status
   normalize: []
-  short: the overall status of logging, this is correlated to the status of concerned
-    actions but  not a simple sum of the actions
+  short: the overall status of logging
   type: keyword
 Endpoint.policy.applied.configurations.malware:
   dashed_name: Endpoint-policy-applied-configurations-malware
@@ -283,8 +281,7 @@ Endpoint.policy.applied.configurations.malware.status:
   level: custom
   name: policy.applied.configurations.malware.status
   normalize: []
-  short: the overall status of malware, this is correlated to the status of concerned
-    actions  but not a simple sum of the actions
+  short: the overall status of malware
   type: keyword
 Endpoint.policy.applied.configurations.streaming:
   dashed_name: Endpoint-policy-applied-configurations-streaming
@@ -314,8 +311,7 @@ Endpoint.policy.applied.configurations.streaming.status:
   level: custom
   name: policy.applied.configurations.streaming.status
   normalize: []
-  short: the overall status of data streaming, this is correlated to the status of
-    concerned actions  but not a simple sum of the actions
+  short: overall status of data streaming
   type: keyword
 Endpoint.policy.applied.id:
   dashed_name: Endpoint-policy-applied-id
@@ -384,7 +380,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -1017,8 +1013,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1094,25 +1094,26 @@ process.parent.Ext:
   type: object
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
-  description: The field set containing parent process info in case of any ppid spoofing.
+  description: The field set containing process info in case of any pid spoofing.
+    This is mainly useful for process.parent.
   flat_name: process.parent.Ext.real
   level: custom
   name: Ext.real
   normalize: []
   original_fieldset: process
-  short: The field set containing parent process info in case of any ppid spoofing.
+  short: The field set containing process info in case of any pid spoofing. This is
+    mainly useful for process.parent.
   type: object
 process.parent.Ext.real.pid:
   dashed_name: process-parent-Ext-real-pid
-  description: The ppid of the process that actually spawned the current process,
-    in case of ppid spoofing.
+  description: For process.parent this will be the ppid of the process that actually
+    spawned the current process.
   flat_name: process.parent.Ext.real.pid
   level: custom
   name: Ext.real.pid
   normalize: []
   original_fieldset: process
-  short: The ppid of the process that actually spawned the current process, in case
-    of ppid spoofing.
+  short: The real pid of the process if ppid spoofing is happening.
   type: long
 process.parent.entity_id:
   dashed_name: process-parent-entity-id

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -725,8 +725,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -1083,22 +1082,14 @@ process.name:
   normalize: []
   short: Process name.
   type: keyword
-process.parent:
-  dashed_name: process-parent
-  description: Extended "process.parent" field set.
-  flat_name: process.parent
-  level: custom
-  name: parent
-  normalize: []
-  short: Extended "process.parent" field set.
-  type: object
 process.parent.Ext:
   dashed_name: process-parent-Ext
   description: Object for all custom defined fields to live in.
   flat_name: process.parent.Ext
   level: custom
-  name: parent.Ext
+  name: Ext
   normalize: []
+  original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
 process.parent.Ext.real:
@@ -1106,8 +1097,9 @@ process.parent.Ext.real:
   description: The field set containing parent process info in case of any ppid spoofing.
   flat_name: process.parent.Ext.real
   level: custom
-  name: parent.Ext.real
+  name: Ext.real
   normalize: []
+  original_fieldset: process
   short: The field set containing parent process info in case of any ppid spoofing.
   type: object
 process.parent.Ext.real.pid:
@@ -1116,8 +1108,9 @@ process.parent.Ext.real.pid:
     in case of ppid spoofing.
   flat_name: process.parent.Ext.real.pid
   level: custom
-  name: parent.Ext.real.pid
+  name: Ext.real.pid
   normalize: []
+  original_fieldset: process
   short: The ppid of the process that actually spawned the current process, in case
     of ppid spoofing.
   type: long
@@ -1136,8 +1129,9 @@ process.parent.entity_id:
   flat_name: process.parent.entity_id
   ignore_above: 1024
   level: extended
-  name: parent.entity_id
+  name: entity_id
   normalize: []
+  original_fieldset: process
   short: Unique identifier for the process.
   type: keyword
 process.parent.executable:
@@ -1152,8 +1146,9 @@ process.parent.executable:
     name: text
     norms: false
     type: text
-  name: parent.executable
+  name: executable
   normalize: []
+  original_fieldset: process
   short: Absolute path to the process executable.
   type: keyword
 process.parent.name:
@@ -1170,8 +1165,9 @@ process.parent.name:
     name: text
     norms: false
     type: text
-  name: parent.name
+  name: name
   normalize: []
+  original_fieldset: process
   short: Process name.
   type: keyword
 process.parent.pid:
@@ -1181,8 +1177,9 @@ process.parent.pid:
   flat_name: process.parent.pid
   format: string
   level: core
-  name: parent.pid
+  name: pid
   normalize: []
+  original_fieldset: process
   short: Process id.
   type: long
 process.pe.original_file_name:
@@ -1271,13 +1268,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/schemas/v1/registry/registry.yaml
+++ b/schemas/v1/registry/registry.yaml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -725,8 +725,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -950,7 +949,8 @@ registry.data.strings:
   ignore_above: 1024
   level: core
   name: data.strings
-  normalize: []
+  normalize:
+  - array
   short: List of strings representing what was written to the registry.
   type: keyword
 registry.hive:
@@ -1050,13 +1050,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name

--- a/schemas/v1/security/security.yaml
+++ b/schemas/v1/security/security.yaml
@@ -34,7 +34,7 @@ agent.type:
   dashed_name: agent-type
   description: 'Type of the agent.
 
-    The agent type stays always the same and should be given by the agent used. In
+    The agent type always stays the same and should be given by the agent used. In
     case of Filebeat the agent would always be Filebeat also if two Filebeat instances
     are run on the same machine.'
   example: filebeat
@@ -725,8 +725,7 @@ host.os.Ext.variant:
   normalize: []
   original_fieldset: os
   short: A string value or phrase that further aid to classify or qualify the operating
-    system (OS).  For example the distribution for a Linux OS will be entered in this
-    field.
+    system (OS).
   type: keyword
 host.os.family:
   dashed_name: host-os-family
@@ -973,13 +972,13 @@ user.domain:
   type: keyword
 user.id:
   dashed_name: user-id
-  description: Unique identifiers of the user.
+  description: Unique identifier of the user.
   flat_name: user.id
   ignore_above: 1024
   level: core
   name: id
   normalize: []
-  short: Unique identifiers of the user.
+  short: Unique identifier of the user.
   type: keyword
 user.name:
   dashed_name: user-name


### PR DESCRIPTION
This PR pulls in ECS version 1.6.0.

Notable changes:

- Short descriptions were added to fields that had a description longer than 120ish characters
- `custom_process.yml` changed a bit since ECS core no longer defines `process.parent` fields, instead it duplicates the `process` fields onto itself as `parent`
- Not longer using my fork for ECS, we're back to ECS `master` branch!

The only things that should have changed from this PR are the descriptions/short fields and some of the metadata from the `process` changes.