### PR TITLE
Adding in geo fields to fix maps page

### DIFF
--- a/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
@@ -17,6 +17,15 @@ fields:
         exceptionable: true
       version:
         exceptionable: true
+  # these fields are needed in the mapping so the maps page of the security app does not throw a bunch of errors
+  source:
+    fields:
+      geo:
+        fields: "*"
+  destination:
+    fields:
+      geo:
+        fields: "*"
   dll:
     fields:
       name: {}

--- a/custom_subsets/elastic_endpoint/file/file.yaml
+++ b/custom_subsets/elastic_endpoint/file/file.yaml
@@ -10,6 +10,15 @@ fields:
   ecs:
     fields:
       version: {}
+  # these fields are needed in the mapping so the maps page of the security app does not throw a bunch of errors
+  source:
+    fields:
+      geo:
+        fields: "*"
+  destination:
+    fields:
+      geo:
+        fields: "*"
   host:
     fields:
       name: {}

--- a/custom_subsets/elastic_endpoint/file/unquarantine.yaml
+++ b/custom_subsets/elastic_endpoint/file/unquarantine.yaml
@@ -9,6 +9,15 @@ fields:
   ecs:
     fields:
       version: {}
+  # these fields are needed in the mapping so the maps page of the security app does not throw a bunch of errors
+  source:
+    fields:
+      geo:
+        fields: "*"
+  destination:
+    fields:
+      geo:
+        fields: "*"
   host:
     fields:
       name: {}

--- a/custom_subsets/elastic_endpoint/library/library.yaml
+++ b/custom_subsets/elastic_endpoint/library/library.yaml
@@ -10,6 +10,15 @@ fields:
   ecs:
     fields:
       version: {}
+  # these fields are needed in the mapping so the maps page of the security app does not throw a bunch of errors
+  source:
+    fields:
+      geo:
+        fields: "*"
+  destination:
+    fields:
+      geo:
+        fields: "*"
   host:
     fields:
       name: {}

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -10,6 +10,15 @@ fields:
   ecs:
     fields:
       version: {}
+  # these fields are needed in the mapping so the maps page of the security app does not throw a bunch of errors
+  source:
+    fields:
+      geo:
+        fields: "*"
+  destination:
+    fields:
+      geo:
+        fields: "*"
   host:
     fields:
       name: {}

--- a/custom_subsets/elastic_endpoint/registry/registry.yaml
+++ b/custom_subsets/elastic_endpoint/registry/registry.yaml
@@ -10,6 +10,15 @@ fields:
   ecs:
     fields:
       version: {}
+  # these fields are needed in the mapping so the maps page of the security app does not throw a bunch of errors
+  source:
+    fields:
+      geo:
+        fields: "*"
+  destination:
+    fields:
+      geo:
+        fields: "*"
   host:
     fields:
       name: {}

--- a/custom_subsets/elastic_endpoint/security/security.yaml
+++ b/custom_subsets/elastic_endpoint/security/security.yaml
@@ -10,6 +10,15 @@ fields:
   ecs:
     fields:
       version: {}
+  # these fields are needed in the mapping so the maps page of the security app does not throw a bunch of errors
+  source:
+    fields:
+      geo:
+        fields: "*"
+  destination:
+    fields:
+      geo:
+        fields: "*"
   host:
     fields:
       name: {}

--- a/generated/alerts/ecs/ecs_flat.yml
+++ b/generated/alerts/ecs/ecs_flat.yml
@@ -2072,6 +2072,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 dll.Ext:
   dashed_name: dll-Ext
   description: Object for all custom defined fields to live in.
@@ -6093,6 +6194,107 @@ rule.version:
   name: version
   normalize: []
   short: Rule version
+  type: keyword
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
   type: keyword
 threat.framework:
   dashed_name: threat-framework

--- a/generated/alerts/ecs/subset/malware_event/ecs_flat.yml
+++ b/generated/alerts/ecs/subset/malware_event/ecs_flat.yml
@@ -2109,6 +2109,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 dll.Ext:
   dashed_name: dll-Ext
   description: Object for all custom defined fields to live in.
@@ -6218,6 +6319,107 @@ rule.version:
   name: version
   normalize: []
   short: Rule version
+  type: keyword
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
   type: keyword
 threat.framework:
   dashed_name: threat-framework

--- a/generated/alerts/elasticsearch/7/template.json
+++ b/generated/alerts/elasticsearch/7/template.json
@@ -828,6 +828,45 @@
           }
         }
       },
