### PR TITLE
Update .backportrc.json during release

### DIFF
--- a/scripts/release_manager/main.py
+++ b/scripts/release_manager/main.py
@@ -206,8 +206,8 @@ def get_release_branch(repo):
 def update_backport(repo, release_branch, upstream_branch):
     # backporting only applies to commits that go to master so if the original release
     # was not targeting master then don't add anything to the .backportrc.json file
-    #if upstream_branch != 'master':
-    #    return
+    if upstream_branch != 'master':
+        return
 
     click.echo('Updating .backportrc.json file')
     branch_name = 'update-backport'
@@ -218,6 +218,7 @@ def update_backport(repo, release_branch, upstream_branch):
     data['targetBranchChoices'].append(release_branch)
     with open(BACKPORT_FILE, 'w') as f:
         json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
 
     repo.index.add([BACKPORT_FILE])
     repo.index.commit("adding {} to backport file".format(release_branch))


### PR DESCRIPTION
This PR will update the `.backportrc.json` file during a release off of the `master` branch (since backporting only applies from master to other release branches).

![image](https://user-images.githubusercontent.com/56361221/96264454-3001d380-0f92-11eb-8692-0c4d4690cd52.png)
