### PR TITLE
[7.10] Add file.extension and process.args_count to file events mapping (#97)

### DIFF
--- a/custom_subsets/elastic_endpoint/file/file.yaml
+++ b/custom_subsets/elastic_endpoint/file/file.yaml
@@ -79,6 +79,7 @@ fields:
               name: {}
   process:
     fields:
+      args_count: {}
       pid: {}
       name: {}
       executable: {}
@@ -104,6 +105,7 @@ fields:
           md5: {}
           sha1: {}
           sha256: {}
+      extension: {}
       Ext:
         fields:
           windows:

--- a/generated/file/ecs/ecs_flat.yml
+++ b/generated/file/ecs/ecs_flat.yml
@@ -858,6 +858,17 @@ file.Ext.windows.zone_identifier:
   normalize: []
   short: Windows zone identifier for a file
   type: keyword
+file.extension:
+  dashed_name: file-extension
+  description: File extension.
+  example: png
+  flat_name: file.extension
+  ignore_above: 1024
+  level: extended
+  name: extension
+  normalize: []
+  short: File extension.
+  type: keyword
 file.gid:
   dashed_name: file-gid
   description: Primary group ID (GID) of the file.
@@ -1272,6 +1283,20 @@ process.Ext.ancestry:
   normalize: []
   short: An array of entity_ids indicating the ancestors for this event
   type: keyword
+process.args_count:
+  dashed_name: process-args-count
+  description: 'Length of the process.args array.
+
+    This field can be useful for querying or performing bucket analysis on how many
+    arguments were provided to start a process. More arguments may be an indication
+    of suspicious activity.'
+  example: 4
+  flat_name: process.args_count
+  level: extended
+  name: args_count
+  normalize: []
+  short: Length of the process.args array.
+  type: long
 process.entity_id:
   dashed_name: process-entity-id
   description: 'Unique identifier for the process.

--- a/generated/file/ecs/subset/file/ecs_flat.yml
+++ b/generated/file/ecs/subset/file/ecs_flat.yml
@@ -828,6 +828,17 @@ file.Ext.windows.zone_identifier:
   normalize: []
   short: Windows zone identifier for a file
   type: keyword
+file.extension:
+  dashed_name: file-extension
+  description: File extension.
+  example: png
+  flat_name: file.extension
+  ignore_above: 1024
+  level: extended
+  name: extension
+  normalize: []
+  short: File extension.
+  type: keyword
 file.gid:
   dashed_name: file-gid
   description: Primary group ID (GID) of the file.
@@ -1242,6 +1253,20 @@ process.Ext.ancestry:
   normalize: []
   short: An array of entity_ids indicating the ancestors for this event
   type: keyword
+process.args_count:
+  dashed_name: process-args-count
+  description: 'Length of the process.args array.
+
+    This field can be useful for querying or performing bucket analysis on how many
+    arguments were provided to start a process. More arguments may be an indication
+    of suspicious activity.'
+  example: 4
+  flat_name: process.args_count
+  level: extended
+  name: args_count
+  normalize: []
+  short: Length of the process.args array.
+  type: long
 process.entity_id:
   dashed_name: process-entity-id
   description: 'Unique identifier for the process.

--- a/generated/file/elasticsearch/7/template.json
+++ b/generated/file/elasticsearch/7/template.json
@@ -206,6 +206,10 @@
             },
             "type": "object"
           },
+          "extension": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "gid": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -397,6 +401,9 @@
               }
             },
             "type": "object"
+          },
+          "args_count": {
+            "type": "long"
           },
           "entity_id": {
             "ignore_above": 1024,

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -347,6 +347,12 @@
       ignore_above: 1024
       description: Windows zone identifier for a file
       default_field: false
+    - name: extension
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: File extension.
+      example: png
     - name: gid
       level: extended
       type: keyword
@@ -590,6 +596,14 @@
       type: keyword
       ignore_above: 1024
       description: An array of entity_ids indicating the ancestors for this event
+      default_field: false
+    - name: args_count
+      level: extended
+      type: long
+      description: 'Length of the process.args array.
+
+        This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.'
+      example: 4
       default_field: false
     - name: entity_id
       level: extended

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -540,6 +540,7 @@ sent by the endpoint.
 | file.Ext.original.uid | The user ID (UID) or security identifier (SID) of the file owner. | keyword |
 | file.Ext.windows | Platform-specific Windows fields | object |
 | file.Ext.windows.zone_identifier | Windows zone identifier for a file | keyword |
+| file.extension | File extension. | keyword |
 | file.gid | Primary group ID (GID) of the file. | keyword |
 | file.group | Primary group name of the file. | keyword |
 | file.hash.md5 | MD5 hash. | keyword |
@@ -574,6 +575,7 @@ sent by the endpoint.
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 | process.Ext | Object for all custom defined fields to live in. | object |
 | process.Ext.ancestry | An array of entity_ids indicating the ancestors for this event | keyword |
+| process.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
 | process.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
 | process.name | Process name. Sometimes called program name or similar. | keyword |

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -828,6 +828,17 @@ file.Ext.windows.zone_identifier:
   normalize: []
   short: Windows zone identifier for a file
   type: keyword
+file.extension:
+  dashed_name: file-extension
+  description: File extension.
+  example: png
+  flat_name: file.extension
+  ignore_above: 1024
+  level: extended
+  name: extension
+  normalize: []
+  short: File extension.
+  type: keyword
 file.gid:
   dashed_name: file-gid
   description: Primary group ID (GID) of the file.
@@ -1242,6 +1253,20 @@ process.Ext.ancestry:
   normalize: []
   short: An array of entity_ids indicating the ancestors for this event
   type: keyword
+process.args_count:
+  dashed_name: process-args-count
+  description: 'Length of the process.args array.
+
+    This field can be useful for querying or performing bucket analysis on how many
+    arguments were provided to start a process. More arguments may be an indication
+    of suspicious activity.'
+  example: 4
+  flat_name: process.args_count
+  level: extended
+  name: args_count
+  normalize: []
+  short: Length of the process.args array.
+  type: long
 process.entity_id:
   dashed_name: process-entity-id
   description: 'Unique identifier for the process.


### PR DESCRIPTION
Backports the following commits to 7.10:
 - Add file.extension and process.args_count to file events mapping (#97)