### PR TITLE
Improve release process

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ gitpython = "==3.1.2"
 jinja2 = "==2.11.2"
 pyyaml-include = "==1.2"
 click = "*"
+xxhash = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "94f07f973fbf29a7bdd16f379e7db5fa5c85b9e0bc2e80003c1d1a7174a28559"
+            "sha256": "8f02add7fc5f2ce4caeb54944db6f16ead86862707b8d413ff9642c3b8e6929f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -127,6 +127,62 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.0.4"
+        },
+        "xxhash": {
+            "hashes": [
+                "sha256:02476c5cef803cfd1350662b1e543e47ad64bd5f7f792033d94d590f9674da11",
+                "sha256:0ecea927fd3df8f3f3a1d6e5bc85838eb44a69ea2f4c9263dfd0f68c4e17e483",
+                "sha256:0f5f1b9ae8e2cf2ff606018769f7e46147df70291312f64e1b80d10482ca8c0b",
+                "sha256:16e4b7d508bb49b6fc84bf077f2f7f51263b5618cc61f33a64ed43786ec2c6cf",
+                "sha256:1b86f49b36c25ebdbd1b5539d428a37d9051ad49eb576a3edd964a8770bc8f3a",
+                "sha256:28c1f0bb6dadc11162d1f2e203d7a12d38b511b87fbb5ffa729594fd456f48e6",
+                "sha256:2912d7810bcf7e39b3929fb186fe46ff83b1bd4a3d6b7eba956d57fa1516ac0c",
+                "sha256:2f0ca6673fcbae988389576a779c00a62a28718a18ddc7b2e5b32d7fb30c6f98",
+                "sha256:3221f1a5bc2ee1f150b84a0c4c7cddc7724aaa01460f3353cf63fd667d89f593",
+                "sha256:33c4832e689f429539d70baf69162b41dfbabc7f31ca542b5b772cb8a55e7a79",
+                "sha256:3d25b540148f1ebf4852e4115f3f4819b585ecd36f121a1f388e8966d69d3a1c",
+                "sha256:3f29f6d455388cc415fe52c0f63f442aaea674cee35a2252d8d4dc8d640938c6",
+                "sha256:4167f22b037e128820f7642ecc1fbf1b4b4956346093a2e75081bee82b9cfb7e",
+                "sha256:44b26872fd63f1eaf1ab527817aebbd455a3fdcbd56ff6df74fd42a6a137cff4",
+                "sha256:48b99c55fc643b32f5efca9c35fcaac6ea553958cf503e202c10eb62718e7a0e",
+                "sha256:58ca818554c1476fa1456f6cd4b87002e2294f09baf0f81e5a2a4968e62c423c",
+                "sha256:5b3c0c84187556d463626ceed85f0d735a5b8ea1678da3e858d3934f38f23915",
+                "sha256:5d2edbb50025a67f061d09d381c54c7d0948c1572f6c9bd15ee238a303d368d9",
+                "sha256:635b1d7fa85d215112f41d089bd113ac139f6a42769fcc49c73e779904160f7f",
+                "sha256:7291392bdb1d38c44557dfd3fcd4fd04c363a696dbfa7e6592700a31e4ff6657",
+                "sha256:7709bc8a5e30c74b07203553f33232531e7739458f72204908cedb08a00bd546",
+                "sha256:7943ede91d8aedfcacb7178b2d881b7498145590206ff61c3e84dc66e6a51d6a",
+                "sha256:80903d4ce7337921bbc8e5ac695b45691b43c0a00b21964c76e19ea21b9108ea",
+                "sha256:82034c9ed54db20f051133cba01de959b5208fe2900e67ebb4c9631f1fd523fd",
+                "sha256:85c5de6c56335b75beef2cba713f95a1b62422be5e27dad30b5083419c6839c4",
+                "sha256:8b7e930a60dfe7380e52466aa27941290dd575a5750c622158c86941797eaa1b",
+                "sha256:8f90deec6567a38e1da29feff36973468691e309b2db8235e64936e61df77c43",
+                "sha256:922ae5b1efa1f9a9cc959f7197113a623ad110853622e990433242a9d8d00d5c",
+                "sha256:99b5412a3eddb1aa9aaf36cdbf93be4eca99ad83ff8c692672fdeedc7fb597de",
+                "sha256:9d0311fcd78dabe04ab3b4034659628b00ac220e77e37648f73aebbf4cb13680",
+                "sha256:ade1c356acd0b0454a3d3cf42442afe7ad0f46fc944ea1e84720b3858bfdb772",
+                "sha256:b5c2edb8b0a2acc5bdac984b3177711f206463b970aa03087221771c2b0d8f1d",
+                "sha256:b94f13f4f946500f3cc78f11da4ec4b340bd92c5200b5fe4e6aeac96064aa1fd",
+                "sha256:bcd1e9f3ba8df23edefe1d0a886f16b4e27602acbd8575b39540fea26e1aa6d2",
+                "sha256:bdbc195231c87d63b0503785d9c5264f4275a92da41d9f28fdf08fb321453356",
+                "sha256:bde4d39997de901d0a66ebd631b34f9cf106676fec0878f36b7baf630cb3965a",
+                "sha256:be93004b832717234a7d2f47dc555428ab1e8712f99cad7d212cebe0e27d3d48",
+                "sha256:bf360465dc3d24b1501b799c85815c82ddcfc0ffbcba0232968f3a7cd64306fc",
+                "sha256:cb4feeb8881eb89b9ddd0fae797deb078ebdaad6b1ae6c185b9993d241ed365a",
+                "sha256:cba4b6d174b524623ac8b64bda734601d574f95033f87ddf9c495c69a70135e8",
+                "sha256:d1859d54837af16ae2a7975477e619793ac698a374d909f533e317c3b384b223",
+                "sha256:df8d1ebdef86bd5d772d81c91d5d111a5ee8e4b68b8fc6b6edfa5aa825dd2a3d",
+                "sha256:e0fc170c3a00ca008d992c2e6324da3f1467b30044b5835d2feb27870645d38c",
+                "sha256:e296b0dee072a54c40c04f09ca35bb9902bb74b54f0fffeafabfc937b3ec85f9",
+                "sha256:e37b25182e969212d5aec60a8da7d1e6a960dbffdb9ba4c63e2240de3605c184",
+                "sha256:f01c59f5bad2e46bb4235b71b36c56be353f08b6d514a3bd0deb9bf56e4b180a",
+                "sha256:fabee25186b6649bbf6ff258f23941339902374786f8317b0422144ddaa505df",
+                "sha256:fb3c9760598009b1d8bbe57785e278aeb956efb7372d8f9b0bb43cd46f420dff",
+                "sha256:fc03a399205268815742125b17d967afa9f23b08cdafe185e41368cf7ba9b278",
+                "sha256:fca7d0fb6fde33d1ac5f97298f44e711e5fe1b4587832864be8c6545cb072a54"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
         }
     },
     "develop": {}