+      "destination": {
+        "properties": {
+          "geo": {
+            "properties": {
+              "city_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "continent_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "location": {
+                "type": "geo_point"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      },
       "dll": {
         "properties": {
           "Ext": {
@@ -2261,6 +2300,45 @@
           "version": {
             "ignore_above": 1024,
             "type": "keyword"
+          }
+        }
+      },
+      "source": {
+        "properties": {
+          "geo": {
+            "properties": {
+              "city_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "continent_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "location": {
+                "type": "geo_point"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
           }
         }
       },

--- a/generated/file/ecs/ecs_flat.yml
+++ b/generated/file/ecs/ecs_flat.yml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -1231,6 +1332,107 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 user.Ext:
   dashed_name: user-Ext
   description: Object for all custom defined fields to live in.

--- a/generated/file/ecs/subset/file/ecs_flat.yml
+++ b/generated/file/ecs/subset/file/ecs_flat.yml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -1201,6 +1302,107 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 user.Ext:
   dashed_name: user-Ext
   description: Object for all custom defined fields to live in.

--- a/generated/file/ecs/subset/unquarantine/ecs_flat.yml
+++ b/generated/file/ecs/subset/unquarantine/ecs_flat.yml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -912,4 +1013,105 @@ host.os.version:
   normalize: []
   original_fieldset: os
   short: Operating system version as a raw string.
+  type: keyword
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
   type: keyword

--- a/generated/file/elasticsearch/7/template.json
+++ b/generated/file/elasticsearch/7/template.json
@@ -51,6 +51,45 @@
           }
         }
       },
+      "destination": {
+        "properties": {
+          "geo": {
+            "properties": {
+              "city_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "continent_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "location": {
+                "type": "geo_point"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      },
       "ecs": {
         "properties": {
           "version": {
@@ -375,6 +414,45 @@
             "properties": {
               "id": {
                 "type": "long"
+              }
+            }
+          }
+        }
+      },
+      "source": {
+        "properties": {
+          "geo": {
+            "properties": {
+              "city_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "continent_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "location": {
+                "type": "geo_point"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           }

--- a/generated/library/ecs/ecs_flat.yml
+++ b/generated/library/ecs/ecs_flat.yml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 dll.Ext:
   dashed_name: dll-Ext
   description: Object for all custom defined fields to live in.
@@ -1141,6 +1242,107 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 user.Ext:
   dashed_name: user-Ext
   description: Object for all custom defined fields to live in.

--- a/generated/library/ecs/subset/library/ecs_flat.yml
+++ b/generated/library/ecs/subset/library/ecs_flat.yml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 dll.Ext:
   dashed_name: dll-Ext
   description: Object for all custom defined fields to live in.
@@ -1141,6 +1242,107 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 user.Ext:
   dashed_name: user-Ext
   description: Object for all custom defined fields to live in.

--- a/generated/library/elasticsearch/7/template.json
+++ b/generated/library/elasticsearch/7/template.json
@@ -51,6 +51,45 @@
           }
         }
       },
+      "destination": {
+        "properties": {
+          "geo": {
+            "properties": {
+              "city_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "continent_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "location": {
+                "type": "geo_point"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      },
       "dll": {
         "properties": {
           "Ext": {
@@ -358,6 +397,45 @@
             "properties": {
               "id": {
                 "type": "long"
+              }
+            }
+          }
+        }
+      },
+      "source": {
+        "properties": {
+          "geo": {
+            "properties": {
+              "city_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "continent_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "location": {
+                "type": "geo_point"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           }

--- a/generated/process/ecs/ecs_flat.yml
+++ b/generated/process/ecs/ecs_flat.yml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -1217,6 +1318,107 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 user.Ext:
   dashed_name: user-Ext
   description: Object for all custom defined fields to live in.

--- a/generated/process/ecs/subset/process/ecs_flat.yml
+++ b/generated/process/ecs/subset/process/ecs_flat.yml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -1217,6 +1318,107 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 user.Ext:
   dashed_name: user-Ext
   description: Object for all custom defined fields to live in.

--- a/generated/process/elasticsearch/7/template.json
+++ b/generated/process/elasticsearch/7/template.json
@@ -51,6 +51,45 @@
           }
         }
       },
+      "destination": {
+        "properties": {
+          "geo": {
+            "properties": {
+              "city_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "continent_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "location": {
+                "type": "geo_point"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      },
       "ecs": {
         "properties": {
           "version": {
@@ -381,6 +420,45 @@
             "properties": {
               "id": {
                 "type": "long"
+              }
+            }
+          }
+        }
+      },
+      "source": {
+        "properties": {
+          "geo": {
+            "properties": {
+              "city_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "continent_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "location": {
+                "type": "geo_point"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           }

--- a/generated/registry/ecs/ecs_flat.yml
+++ b/generated/registry/ecs/ecs_flat.yml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -997,6 +1098,107 @@ registry.value:
   name: value
   normalize: []
   short: Name of the value written.
+  type: keyword
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
   type: keyword
 user.Ext:
   dashed_name: user-Ext

--- a/generated/registry/ecs/subset/registry/ecs_flat.yml
+++ b/generated/registry/ecs/subset/registry/ecs_flat.yml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -997,6 +1098,107 @@ registry.value:
   name: value
   normalize: []
   short: Name of the value written.
+  type: keyword
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
   type: keyword
 user.Ext:
   dashed_name: user-Ext

--- a/generated/registry/elasticsearch/7/template.json
+++ b/generated/registry/elasticsearch/7/template.json
@@ -51,6 +51,45 @@
           }
         }
       },
+      "destination": {
+        "properties": {
+          "geo": {
+            "properties": {
+              "city_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "continent_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "location": {
+                "type": "geo_point"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      },
       "ecs": {
         "properties": {
           "version": {
@@ -286,6 +325,45 @@
           "value": {
             "ignore_above": 1024,
             "type": "keyword"
+          }
+        }
+      },
+      "source": {
+        "properties": {
+          "geo": {
+            "properties": {
+              "city_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "continent_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "location": {
+                "type": "geo_point"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
           }
         }
       },

--- a/generated/security/ecs/ecs_flat.yml
+++ b/generated/security/ecs/ecs_flat.yml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -920,6 +1021,107 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 user.Ext:
   dashed_name: user-Ext
   description: Object for all custom defined fields to live in.

--- a/generated/security/ecs/subset/security/ecs_flat.yml
+++ b/generated/security/ecs/subset/security/ecs_flat.yml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -920,6 +1021,107 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 user.Ext:
   dashed_name: user-Ext
   description: Object for all custom defined fields to live in.

--- a/generated/security/elasticsearch/7/template.json
+++ b/generated/security/elasticsearch/7/template.json
@@ -51,6 +51,45 @@
           }
         }
       },
+      "destination": {
+        "properties": {
+          "geo": {
+            "properties": {
+              "city_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "continent_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "location": {
+                "type": "geo_point"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      },
       "ecs": {
         "properties": {
           "version": {
@@ -252,6 +291,45 @@
             "properties": {
               "id": {
                 "type": "long"
+              }
+            }
+          }
+        }
+      },
+      "source": {
+        "properties": {
+          "geo": {
+            "properties": {
+              "city_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "continent_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "country_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "location": {
+                "type": "geo_point"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_iso_code": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "region_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           }

--- a/package/endpoint/dataset/alerts/fields/fields.yml
+++ b/package/endpoint/dataset/alerts/fields/fields.yml
@@ -1255,6 +1255,67 @@
     type: constant_keyword
     description: Data stream type.
     default_field: false
+- name: destination
+  title: Destination
+  group: 2
+  description: 'Destination fields describe details about the destination of a packet/event.
+
+    Destination fields are usually populated in conjunction with source fields.'
+  type: group
+  fields:
+  - name: geo.city_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: City name.
+    example: Montreal
+  - name: geo.continent_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Name of the continent.
+    example: North America
+  - name: geo.country_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country ISO code.
+    example: CA
+  - name: geo.country_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country name.
+    example: Canada
+  - name: geo.location
+    level: core
+    type: geo_point
+    description: Longitude and latitude.
+    example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  - name: geo.name
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'User-defined description of a location, at the level of granularity
+      they care about.
+
+      Could be the name of their data centers, the floor number, if this describes
+      a local physical entity, city names.
+
+      Not typically used in automated geolocation.'
+    example: boston-dc
+  - name: geo.region_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region ISO code.
+    example: CA-QC
+  - name: geo.region_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region name.
+    example: Quebec
 - name: dll
   title: DLL
   group: 2
@@ -3522,6 +3583,67 @@
     description: The version / revision of the rule being used for analysis.
     example: 1.1
     default_field: false
+- name: source
+  title: Source
+  group: 2
+  description: 'Source fields describe details about the source of a packet/event.
+
+    Source fields are usually populated in conjunction with destination fields.'
+  type: group
+  fields:
+  - name: geo.city_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: City name.
+    example: Montreal
+  - name: geo.continent_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Name of the continent.
+    example: North America
+  - name: geo.country_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country ISO code.
+    example: CA
+  - name: geo.country_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country name.
+    example: Canada
+  - name: geo.location
+    level: core
+    type: geo_point
+    description: Longitude and latitude.
+    example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  - name: geo.name
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'User-defined description of a location, at the level of granularity
+      they care about.
+
+      Could be the name of their data centers, the floor number, if this describes
+      a local physical entity, city names.
+
+      Not typically used in automated geolocation.'
+    example: boston-dc
+  - name: geo.region_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region ISO code.
+    example: CA-QC
+  - name: geo.region_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region name.
+    example: Quebec
 - name: threat
   title: Threat
   group: 2

--- a/package/endpoint/dataset/file/fields/fields.yml
+++ b/package/endpoint/dataset/file/fields/fields.yml
@@ -84,6 +84,67 @@
     type: constant_keyword
     description: Data stream type.
     default_field: false
+- name: destination
+  title: Destination
+  group: 2
+  description: 'Destination fields describe details about the destination of a packet/event.
+
+    Destination fields are usually populated in conjunction with source fields.'
+  type: group
+  fields:
+  - name: geo.city_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: City name.
+    example: Montreal
+  - name: geo.continent_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Name of the continent.
+    example: North America
+  - name: geo.country_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country ISO code.
+    example: CA
+  - name: geo.country_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country name.
+    example: Canada
+  - name: geo.location
+    level: core
+    type: geo_point
+    description: Longitude and latitude.
+    example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  - name: geo.name
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'User-defined description of a location, at the level of granularity
+      they care about.
+
+      Could be the name of their data centers, the floor number, if this describes
+      a local physical entity, city names.
+
+      Not typically used in automated geolocation.'
+    example: boston-dc
+  - name: geo.region_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region ISO code.
+    example: CA-QC
+  - name: geo.region_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region name.
+    example: Quebec
 - name: ecs
   title: ECS
   group: 2
@@ -646,6 +707,67 @@
     format: string
     description: Thread ID.
     example: 4242
+- name: source
+  title: Source
+  group: 2
+  description: 'Source fields describe details about the source of a packet/event.
+
+    Source fields are usually populated in conjunction with destination fields.'
+  type: group
+  fields:
+  - name: geo.city_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: City name.
+    example: Montreal
+  - name: geo.continent_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Name of the continent.
+    example: North America
+  - name: geo.country_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country ISO code.
+    example: CA
+  - name: geo.country_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country name.
+    example: Canada
+  - name: geo.location
+    level: core
+    type: geo_point
+    description: Longitude and latitude.
+    example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  - name: geo.name
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'User-defined description of a location, at the level of granularity
+      they care about.
+
+      Could be the name of their data centers, the floor number, if this describes
+      a local physical entity, city names.
+
+      Not typically used in automated geolocation.'
+    example: boston-dc
+  - name: geo.region_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region ISO code.
+    example: CA-QC
+  - name: geo.region_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region name.
+    example: Quebec
 - name: user
   title: User
   group: 2

--- a/package/endpoint/dataset/library/fields/fields.yml
+++ b/package/endpoint/dataset/library/fields/fields.yml
@@ -84,6 +84,67 @@
     type: constant_keyword
     description: Data stream type.
     default_field: false
+- name: destination
+  title: Destination
+  group: 2
+  description: 'Destination fields describe details about the destination of a packet/event.
+
+    Destination fields are usually populated in conjunction with source fields.'
+  type: group
+  fields:
+  - name: geo.city_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: City name.
+    example: Montreal
+  - name: geo.continent_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Name of the continent.
+    example: North America
+  - name: geo.country_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country ISO code.
+    example: CA
+  - name: geo.country_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country name.
+    example: Canada
+  - name: geo.location
+    level: core
+    type: geo_point
+    description: Longitude and latitude.
+    example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  - name: geo.name
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'User-defined description of a location, at the level of granularity
+      they care about.
+
+      Could be the name of their data centers, the floor number, if this describes
+      a local physical entity, city names.
+
+      Not typically used in automated geolocation.'
+    example: boston-dc
+  - name: geo.region_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region ISO code.
+    example: CA-QC
+  - name: geo.region_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region name.
+    example: Quebec
 - name: dll
   title: DLL
   group: 2
@@ -619,6 +680,67 @@
     format: string
     description: Thread ID.
     example: 4242
+- name: source
+  title: Source
+  group: 2
+  description: 'Source fields describe details about the source of a packet/event.
+
+    Source fields are usually populated in conjunction with destination fields.'
+  type: group
+  fields:
+  - name: geo.city_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: City name.
+    example: Montreal
+  - name: geo.continent_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Name of the continent.
+    example: North America
+  - name: geo.country_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country ISO code.
+    example: CA
+  - name: geo.country_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country name.
+    example: Canada
+  - name: geo.location
+    level: core
+    type: geo_point
+    description: Longitude and latitude.
+    example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  - name: geo.name
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'User-defined description of a location, at the level of granularity
+      they care about.
+
+      Could be the name of their data centers, the floor number, if this describes
+      a local physical entity, city names.
+
+      Not typically used in automated geolocation.'
+    example: boston-dc
+  - name: geo.region_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region ISO code.
+    example: CA-QC
+  - name: geo.region_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region name.
+    example: Quebec
 - name: user
   title: User
   group: 2

--- a/package/endpoint/dataset/process/fields/fields.yml
+++ b/package/endpoint/dataset/process/fields/fields.yml
@@ -84,6 +84,67 @@
     type: constant_keyword
     description: Data stream type.
     default_field: false
+- name: destination
+  title: Destination
+  group: 2
+  description: 'Destination fields describe details about the destination of a packet/event.
+
+    Destination fields are usually populated in conjunction with source fields.'
+  type: group
+  fields:
+  - name: geo.city_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: City name.
+    example: Montreal
+  - name: geo.continent_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Name of the continent.
+    example: North America
+  - name: geo.country_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country ISO code.
+    example: CA
+  - name: geo.country_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country name.
+    example: Canada
+  - name: geo.location
+    level: core
+    type: geo_point
+    description: Longitude and latitude.
+    example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  - name: geo.name
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'User-defined description of a location, at the level of granularity
+      they care about.
+
+      Could be the name of their data centers, the floor number, if this describes
+      a local physical entity, city names.
+
+      Not typically used in automated geolocation.'
+    example: boston-dc
+  - name: geo.region_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region ISO code.
+    example: CA-QC
+  - name: geo.region_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region name.
+    example: Quebec
 - name: ecs
   title: ECS
   group: 2
@@ -648,6 +709,67 @@
     format: string
     description: Thread ID.
     example: 4242
+- name: source
+  title: Source
+  group: 2
+  description: 'Source fields describe details about the source of a packet/event.
+
+    Source fields are usually populated in conjunction with destination fields.'
+  type: group
+  fields:
+  - name: geo.city_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: City name.
+    example: Montreal
+  - name: geo.continent_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Name of the continent.
+    example: North America
+  - name: geo.country_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country ISO code.
+    example: CA
+  - name: geo.country_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country name.
+    example: Canada
+  - name: geo.location
+    level: core
+    type: geo_point
+    description: Longitude and latitude.
+    example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  - name: geo.name
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'User-defined description of a location, at the level of granularity
+      they care about.
+
+      Could be the name of their data centers, the floor number, if this describes
+      a local physical entity, city names.
+
+      Not typically used in automated geolocation.'
+    example: boston-dc
+  - name: geo.region_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region ISO code.
+    example: CA-QC
+  - name: geo.region_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region name.
+    example: Quebec
 - name: user
   title: User
   group: 2

--- a/package/endpoint/dataset/registry/fields/fields.yml
+++ b/package/endpoint/dataset/registry/fields/fields.yml
@@ -84,6 +84,67 @@
     type: constant_keyword
     description: Data stream type.
     default_field: false
+- name: destination
+  title: Destination
+  group: 2
+  description: 'Destination fields describe details about the destination of a packet/event.
+
+    Destination fields are usually populated in conjunction with source fields.'
+  type: group
+  fields:
+  - name: geo.city_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: City name.
+    example: Montreal
+  - name: geo.continent_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Name of the continent.
+    example: North America
+  - name: geo.country_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country ISO code.
+    example: CA
+  - name: geo.country_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country name.
+    example: Canada
+  - name: geo.location
+    level: core
+    type: geo_point
+    description: Longitude and latitude.
+    example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  - name: geo.name
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'User-defined description of a location, at the level of granularity
+      they care about.
+
+      Could be the name of their data centers, the floor number, if this describes
+      a local physical entity, city names.
+
+      Not typically used in automated geolocation.'
+    example: boston-dc
+  - name: geo.region_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region ISO code.
+    example: CA-QC
+  - name: geo.region_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region name.
+    example: Quebec
 - name: ecs
   title: ECS
   group: 2
@@ -518,6 +579,67 @@
     description: Name of the value written.
     example: Debugger
     default_field: false
+- name: source
+  title: Source
+  group: 2
+  description: 'Source fields describe details about the source of a packet/event.
+
+    Source fields are usually populated in conjunction with destination fields.'
+  type: group
+  fields:
+  - name: geo.city_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: City name.
+    example: Montreal
+  - name: geo.continent_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Name of the continent.
+    example: North America
+  - name: geo.country_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country ISO code.
+    example: CA
+  - name: geo.country_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country name.
+    example: Canada
+  - name: geo.location
+    level: core
+    type: geo_point
+    description: Longitude and latitude.
+    example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  - name: geo.name
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'User-defined description of a location, at the level of granularity
+      they care about.
+
+      Could be the name of their data centers, the floor number, if this describes
+      a local physical entity, city names.
+
+      Not typically used in automated geolocation.'
+    example: boston-dc
+  - name: geo.region_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region ISO code.
+    example: CA-QC
+  - name: geo.region_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region name.
+    example: Quebec
 - name: user
   title: User
   group: 2

--- a/package/endpoint/dataset/security/fields/fields.yml
+++ b/package/endpoint/dataset/security/fields/fields.yml
@@ -84,6 +84,67 @@
     type: constant_keyword
     description: Data stream type.
     default_field: false
+- name: destination
+  title: Destination
+  group: 2
+  description: 'Destination fields describe details about the destination of a packet/event.
+
+    Destination fields are usually populated in conjunction with source fields.'
+  type: group
+  fields:
+  - name: geo.city_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: City name.
+    example: Montreal
+  - name: geo.continent_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Name of the continent.
+    example: North America
+  - name: geo.country_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country ISO code.
+    example: CA
+  - name: geo.country_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country name.
+    example: Canada
+  - name: geo.location
+    level: core
+    type: geo_point
+    description: Longitude and latitude.
+    example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  - name: geo.name
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'User-defined description of a location, at the level of granularity
+      they care about.
+
+      Could be the name of their data centers, the floor number, if this describes
+      a local physical entity, city names.
+
+      Not typically used in automated geolocation.'
+    example: boston-dc
+  - name: geo.region_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region ISO code.
+    example: CA-QC
+  - name: geo.region_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region name.
+    example: Quebec
 - name: ecs
   title: ECS
   group: 2
@@ -459,6 +520,67 @@
     format: string
     description: Thread ID.
     example: 4242
+- name: source
+  title: Source
+  group: 2
+  description: 'Source fields describe details about the source of a packet/event.
+
+    Source fields are usually populated in conjunction with destination fields.'
+  type: group
+  fields:
+  - name: geo.city_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: City name.
+    example: Montreal
+  - name: geo.continent_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Name of the continent.
+    example: North America
+  - name: geo.country_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country ISO code.
+    example: CA
+  - name: geo.country_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Country name.
+    example: Canada
+  - name: geo.location
+    level: core
+    type: geo_point
+    description: Longitude and latitude.
+    example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  - name: geo.name
+    level: extended
+    type: keyword
+    ignore_above: 1024
+    description: 'User-defined description of a location, at the level of granularity
+      they care about.
+
+      Could be the name of their data centers, the floor number, if this describes
+      a local physical entity, city names.
+
+      Not typically used in automated geolocation.'
+    example: boston-dc
+  - name: geo.region_iso_code
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region ISO code.
+    example: CA-QC
+  - name: geo.region_name
+    level: core
+    type: keyword
+    ignore_above: 1024
+    description: Region name.
+    example: Quebec
 - name: user
   title: User
   group: 2

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -163,6 +163,14 @@ sent by the endpoint.
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| destination.geo.city_name | City name. | keyword |
+| destination.geo.continent_name | Name of the continent. | keyword |
+| destination.geo.country_iso_code | Country ISO code. | keyword |
+| destination.geo.country_name | Country name. | keyword |
+| destination.geo.location | Longitude and latitude. | geo_point |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
+| destination.geo.region_iso_code | Region ISO code. | keyword |
+| destination.geo.region_name | Region name. | keyword |
 | dll.Ext | Object for all custom defined fields to live in. | object |
 | dll.Ext.code_signature | Nested version of ECS code_signature fieldset. | nested |
 | dll.Ext.code_signature.exists | Boolean to capture if a signature is present. | boolean |
@@ -451,6 +459,14 @@ sent by the endpoint.
 | rule.ruleset | Name of the ruleset, policy, group, or parent category in which the rule used to generate this event is a member. | keyword |
 | rule.uuid | A rule ID that is unique within the scope of a set or group of agents, observers, or other entities using the rule for detection of this event. | keyword |
 | rule.version | The version / revision of the rule being used for analysis. | keyword |
+| source.geo.city_name | City name. | keyword |
+| source.geo.continent_name | Name of the continent. | keyword |
+| source.geo.country_iso_code | Country ISO code. | keyword |
+| source.geo.country_name | Country name. | keyword |
+| source.geo.location | Longitude and latitude. | geo_point |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
+| source.geo.region_iso_code | Region ISO code. | keyword |
+| source.geo.region_name | Region name. | keyword |
 | threat.framework | Name of the threat framework used to further categorize and classify the tactic and technique of the reported threat. Framework classification can be provided by detecting systems, evaluated at ingest time, or retrospectively tagged to events. | keyword |
 | threat.tactic.id | The id of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/ ) | keyword |
 | threat.tactic.name | Name of the type of tactic used by this threat. You can use a MITRE ATT&CK® tactic, for example. (ex. https://attack.mitre.org/tactics/TA0040/) | keyword |
@@ -490,6 +506,14 @@ sent by the endpoint.
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| destination.geo.city_name | City name. | keyword |
+| destination.geo.continent_name | Name of the continent. | keyword |
+| destination.geo.country_iso_code | Country ISO code. | keyword |
+| destination.geo.country_name | Country name. | keyword |
+| destination.geo.location | Longitude and latitude. | geo_point |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
+| destination.geo.region_iso_code | Region ISO code. | keyword |
+| destination.geo.region_name | Region name. | keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.Ext | Object for all custom defined fields to live in. | object |
 | event.Ext.correlation | Information about event this should be correlated with. | object |
@@ -555,6 +579,14 @@ sent by the endpoint.
 | process.name | Process name. Sometimes called program name or similar. | keyword |
 | process.pid | Process id. | long |
 | process.thread.id | Thread ID. | long |
+| source.geo.city_name | City name. | keyword |
+| source.geo.continent_name | Name of the continent. | keyword |
+| source.geo.country_iso_code | Country ISO code. | keyword |
+| source.geo.country_name | Country name. | keyword |
+| source.geo.location | Longitude and latitude. | geo_point |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
+| source.geo.region_iso_code | Region ISO code. | keyword |
+| source.geo.region_name | Region name. | keyword |
 | user.Ext | Object for all custom defined fields to live in. | object |
 | user.Ext.real | User info prior to any setuid operations. | object |
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
@@ -577,6 +609,14 @@ sent by the endpoint.
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| destination.geo.city_name | City name. | keyword |
+| destination.geo.continent_name | Name of the continent. | keyword |
+| destination.geo.country_iso_code | Country ISO code. | keyword |
+| destination.geo.country_name | Country name. | keyword |
+| destination.geo.location | Longitude and latitude. | geo_point |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
+| destination.geo.region_iso_code | Region ISO code. | keyword |
+| destination.geo.region_name | Region name. | keyword |
 | dll.Ext | Object for all custom defined fields to live in. | object |
 | dll.Ext.code_signature | Nested version of ECS code_signature fieldset. | nested |
 | dll.Ext.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
@@ -635,6 +675,14 @@ sent by the endpoint.
 | process.name | Process name. Sometimes called program name or similar. | keyword |
 | process.pid | Process id. | long |
 | process.thread.id | Thread ID. | long |
+| source.geo.city_name | City name. | keyword |
+| source.geo.continent_name | Name of the continent. | keyword |
+| source.geo.country_iso_code | Country ISO code. | keyword |
+| source.geo.country_name | Country name. | keyword |
+| source.geo.location | Longitude and latitude. | geo_point |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
+| source.geo.region_iso_code | Region ISO code. | keyword |
+| source.geo.region_name | Region name. | keyword |
 | user.Ext | Object for all custom defined fields to live in. | object |
 | user.Ext.real | User info prior to any setuid operations. | object |
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
@@ -776,6 +824,14 @@ sent by the endpoint.
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| destination.geo.city_name | City name. | keyword |
+| destination.geo.continent_name | Name of the continent. | keyword |
+| destination.geo.country_iso_code | Country ISO code. | keyword |
+| destination.geo.country_name | Country name. | keyword |
+| destination.geo.location | Longitude and latitude. | geo_point |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
+| destination.geo.region_iso_code | Region ISO code. | keyword |
+| destination.geo.region_name | Region name. | keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
@@ -838,6 +894,14 @@ sent by the endpoint.
 | process.pe.original_file_name | Internal name of the file, provided at compile-time. | keyword |
 | process.pid | Process id. | long |
 | process.thread.id | Thread ID. | long |
+| source.geo.city_name | City name. | keyword |
+| source.geo.continent_name | Name of the continent. | keyword |
+| source.geo.country_iso_code | Country ISO code. | keyword |
+| source.geo.country_name | Country name. | keyword |
+| source.geo.location | Longitude and latitude. | geo_point |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
+| source.geo.region_iso_code | Region ISO code. | keyword |
+| source.geo.region_name | Region name. | keyword |
 | user.Ext | Object for all custom defined fields to live in. | object |
 | user.Ext.real | User info prior to any setuid operations. | object |
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
@@ -860,6 +924,14 @@ sent by the endpoint.
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| destination.geo.city_name | City name. | keyword |
+| destination.geo.continent_name | Name of the continent. | keyword |
+| destination.geo.country_iso_code | Country ISO code. | keyword |
+| destination.geo.country_name | Country name. | keyword |
+| destination.geo.location | Longitude and latitude. | geo_point |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
+| destination.geo.region_iso_code | Region ISO code. | keyword |
+| destination.geo.region_name | Region name. | keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
@@ -905,6 +977,14 @@ sent by the endpoint.
 | registry.key | Hive-relative path of keys. | keyword |
 | registry.path | Full path, including hive, key and value | keyword |
 | registry.value | Name of the value written. | keyword |
+| source.geo.city_name | City name. | keyword |
+| source.geo.continent_name | Name of the continent. | keyword |
+| source.geo.country_iso_code | Country ISO code. | keyword |
+| source.geo.country_name | Country name. | keyword |
+| source.geo.location | Longitude and latitude. | geo_point |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
+| source.geo.region_iso_code | Region ISO code. | keyword |
+| source.geo.region_name | Region name. | keyword |
 | user.Ext | Object for all custom defined fields to live in. | object |
 | user.Ext.real | User info prior to any setuid operations. | object |
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
@@ -927,6 +1007,14 @@ sent by the endpoint.
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| destination.geo.city_name | City name. | keyword |
+| destination.geo.continent_name | Name of the continent. | keyword |
+| destination.geo.country_iso_code | Country ISO code. | keyword |
+| destination.geo.country_name | Country name. | keyword |
+| destination.geo.location | Longitude and latitude. | geo_point |
+| destination.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
+| destination.geo.region_iso_code | Region ISO code. | keyword |
+| destination.geo.region_name | Region name. | keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
@@ -966,6 +1054,14 @@ sent by the endpoint.
 | process.name | Process name. Sometimes called program name or similar. | keyword |
 | process.pid | Process id. | long |
 | process.thread.id | Thread ID. | long |
+| source.geo.city_name | City name. | keyword |
+| source.geo.continent_name | Name of the continent. | keyword |
+| source.geo.country_iso_code | Country ISO code. | keyword |
+| source.geo.country_name | Country name. | keyword |
+| source.geo.location | Longitude and latitude. | geo_point |
+| source.geo.name | User-defined description of a location, at the level of granularity they care about. Could be the name of their data centers, the floor number, if this describes a local physical entity, city names. Not typically used in automated geolocation. | keyword |
+| source.geo.region_iso_code | Region ISO code. | keyword |
+| source.geo.region_name | Region name. | keyword |
 | user.Ext | Object for all custom defined fields to live in. | object |
 | user.Ext.real | User info prior to any setuid operations. | object |
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -2072,6 +2072,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 dll.Ext:
   dashed_name: dll-Ext
   description: Object for all custom defined fields to live in.
@@ -6093,6 +6194,107 @@ rule.version:
   name: version
   normalize: []
   short: Rule version
+  type: keyword
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
   type: keyword
 threat.framework:
   dashed_name: threat-framework

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -1201,6 +1302,107 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 user.Ext:
   dashed_name: user-Ext
   description: Object for all custom defined fields to live in.

--- a/schemas/v1/file/unquarantine.yaml
+++ b/schemas/v1/file/unquarantine.yaml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -912,4 +1013,105 @@ host.os.version:
   normalize: []
   original_fieldset: os
   short: Operating system version as a raw string.
+  type: keyword
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
   type: keyword

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 dll.Ext:
   dashed_name: dll-Ext
   description: Object for all custom defined fields to live in.
@@ -1141,6 +1242,107 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 user.Ext:
   dashed_name: user-Ext
   description: Object for all custom defined fields to live in.

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -1217,6 +1318,107 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 user.Ext:
   dashed_name: user-Ext
   description: Object for all custom defined fields to live in.

--- a/schemas/v1/registry/registry.yaml
+++ b/schemas/v1/registry/registry.yaml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -997,6 +1098,107 @@ registry.value:
   name: value
   normalize: []
   short: Name of the value written.
+  type: keyword
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
   type: keyword
 user.Ext:
   dashed_name: user-Ext

--- a/schemas/v1/security/security.yaml
+++ b/schemas/v1/security/security.yaml
@@ -83,6 +83,107 @@ data_stream.type:
   normalize: []
   short: Data stream type.
   type: constant_keyword
+destination.geo.city_name:
+  dashed_name: destination-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: destination.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+destination.geo.continent_name:
+  dashed_name: destination-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: destination.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+destination.geo.country_iso_code:
+  dashed_name: destination-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: destination.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+destination.geo.country_name:
+  dashed_name: destination-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: destination.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+destination.geo.location:
+  dashed_name: destination-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: destination.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+destination.geo.name:
+  dashed_name: destination-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: destination.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+destination.geo.region_iso_code:
+  dashed_name: destination-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: destination.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+destination.geo.region_name:
+  dashed_name: destination-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: destination.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -920,6 +1021,107 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+source.geo.city_name:
+  dashed_name: source-geo-city-name
+  description: City name.
+  example: Montreal
+  flat_name: source.geo.city_name
+  ignore_above: 1024
+  level: core
+  name: city_name
+  normalize: []
+  original_fieldset: geo
+  short: City name.
+  type: keyword
+source.geo.continent_name:
+  dashed_name: source-geo-continent-name
+  description: Name of the continent.
+  example: North America
+  flat_name: source.geo.continent_name
+  ignore_above: 1024
+  level: core
+  name: continent_name
+  normalize: []
+  original_fieldset: geo
+  short: Name of the continent.
+  type: keyword
+source.geo.country_iso_code:
+  dashed_name: source-geo-country-iso-code
+  description: Country ISO code.
+  example: CA
+  flat_name: source.geo.country_iso_code
+  ignore_above: 1024
+  level: core
+  name: country_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Country ISO code.
+  type: keyword
+source.geo.country_name:
+  dashed_name: source-geo-country-name
+  description: Country name.
+  example: Canada
+  flat_name: source.geo.country_name
+  ignore_above: 1024
+  level: core
+  name: country_name
+  normalize: []
+  original_fieldset: geo
+  short: Country name.
+  type: keyword
+source.geo.location:
+  dashed_name: source-geo-location
+  description: Longitude and latitude.
+  example: '{ "lon": -73.614830, "lat": 45.505918 }'
+  flat_name: source.geo.location
+  level: core
+  name: location
+  normalize: []
+  original_fieldset: geo
+  short: Longitude and latitude.
+  type: geo_point
+source.geo.name:
+  dashed_name: source-geo-name
+  description: 'User-defined description of a location, at the level of granularity
+    they care about.
+
+    Could be the name of their data centers, the floor number, if this describes a
+    local physical entity, city names.
+
+    Not typically used in automated geolocation.'
+  example: boston-dc
+  flat_name: source.geo.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: geo
+  short: User-defined description of a location.
+  type: keyword
+source.geo.region_iso_code:
+  dashed_name: source-geo-region-iso-code
+  description: Region ISO code.
+  example: CA-QC
+  flat_name: source.geo.region_iso_code
+  ignore_above: 1024
+  level: core
+  name: region_iso_code
+  normalize: []
+  original_fieldset: geo
+  short: Region ISO code.
+  type: keyword
+source.geo.region_name:
+  dashed_name: source-geo-region-name
+  description: Region name.
+  example: Quebec
+  flat_name: source.geo.region_name
+  ignore_above: 1024
+  level: core
+  name: region_name
+  normalize: []
+  original_fieldset: geo
+  short: Region name.
+  type: keyword
 user.Ext:
   dashed_name: user-Ext
   description: Object for all custom defined fields to live in.


### PR DESCRIPTION
This PR adds the geo fields to all the mappings in the `log-*` indices. This will resolve the failures described in this ticket: https://github.com/elastic/kibana/issues/73304 where certain geo fields are not found and cause the maps page in the security app to throw a bunch of errors.

The fields won't even be populated but this is an easy work around until the maps can be upgraded to ignore the shard errors.

<details><summary>Example of it working</summary>

![image](https://user-images.githubusercontent.com/56361221/94607688-3a219380-026a-11eb-998d-c32ccd4a6c08.png)


![image](https://user-images.githubusercontent.com/56361221/94607862-7ce36b80-026a-11eb-8e87-e8ede2752823.png)

</details>