### PR TITLE
add the transform file back

### DIFF
--- a/package/endpoint/dataset/metadata/elasticsearch/transform/current-default.json
+++ b/package/endpoint/dataset/metadata/elasticsearch/transform/current-default.json
@@ -1,0 +1,35 @@
+{
+    "source": {
+        "index": "metrics-endpoint.metadata-default*"
+    },
+    "dest": {
+        "index": "metrics-endpoint.metadata_current-default"
+    },
+    "pivot": {
+        "group_by": {
+            "agent.id": {
+                "terms": {
+                    "field": "agent.id"
+                }
+            }
+        },
+        "aggregations": {
+            "HostDetails": {
+                "scripted_metric": {
+                    "init_script": "state.timestamp_latest = 0L; state.last_doc=''",
+                    "map_script": "def current_date = doc['@timestamp'].getValue().toInstant().toEpochMilli(); if (current_date \u003e state.timestamp_latest) {state.timestamp_latest = current_date;state.last_doc = new HashMap(params['_source']);}",
+                    "combine_script": "return state",
+                    "reduce_script": "def last_doc = '';def timestamp_latest = 0L; for (s in states) {if (s.timestamp_latest \u003e (timestamp_latest)) {timestamp_latest = s.timestamp_latest; last_doc = s.last_doc;}} return last_doc"
+                }
+            }
+        }
+    },
+    "description": "collapse and update the latest document for each host",
+    "frequency": "1m",
+    "sync": {
+        "time": {
+            "field": "event.ingested",
+            "delay": "60s"
+        }
+    }
+}


### PR DESCRIPTION
We can now successfully deploy an 8.0 cloud instance which will stand up Ingest and install the transform.  Reverting this change so that we don't push this to the registry.

More info: https://github.com/elastic/kibana/issues/77133#issuecomment-692792691