--- a/scripts/release_manager/main.py
+++ b/scripts/release_manager/main.py
@@ -119,7 +119,7 @@ def create_pr(env, version, package_dir, package_storage_path):
     res = subprocess.Popen(['hub', 'pull-request',
                             '-m', '[{}] Endpoint package version {}'.format(env, version),
                             '-m', 'Releasing new endpoint package',
-                            '-m', 'endpoint/{} directory sha1 hash: {}'.format(version, dir_hash),
+                            '-m', 'endpoint/{} directory signature: {}'.format(version, dir_hash),
                             '-b', 'elastic:{}'.format(env), '-d'], cwd=package_storage_path,
                            stderr=subprocess.PIPE, stdout=subprocess.PIPE)
     stdout = res.stdout.read()

--- a/scripts/release_manager/main.py
+++ b/scripts/release_manager/main.py
@@ -119,7 +119,7 @@ def create_pr(env, version, package_dir, package_storage_path):
     res = subprocess.Popen(['hub', 'pull-request',
                             '-m', '[{}] Endpoint package version {}'.format(env, version),
                             '-m', 'Releasing new endpoint package',
-                            '-m', 'endpoint/{} sha1 hash: {}'.format(version, dir_hash),
+                            '-m', 'endpoint/{} directory sha1 hash: {}'.format(version, dir_hash),
                             '-b', 'elastic:{}'.format(env), '-d'], cwd=package_storage_path,
                            stderr=subprocess.PIPE, stdout=subprocess.PIPE)
     stdout = res.stdout.read()


### PR DESCRIPTION
This PR improves the package release script by:

- Calculating a xxhash (using xxhash for speed) of the endpoint package directory to include in the PR
  - This will help with simple verification when using the `elastic-package promote` script to ensure that the package is the same as it is promoted to a new environment
- Adding functionality for creating the new release branch (7.10, 7.11, etc) after releasing a package

https://github.com/elastic/package-storage/pull/476
![image](https://user-images.githubusercontent.com/56361221/96040943-139e5380-0e39-11eb-9e64-03c8451f00fb.png)

![image](https://user-images.githubusercontent.com/56361221/96041161-5fe99380-0e39-11eb-99a1-ba99942a03c9.png)

```
Is this a dev or prod release? (dev, prod) [dev]: prod
Current package version: 0.17.0-dev.0
Which upstream branch should we release from? (7.10, 7.9, master, master_test) [master]: master_test
Preparing for a release, removing the build number
Version: 0.17.0
Tagging endpoint version: v0.17.0
Copying package to: /Users/jbuttner/proj/es/package-storage/packages/endpoint/0.17.0
Endpoint package directory hash: b32d2745739c79f9
Creating PR to package-storage repo
https://github.com/elastic/package-storage/pull/476

Current version is: 0.17.0
Bumping the patch version because the base release branch was not master
New version: 0.17.1-dev.0
Pushing changes to upstream
Should we create a branch to track this release? [y/N]: y
What should the release branch name be?: fake_7.11
New version: 0.17.1-dev.0
Pushing changes to upstream
```