### PR TITLE
Align alerts and events mapping

### DIFF
--- a/custom_subsets/elastic_endpoint/file/file.yaml
+++ b/custom_subsets/elastic_endpoint/file/file.yaml
@@ -21,20 +21,23 @@ fields:
         fields: "*"
   host:
     fields:
-      name: {}
+      architecture: {}
+      domain: {}
       hostname: {}
+      id: {}
       ip: {}
       mac: {}
-      architecture: {}
-      id: {}
+      name: {}
+      type: {}
+      uptime: {}
       os:
         fields:
+          family: {}
+          full: {}
+          kernel: {}
           platform: {}
           version: {}
-          family: {}
           name: {}
-          kernel: {}
-          full: {}
           Ext:
             fields:
               variant: {}
@@ -43,14 +46,18 @@ fields:
       action: {}
       category: {}
       created: {}
+      code: {}
       dataset: {}
+      hash: {}
       id: {}
+      ingested: {}
       kind: {}
       module: {}
       outcome: {}
+      provider: {}
       sequence: {}
+      severity: {}
       type: {}
-      ingested: {}
   agent:
     fields:
       version: {}
@@ -58,6 +65,7 @@ fields:
       id: {}
   group:
     fields:
+      domain: {}
       id: {}
       name: {}
       Ext:
@@ -68,9 +76,23 @@ fields:
               name: {}
   user:
     fields:
+      domain: {}
+      email: {}
+      full_name: {}
+      hash: {}
       id: {}
       name: {}
-      domain: {}
+      group:
+        fields:
+          domain: {}
+          id: {}
+          name: {}
+          Ext:
+            fields:
+              real:
+                fields:
+                  id: {}
+                  name: {}
       Ext:
         fields:
           real:
@@ -92,12 +114,14 @@ fields:
           ancestry: {}
   file:
     fields:
-      name: {}
-      path: {}
-      mode: {}
-      inode: {}
-      uid: {}
-      owner: {}
+      accessed: {}
+      attributes: {}
+      created: {}
+      ctime: {}
+      device: {}
+      directory: {}
+      drive_letter: {}
+      extension: {}
       gid: {}
       group: {}
       hash:
@@ -105,7 +129,25 @@ fields:
           md5: {}
           sha1: {}
           sha256: {}
-      extension: {}
+          sha512: {}
+      inode: {}
+      mime_type: {}
+      mode: {}
+      mtime: {}
+      name: {}
+      owner: {}
+      path: {}
+      pe:
+        fields:
+          company: {}
+          description: {}
+          file_version: {}
+          original_file_name: {}
+          product: {}
+      size: {}
+      target_path: {}
+      type: {}
+      uid: {}
       Ext:
         fields:
           windows:

--- a/custom_subsets/elastic_endpoint/library/library.yaml
+++ b/custom_subsets/elastic_endpoint/library/library.yaml
@@ -21,20 +21,23 @@ fields:
         fields: "*"
   host:
     fields:
-      name: {}
+      architecture: {}
+      domain: {}
       hostname: {}
+      id: {}
       ip: {}
       mac: {}
-      architecture: {}
-      id: {}
+      name: {}
+      type: {}
+      uptime: {}
       os:
         fields:
+          family: {}
+          full: {}
+          kernel: {}
           platform: {}
           version: {}
-          family: {}
           name: {}
-          kernel: {}
-          full: {}
           Ext:
             fields:
               variant: {}
@@ -43,13 +46,18 @@ fields:
       action: {}
       category: {}
       created: {}
+      code: {}
       dataset: {}
+      hash: {}
       id: {}
+      ingested: {}
       kind: {}
       module: {}
+      outcome: {}
+      provider: {}
       sequence: {}
+      severity: {}
       type: {}
-      ingested: {}
   agent:
     fields:
       version: {}
@@ -57,6 +65,7 @@ fields:
       id: {}
   group:
     fields:
+      domain: {}
       id: {}
       name: {}
       Ext:
@@ -67,9 +76,23 @@ fields:
               name: {}
   user:
     fields:
+      domain: {}
+      email: {}
+      full_name: {}
+      hash: {}
       id: {}
       name: {}
-      domain: {}
+      group:
+        fields:
+          domain: {}
+          id: {}
+          name: {}
+          Ext:
+            fields:
+              real:
+                fields:
+                  id: {}
+                  name: {}
       Ext:
         fields:
           real:
@@ -92,8 +115,10 @@ fields:
     fields:
       pe:
         fields:
-          original_file_name: {}
+          company: {}
+          description: {}
           file_version: {}
+          original_file_name: {}
           product: {}
       name: {}
       path: {}
@@ -102,22 +127,31 @@ fields:
           md5: {}
           sha1: {}
           sha256: {}
+          sha512: {}
       Ext:
         fields:
           code_signature:
             fields:
-              subject_name: {}
+              exists: {}
               status: {}
+              subject_name: {}
+              trusted: {}
+              valid: {}
   dll:
     fields:
       pe:
         fields:
-          original_file_name: {}
+          company: {}
+          description: {}
           file_version: {}
+          original_file_name: {}
           product: {}
       Ext:
         fields:
           code_signature:
             fields:
-              subject_name: {}
+              exists: {}
               status: {}
+              subject_name: {}
+              trusted: {}
+              valid: {}

--- a/custom_subsets/elastic_endpoint/metrics/metrics.yaml
+++ b/custom_subsets/elastic_endpoint/metrics/metrics.yaml
@@ -21,34 +21,42 @@ fields:
         fields: "*"
   host:
     fields:
-      name: {}
+      architecture: {}
+      domain: {}
       hostname: {}
+      id: {}
       ip: {}
       mac: {}
-      architecture: {}
-      id: {}
+      name: {}
+      type: {}
+      uptime: {}
       os:
         fields:
+          family: {}
+          full: {}
+          kernel: {}
           platform: {}
           version: {}
-          family: {}
           name: {}
-          kernel: {}
-          full: {}
           Ext:
             fields:
               variant: {}
   event:
     fields:
-      start: {}
-      end: {}
       action: {}
       category: {}
       created: {}
+      code: {}
       dataset: {}
+      end: {}
+      hash: {}
       id: {}
+      ingested: {}
       kind: {}
       module: {}
+      outcome: {}
+      provider: {}
       sequence: {}
+      severity: {}
+      start: {}
       type: {}
-      ingested: {}

--- a/custom_subsets/elastic_endpoint/network/network.yaml
+++ b/custom_subsets/elastic_endpoint/network/network.yaml
@@ -12,20 +12,23 @@ fields:
       version: {}
   host:
     fields:
-      name: {}
+      architecture: {}
+      domain: {}
       hostname: {}
+      id: {}
       ip: {}
       mac: {}
-      architecture: {}
-      id: {}
+      name: {}
+      type: {}
+      uptime: {}
       os:
         fields:
+          family: {}
+          full: {}
+          kernel: {}
           platform: {}
           version: {}
-          family: {}
           name: {}
-          kernel: {}
-          full: {}
           Ext:
             fields:
               variant: {}
@@ -34,13 +37,18 @@ fields:
       action: {}
       category: {}
       created: {}
+      code: {}
       dataset: {}
+      hash: {}
       id: {}
+      ingested: {}
       kind: {}
       module: {}
+      outcome: {}
+      provider: {}
       sequence: {}
+      severity: {}
       type: {}
-      ingested: {}
   agent:
     fields:
       version: {}
@@ -48,6 +56,7 @@ fields:
       id: {}
   group:
     fields:
+      domain: {}
       id: {}
       name: {}
       Ext:
@@ -58,9 +67,23 @@ fields:
               name: {}
   user:
     fields:
+      domain: {}
+      email: {}
+      full_name: {}
+      hash: {}
       id: {}
       name: {}
-      domain: {}
+      group:
+        fields:
+          domain: {}
+          id: {}
+          name: {}
+          Ext:
+            fields:
+              real:
+                fields:
+                  id: {}
+                  name: {}
       Ext:
         fields:
           real:

--- a/custom_subsets/elastic_endpoint/policy/policy.yaml
+++ b/custom_subsets/elastic_endpoint/policy/policy.yaml
@@ -23,16 +23,21 @@ fields:
             fields: "*"
   event:
     fields:
-      id: {}
-      kind: {}
-      created: {}
-      category: {}
-      type: {}
-      module: {}
       action: {}
+      category: {}
+      created: {}
+      code: {}
       dataset: {}
+      hash: {}
+      id: {}
       ingested: {}
+      kind: {}
+      module: {}
+      outcome: {}
+      provider: {}
       sequence: {}
+      severity: {}
+      type: {}
   host:
     fields:
       id: {}

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -21,20 +21,23 @@ fields:
         fields: "*"
   host:
     fields:
-      name: {}
+      architecture: {}
+      domain: {}
       hostname: {}
+      id: {}
       ip: {}
       mac: {}
-      architecture: {}
-      id: {}
+      name: {}
+      type: {}
+      uptime: {}
       os:
         fields:
+          family: {}
+          full: {}
+          kernel: {}
           platform: {}
           version: {}
-          family: {}
           name: {}
-          kernel: {}
-          full: {}
           Ext:
             fields:
               variant: {}
@@ -43,13 +46,18 @@ fields:
       action: {}
       category: {}
       created: {}
+      code: {}
       dataset: {}
+      hash: {}
       id: {}
+      ingested: {}
       kind: {}
       module: {}
+      outcome: {}
+      provider: {}
       sequence: {}
+      severity: {}
       type: {}
-      ingested: {}
   agent:
     fields:
       version: {}
@@ -57,6 +65,7 @@ fields:
       id: {}
   group:
     fields:
+      domain: {}
       id: {}
       name: {}
       Ext:
@@ -67,9 +76,23 @@ fields:
               name: {}
   user:
     fields:
+      domain: {}
+      email: {}
+      full_name: {}
+      hash: {}
       id: {}
       name: {}
-      domain: {}
+      group:
+        fields:
+          domain: {}
+          id: {}
+          name: {}
+          Ext:
+            fields:
+              real:
+                fields:
+                  id: {}
+                  name: {}
       Ext:
         fields:
           real:
@@ -78,49 +101,111 @@ fields:
               name: {}
   process:
     fields:
-      entity_id: {}
-      pe:
-        fields:
-          original_file_name: {}
-      pid: {}
-      name: {}
-      executable: {}
       args: {}
-      command_line: {}
-      exit_code: {}
-      thread:
+      args_count: {}
+      code_signature:
         fields:
-          id: {}
+          exists: {}
+          status: {}
+          subject_name: {}
+          trusted: {}
+          valid: {}
+      command_line: {}
+      entity_id: {}
+      executable: {}
+      exit_code: {}
       hash:
         fields:
           md5: {}
           sha1: {}
           sha256: {}
-      parent:
+          sha512: {}
+      name: {}
+      pe:
         fields:
-          entity_id: {}
-          pid: {}
+          company: {}
+          description: {}
+          file_version: {}
+          original_file_name: {}
+          product: {}
+      pgid: {}
+      pid: {}
+      ppid: {}
+      thread:
+        fields:
+          id: {}
           name: {}
-          executable: {}
-          Ext:
-            fields:
-              real:
-                fields:
-                  pid: {}
+      title: {}
+      uptime: {}
+      working_directory: {}
       Ext:
         fields:
           ancestry: {}
           authentication_id: {}
           code_signature:
             fields:
-              subject_name: {}
+              exists: {}
               status: {}
+              subject_name: {}
+              trusted: {}
+              valid: {}
           session: {}
           token:
             fields:
               elevation: {}
               elevation_type: {}
               integrity_level_name: {}
+      parent:
+        fields:
+          args: {}
+          args_count: {}
+          code_signature:
+            fields:
+              exists: {}
+              status: {}
+              subject_name: {}
+              trusted: {}
+              valid: {}
+          command_line: {}
+          entity_id: {}
+          executable: {}
+          exit_code: {}
+          hash:
+            fields:
+              md5: {}
+              sha1: {}
+              sha256: {}
+              sha512: {}
+          name: {}
+          pe:
+            fields:
+              company: {}
+              description: {}
+              file_version: {}
+              original_file_name: {}
+              product: {}
+          pgid: {}
+          pid: {}
+          ppid: {}
+          thread:
+            fields:
+              id: {}
+              name: {}
+          title: {}
+          uptime: {}
+          working_directory: {}
+          Ext:
+            fields:
+              real:
+                fields:
+                  pid: {}
+              code_signature:
+                fields:
+                  exists: {}
+                  status: {}
+                  subject_name: {}
+                  trusted: {}
+                  valid: {}
   package:
     fields:
       name: {}

--- a/custom_subsets/elastic_endpoint/registry/registry.yaml
+++ b/custom_subsets/elastic_endpoint/registry/registry.yaml
@@ -21,20 +21,23 @@ fields:
         fields: "*"
   host:
     fields:
-      name: {}
+      architecture: {}
+      domain: {}
       hostname: {}
+      id: {}
       ip: {}
       mac: {}
-      architecture: {}
-      id: {}
+      name: {}
+      type: {}
+      uptime: {}
       os:
         fields:
+          family: {}
+          full: {}
+          kernel: {}
           platform: {}
           version: {}
-          family: {}
           name: {}
-          kernel: {}
-          full: {}
           Ext:
             fields:
               variant: {}
@@ -43,13 +46,18 @@ fields:
       action: {}
       category: {}
       created: {}
+      code: {}
       dataset: {}
+      hash: {}
       id: {}
+      ingested: {}
       kind: {}
       module: {}
+      outcome: {}
+      provider: {}
       sequence: {}
+      severity: {}
       type: {}
-      ingested: {}
   agent:
     fields:
       version: {}
@@ -57,6 +65,7 @@ fields:
       id: {}
   group:
     fields:
+      domain: {}
       id: {}
       name: {}
       Ext:
@@ -67,9 +76,23 @@ fields:
               name: {}
   user:
     fields:
+      domain: {}
+      email: {}
+      full_name: {}
+      hash: {}
       id: {}
       name: {}
-      domain: {}
+      group:
+        fields:
+          domain: {}
+          id: {}
+          name: {}
+          Ext:
+            fields:
+              real:
+                fields:
+                  id: {}
+                  name: {}
       Ext:
         fields:
           real:

--- a/custom_subsets/elastic_endpoint/security/security.yaml
+++ b/custom_subsets/elastic_endpoint/security/security.yaml
@@ -21,20 +21,23 @@ fields:
         fields: "*"
   host:
     fields:
-      name: {}
+      architecture: {}
+      domain: {}
       hostname: {}
+      id: {}
       ip: {}
       mac: {}
-      architecture: {}
-      id: {}
+      name: {}
+      type: {}
+      uptime: {}
       os:
         fields:
+          family: {}
+          full: {}
+          kernel: {}
           platform: {}
           version: {}
-          family: {}
           name: {}
-          kernel: {}
-          full: {}
           Ext:
             fields:
               variant: {}
@@ -43,13 +46,18 @@ fields:
       action: {}
       category: {}
       created: {}
+      code: {}
       dataset: {}
+      hash: {}
       id: {}
+      ingested: {}
       kind: {}
       module: {}
+      outcome: {}
+      provider: {}
       sequence: {}
+      severity: {}
       type: {}
-      ingested: {}
   agent:
     fields:
       version: {}
@@ -57,6 +65,7 @@ fields:
       id: {}
   group:
     fields:
+      domain: {}
       id: {}
       name: {}
       Ext:
@@ -67,9 +76,23 @@ fields:
               name: {}
   user:
     fields:
+      domain: {}
+      email: {}
+      full_name: {}
+      hash: {}
       id: {}
       name: {}
-      domain: {}
+      group:
+        fields:
+          domain: {}
+          id: {}
+          name: {}
+          Ext:
+            fields:
+              real:
+                fields:
+                  id: {}
+                  name: {}
       Ext:
         fields:
           real:

--- a/generated/file/ecs/ecs_flat.yml
+++ b/generated/file/ecs/ecs_flat.yml
@@ -400,6 +400,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -437,6 +452,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -595,6 +623,21 @@ event.outcome:
   normalize: []
   short: The outcome of the event. The lowest level categorization field in the hierarchy.
   type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -607,6 +650,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -858,6 +921,93 @@ file.Ext.windows.zone_identifier:
   normalize: []
   short: Windows zone identifier for a file
   type: keyword
+file.accessed:
+  dashed_name: file-accessed
+  description: 'Last time the file was accessed.
+
+    Note that not all filesystems keep track of access time.'
+  flat_name: file.accessed
+  level: extended
+  name: accessed
+  normalize: []
+  short: Last time the file was accessed.
+  type: date
+file.attributes:
+  dashed_name: file-attributes
+  description: 'Array of file attributes.
+
+    Attributes names will vary by platform. Here''s a non-exhaustive list of values
+    that are expected in this field: archive, compressed, directory, encrypted, execute,
+    hidden, read, readonly, system, write.'
+  example: '["readonly", "system"]'
+  flat_name: file.attributes
+  ignore_above: 1024
+  level: extended
+  name: attributes
+  normalize:
+  - array
+  short: Array of file attributes.
+  type: keyword
+file.created:
+  dashed_name: file-created
+  description: 'File creation time.
+
+    Note that not all filesystems store the creation time.'
+  flat_name: file.created
+  level: extended
+  name: created
+  normalize: []
+  short: File creation time.
+  type: date
+file.ctime:
+  dashed_name: file-ctime
+  description: 'Last time the file attributes or metadata changed.
+
+    Note that changes to the file content will update `mtime`. This implies `ctime`
+    will be adjusted at the same time, since `mtime` is an attribute of the file.'
+  flat_name: file.ctime
+  level: extended
+  name: ctime
+  normalize: []
+  short: Last time the file attributes or metadata changed.
+  type: date
+file.device:
+  dashed_name: file-device
+  description: Device that is the source of the file.
+  example: sda
+  flat_name: file.device
+  ignore_above: 1024
+  level: extended
+  name: device
+  normalize: []
+  short: Device that is the source of the file.
+  type: keyword
+file.directory:
+  dashed_name: file-directory
+  description: Directory where the file is located. It should include the drive letter,
+    when appropriate.
+  example: /home/alice
+  flat_name: file.directory
+  ignore_above: 1024
+  level: extended
+  name: directory
+  normalize: []
+  short: Directory where the file is located.
+  type: keyword
+file.drive_letter:
+  dashed_name: file-drive-letter
+  description: 'Drive letter where the file is located. This field is only relevant
+    on Windows.
+
+    The value should be uppercase, and not include the colon.'
+  example: C
+  flat_name: file.drive_letter
+  ignore_above: 1
+  level: extended
+  name: drive_letter
+  normalize: []
+  short: Drive letter where the file is located.
+  type: keyword
 file.extension:
   dashed_name: file-extension
   description: File extension.
@@ -924,6 +1074,17 @@ file.hash.sha256:
   original_fieldset: hash
   short: SHA256 hash.
   type: keyword
+file.hash.sha512:
+  dashed_name: file-hash-sha512
+  description: SHA512 hash.
+  flat_name: file.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
 file.inode:
   dashed_name: file-inode
   description: Inode representing the file in the filesystem.
@@ -934,6 +1095,19 @@ file.inode:
   name: inode
   normalize: []
   short: Inode representing the file in the filesystem.
+  type: keyword
+file.mime_type:
+  dashed_name: file-mime-type
+  description: MIME type should identify the format of the file or stream of bytes
+    using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official
+    types], where possible. When more than one type is applicable, the most specific
+    type should be used.
+  flat_name: file.mime_type
+  ignore_above: 1024
+  level: extended
+  name: mime_type
+  normalize: []
+  short: Media type of file, document, or arrangement of bytes.
   type: keyword
 file.mode:
   dashed_name: file-mode
@@ -946,6 +1120,15 @@ file.mode:
   normalize: []
   short: Mode of the file in octal representation.
   type: keyword
+file.mtime:
+  dashed_name: file-mtime
+  description: Last time the file content was modified.
+  flat_name: file.mtime
+  level: extended
+  name: mtime
+  normalize: []
+  short: Last time the file content was modified.
+  type: date
 file.name:
   dashed_name: file-name
   description: Name of the file including the extension, without the directory.
@@ -989,6 +1172,109 @@ file.path:
   name: path
   normalize: []
   short: Full path to the file, including the file name.
+  type: keyword
+file.pe.company:
+  dashed_name: file-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: file.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+file.pe.description:
+  dashed_name: file-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: file.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+file.pe.file_version:
+  dashed_name: file-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: file.pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+file.pe.original_file_name:
+  dashed_name: file-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: file.pe.original_file_name
+  ignore_above: 1024
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: keyword
+file.pe.product:
+  dashed_name: file-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: file.pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+file.size:
+  dashed_name: file-size
+  description: 'File size in bytes.
+
+    Only relevant when `file.type` is "file".'
+  example: 16384
+  flat_name: file.size
+  level: extended
+  name: size
+  normalize: []
+  short: File size in bytes.
+  type: long
+file.target_path:
+  dashed_name: file-target-path
+  description: Target path for symlinks.
+  flat_name: file.target_path
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: file.target_path.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
+  - flat_name: file.target_path.text
+    name: text
+    norms: false
+    type: text
+  name: target_path
+  normalize: []
+  short: Target path for symlinks.
+  type: keyword
+file.type:
+  dashed_name: file-type
+  description: File type (file, dir, or symlink).
+  example: file
+  flat_name: file.type
+  ignore_above: 1024
+  level: extended
+  name: type
+  normalize: []
+  short: File type (file, dir, or symlink).
   type: keyword
 file.uid:
   dashed_name: file-uid
@@ -1039,6 +1325,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -1069,6 +1367,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -1247,6 +1559,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -1532,6 +1867,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/generated/file/ecs/subset/file/ecs_flat.yml
+++ b/generated/file/ecs/subset/file/ecs_flat.yml
@@ -370,6 +370,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -407,6 +422,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -565,6 +593,21 @@ event.outcome:
   normalize: []
   short: The outcome of the event. The lowest level categorization field in the hierarchy.
   type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -577,6 +620,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -828,6 +891,93 @@ file.Ext.windows.zone_identifier:
   normalize: []
   short: Windows zone identifier for a file
   type: keyword
+file.accessed:
+  dashed_name: file-accessed
+  description: 'Last time the file was accessed.
+
+    Note that not all filesystems keep track of access time.'
+  flat_name: file.accessed
+  level: extended
+  name: accessed
+  normalize: []
+  short: Last time the file was accessed.
+  type: date
+file.attributes:
+  dashed_name: file-attributes
+  description: 'Array of file attributes.
+
+    Attributes names will vary by platform. Here''s a non-exhaustive list of values
+    that are expected in this field: archive, compressed, directory, encrypted, execute,
+    hidden, read, readonly, system, write.'
+  example: '["readonly", "system"]'
+  flat_name: file.attributes
+  ignore_above: 1024
+  level: extended
+  name: attributes
+  normalize:
+  - array
+  short: Array of file attributes.
+  type: keyword
+file.created:
+  dashed_name: file-created
+  description: 'File creation time.
+
+    Note that not all filesystems store the creation time.'
+  flat_name: file.created
+  level: extended
+  name: created
+  normalize: []
+  short: File creation time.
+  type: date
+file.ctime:
+  dashed_name: file-ctime
+  description: 'Last time the file attributes or metadata changed.
+
+    Note that changes to the file content will update `mtime`. This implies `ctime`
+    will be adjusted at the same time, since `mtime` is an attribute of the file.'
+  flat_name: file.ctime
+  level: extended
+  name: ctime
+  normalize: []
+  short: Last time the file attributes or metadata changed.
+  type: date
+file.device:
+  dashed_name: file-device
+  description: Device that is the source of the file.
+  example: sda
+  flat_name: file.device
+  ignore_above: 1024
+  level: extended
+  name: device
+  normalize: []
+  short: Device that is the source of the file.
+  type: keyword
+file.directory:
+  dashed_name: file-directory
+  description: Directory where the file is located. It should include the drive letter,
+    when appropriate.
+  example: /home/alice
+  flat_name: file.directory
+  ignore_above: 1024
+  level: extended
+  name: directory
+  normalize: []
+  short: Directory where the file is located.
+  type: keyword
+file.drive_letter:
+  dashed_name: file-drive-letter
+  description: 'Drive letter where the file is located. This field is only relevant
+    on Windows.
+
+    The value should be uppercase, and not include the colon.'
+  example: C
+  flat_name: file.drive_letter
+  ignore_above: 1
+  level: extended
+  name: drive_letter
+  normalize: []
+  short: Drive letter where the file is located.
+  type: keyword
 file.extension:
   dashed_name: file-extension
   description: File extension.
@@ -894,6 +1044,17 @@ file.hash.sha256:
   original_fieldset: hash
   short: SHA256 hash.
   type: keyword
+file.hash.sha512:
+  dashed_name: file-hash-sha512
+  description: SHA512 hash.
+  flat_name: file.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
 file.inode:
   dashed_name: file-inode
   description: Inode representing the file in the filesystem.
@@ -904,6 +1065,19 @@ file.inode:
   name: inode
   normalize: []
   short: Inode representing the file in the filesystem.
+  type: keyword
+file.mime_type:
+  dashed_name: file-mime-type
+  description: MIME type should identify the format of the file or stream of bytes
+    using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official
+    types], where possible. When more than one type is applicable, the most specific
+    type should be used.
+  flat_name: file.mime_type
+  ignore_above: 1024
+  level: extended
+  name: mime_type
+  normalize: []
+  short: Media type of file, document, or arrangement of bytes.
   type: keyword
 file.mode:
   dashed_name: file-mode
@@ -916,6 +1090,15 @@ file.mode:
   normalize: []
   short: Mode of the file in octal representation.
   type: keyword
+file.mtime:
+  dashed_name: file-mtime
+  description: Last time the file content was modified.
+  flat_name: file.mtime
+  level: extended
+  name: mtime
+  normalize: []
+  short: Last time the file content was modified.
+  type: date
 file.name:
   dashed_name: file-name
   description: Name of the file including the extension, without the directory.
@@ -959,6 +1142,109 @@ file.path:
   name: path
   normalize: []
   short: Full path to the file, including the file name.
+  type: keyword
+file.pe.company:
+  dashed_name: file-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: file.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+file.pe.description:
+  dashed_name: file-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: file.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+file.pe.file_version:
+  dashed_name: file-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: file.pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+file.pe.original_file_name:
+  dashed_name: file-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: file.pe.original_file_name
+  ignore_above: 1024
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: keyword
+file.pe.product:
+  dashed_name: file-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: file.pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+file.size:
+  dashed_name: file-size
+  description: 'File size in bytes.
+
+    Only relevant when `file.type` is "file".'
+  example: 16384
+  flat_name: file.size
+  level: extended
+  name: size
+  normalize: []
+  short: File size in bytes.
+  type: long
+file.target_path:
+  dashed_name: file-target-path
+  description: Target path for symlinks.
+  flat_name: file.target_path
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: file.target_path.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
+  - flat_name: file.target_path.text
+    name: text
+    norms: false
+    type: text
+  name: target_path
+  normalize: []
+  short: Target path for symlinks.
+  type: keyword
+file.type:
+  dashed_name: file-type
+  description: File type (file, dir, or symlink).
+  example: file
+  flat_name: file.type
+  ignore_above: 1024
+  level: extended
+  name: type
+  normalize: []
+  short: File type (file, dir, or symlink).
   type: keyword
 file.uid:
   dashed_name: file-uid
@@ -1009,6 +1295,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -1039,6 +1337,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -1217,6 +1529,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -1502,6 +1837,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/generated/file/elasticsearch/7/template.json
+++ b/generated/file/elasticsearch/7/template.json
@@ -122,10 +122,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "code": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "created": {
             "type": "date"
           },
           "dataset": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "hash": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -148,7 +156,14 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "provider": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "sequence": {
+            "type": "long"
+          },
+          "severity": {
             "type": "long"
           },
           "type": {
@@ -206,6 +221,31 @@
             },
             "type": "object"
           },
+          "accessed": {
+            "type": "date"
+          },
+          "attributes": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "created": {
+            "type": "date"
+          },
+          "ctime": {
+            "type": "date"
+          },
+          "device": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "directory": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "drive_letter": {
+            "ignore_above": 1,
+            "type": "keyword"
+          },
           "extension": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -231,6 +271,10 @@
               "sha256": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "sha512": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -238,9 +282,16 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "mime_type": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "mode": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "mtime": {
+            "type": "date"
           },
           "name": {
             "ignore_above": 1024,
@@ -262,6 +313,52 @@
                 "type": "text"
               }
             },
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "pe": {
+            "properties": {
+              "company": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "description": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "file_version": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "original_file_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "product": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "size": {
+            "type": "long"
+          },
+          "target_path": {
+            "fields": {
+              "caseless": {
+                "ignore_above": 1024,
+                "normalizer": "lowercase",
+                "type": "keyword"
+              },
+              "text": {
+                "norms": false,
+                "type": "text"
+              }
+            },
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "type": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -291,6 +388,10 @@
             },
             "type": "object"
           },
+          "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "id": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -304,6 +405,10 @@
       "host": {
         "properties": {
           "architecture": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "domain": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -384,6 +489,13 @@
                 "type": "keyword"
               }
             }
+          },
+          "type": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "uptime": {
+            "type": "long"
           }
         }
       },
@@ -511,6 +623,58 @@
             "type": "object"
           },
           "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "email": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "full_name": {
+            "fields": {
+              "text": {
+                "norms": false,
+                "type": "text"
+              }
+            },
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "group": {
+            "properties": {
+              "Ext": {
+                "properties": {
+                  "real": {
+                    "properties": {
+                      "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "domain": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "hash": {
             "ignore_above": 1024,
             "type": "keyword"
           },

--- a/generated/library/ecs/ecs_flat.yml
+++ b/generated/library/ecs/ecs_flat.yml
@@ -202,6 +202,16 @@ dll.Ext.code_signature:
   normalize: []
   short: Nested version of ECS code_signature fieldset.
   type: nested
+dll.Ext.code_signature.exists:
+  dashed_name: dll-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: dll.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
 dll.Ext.code_signature.status:
   dashed_name: dll-Ext-code-signature-status
   description: 'Additional information about the certificate status.
@@ -227,6 +237,57 @@ dll.Ext.code_signature.subject_name:
   name: Ext.code_signature.subject_name
   normalize: []
   short: Subject name of the code signer
+  type: keyword
+dll.Ext.code_signature.trusted:
+  dashed_name: dll-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: dll.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+dll.Ext.code_signature.valid:
+  dashed_name: dll-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: dll.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
+dll.pe.company:
+  dashed_name: dll-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: dll.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+dll.pe.description:
+  dashed_name: dll-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: dll.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
   type: keyword
 dll.pe.file_version:
   dashed_name: dll-pe-file-version
@@ -450,6 +511,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -487,6 +563,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -602,6 +691,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -614,6 +761,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -772,6 +939,16 @@ file.Ext.code_signature:
   normalize: []
   short: Nested version of ECS code_signature fieldset.
   type: nested
+file.Ext.code_signature.exists:
+  dashed_name: file-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: file.Ext.code_signature.exists
+  level: core
+  name: Ext.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
 file.Ext.code_signature.status:
   dashed_name: file-Ext-code-signature-status
   description: 'Additional information about the certificate status.
@@ -798,6 +975,33 @@ file.Ext.code_signature.subject_name:
   normalize: []
   short: Subject name of the code signer
   type: keyword
+file.Ext.code_signature.trusted:
+  dashed_name: file-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: file.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+file.Ext.code_signature.valid:
+  dashed_name: file-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: file.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 file.hash.md5:
   dashed_name: file-hash-md5
   description: MD5 hash.
@@ -831,6 +1035,17 @@ file.hash.sha256:
   original_fieldset: hash
   short: SHA256 hash.
   type: keyword
+file.hash.sha512:
+  dashed_name: file-hash-sha512
+  description: SHA512 hash.
+  flat_name: file.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
 file.name:
   dashed_name: file-name
   description: Name of the file including the extension, without the directory.
@@ -863,6 +1078,30 @@ file.path:
   name: path
   normalize: []
   short: Full path to the file, including the file name.
+  type: keyword
+file.pe.company:
+  dashed_name: file-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: file.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+file.pe.description:
+  dashed_name: file-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: file.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
   type: keyword
 file.pe.file_version:
   dashed_name: file-pe-file-version
@@ -938,6 +1177,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -968,6 +1219,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -1146,6 +1411,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -1417,6 +1705,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/generated/library/ecs/subset/library/ecs_flat.yml
+++ b/generated/library/ecs/subset/library/ecs_flat.yml
@@ -202,6 +202,16 @@ dll.Ext.code_signature:
   normalize: []
   short: Nested version of ECS code_signature fieldset.
   type: nested
+dll.Ext.code_signature.exists:
+  dashed_name: dll-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: dll.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
 dll.Ext.code_signature.status:
   dashed_name: dll-Ext-code-signature-status
   description: 'Additional information about the certificate status.
@@ -227,6 +237,57 @@ dll.Ext.code_signature.subject_name:
   name: Ext.code_signature.subject_name
   normalize: []
   short: Subject name of the code signer
+  type: keyword
+dll.Ext.code_signature.trusted:
+  dashed_name: dll-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: dll.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+dll.Ext.code_signature.valid:
+  dashed_name: dll-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: dll.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
+dll.pe.company:
+  dashed_name: dll-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: dll.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+dll.pe.description:
+  dashed_name: dll-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: dll.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
   type: keyword
 dll.pe.file_version:
   dashed_name: dll-pe-file-version
@@ -450,6 +511,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -487,6 +563,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -602,6 +691,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -614,6 +761,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -772,6 +939,16 @@ file.Ext.code_signature:
   normalize: []
   short: Nested version of ECS code_signature fieldset.
   type: nested
+file.Ext.code_signature.exists:
+  dashed_name: file-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: file.Ext.code_signature.exists
+  level: core
+  name: Ext.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
 file.Ext.code_signature.status:
   dashed_name: file-Ext-code-signature-status
   description: 'Additional information about the certificate status.
@@ -798,6 +975,33 @@ file.Ext.code_signature.subject_name:
   normalize: []
   short: Subject name of the code signer
   type: keyword
+file.Ext.code_signature.trusted:
+  dashed_name: file-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: file.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+file.Ext.code_signature.valid:
+  dashed_name: file-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: file.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 file.hash.md5:
   dashed_name: file-hash-md5
   description: MD5 hash.
@@ -831,6 +1035,17 @@ file.hash.sha256:
   original_fieldset: hash
   short: SHA256 hash.
   type: keyword
+file.hash.sha512:
+  dashed_name: file-hash-sha512
+  description: SHA512 hash.
+  flat_name: file.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
 file.name:
   dashed_name: file-name
   description: Name of the file including the extension, without the directory.
@@ -863,6 +1078,30 @@ file.path:
   name: path
   normalize: []
   short: Full path to the file, including the file name.
+  type: keyword
+file.pe.company:
+  dashed_name: file-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: file.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+file.pe.description:
+  dashed_name: file-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: file.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
   type: keyword
 file.pe.file_version:
   dashed_name: file-pe-file-version
@@ -938,6 +1177,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -968,6 +1219,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -1146,6 +1411,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -1417,6 +1705,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/generated/library/elasticsearch/7/template.json
+++ b/generated/library/elasticsearch/7/template.json
@@ -96,6 +96,9 @@
             "properties": {
               "code_signature": {
                 "properties": {
+                  "exists": {
+                    "type": "boolean"
+                  },
                   "status": {
                     "ignore_above": 1024,
                     "type": "keyword"
@@ -103,6 +106,12 @@
                   "subject_name": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "trusted": {
+                    "type": "boolean"
+                  },
+                  "valid": {
+                    "type": "boolean"
                   }
                 },
                 "type": "nested"
@@ -112,6 +121,14 @@
           },
           "pe": {
             "properties": {
+              "company": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "description": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "file_version": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -146,10 +163,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "code": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "created": {
             "type": "date"
           },
           "dataset": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "hash": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -168,7 +193,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "outcome": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "provider": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "sequence": {
+            "type": "long"
+          },
+          "severity": {
             "type": "long"
           },
           "type": {
@@ -183,6 +219,9 @@
             "properties": {
               "code_signature": {
                 "properties": {
+                  "exists": {
+                    "type": "boolean"
+                  },
                   "status": {
                     "ignore_above": 1024,
                     "type": "keyword"
@@ -190,6 +229,12 @@
                   "subject_name": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "trusted": {
+                    "type": "boolean"
+                  },
+                  "valid": {
+                    "type": "boolean"
                   }
                 },
                 "type": "nested"
@@ -208,6 +253,10 @@
                 "type": "keyword"
               },
               "sha256": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "sha512": {
                 "ignore_above": 1024,
                 "type": "keyword"
               }
@@ -234,6 +283,14 @@
           },
           "pe": {
             "properties": {
+              "company": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "description": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "file_version": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -270,6 +327,10 @@
             },
             "type": "object"
           },
+          "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "id": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -283,6 +344,10 @@
       "host": {
         "properties": {
           "architecture": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "domain": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -363,6 +428,13 @@
                 "type": "keyword"
               }
             }
+          },
+          "type": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "uptime": {
+            "type": "long"
           }
         }
       },
@@ -487,6 +559,58 @@
             "type": "object"
           },
           "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "email": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "full_name": {
+            "fields": {
+              "text": {
+                "norms": false,
+                "type": "text"
+              }
+            },
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "group": {
+            "properties": {
+              "Ext": {
+                "properties": {
+                  "real": {
+                    "properties": {
+                      "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "domain": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "hash": {
             "ignore_above": 1024,
             "type": "keyword"
           },

--- a/generated/metrics/ecs/ecs_flat.yml
+++ b/generated/metrics/ecs/ecs_flat.yml
@@ -477,6 +477,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -526,6 +541,19 @@ event.end:
   short: event.end contains the date when the event ended or when the activity was
     last observed.
   type: date
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  type: keyword
 event.id:
   dashed_name: event-id
   description: Unique ID to describe the event.
@@ -640,6 +668,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -652,6 +738,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.start:
   dashed_name: event-start
@@ -813,6 +919,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -991,6 +1111,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized

--- a/generated/metrics/ecs/subset/metrics/ecs_flat.yml
+++ b/generated/metrics/ecs/subset/metrics/ecs_flat.yml
@@ -477,6 +477,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -526,6 +541,19 @@ event.end:
   short: event.end contains the date when the event ended or when the activity was
     last observed.
   type: date
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  type: keyword
 event.id:
   dashed_name: event-id
   description: Unique ID to describe the event.
@@ -640,6 +668,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -652,6 +738,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.start:
   dashed_name: event-start
@@ -813,6 +919,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -991,6 +1111,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized

--- a/generated/metrics/elasticsearch/7/template.json
+++ b/generated/metrics/elasticsearch/7/template.json
@@ -160,6 +160,10 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "code": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "created": {
             "type": "date"
           },
@@ -169,6 +173,10 @@
           },
           "end": {
             "type": "date"
+          },
+          "hash": {
+            "ignore_above": 1024,
+            "type": "keyword"
           },
           "id": {
             "ignore_above": 1024,
@@ -185,7 +193,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "outcome": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "provider": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "sequence": {
+            "type": "long"
+          },
+          "severity": {
             "type": "long"
           },
           "start": {
@@ -200,6 +219,10 @@
       "host": {
         "properties": {
           "architecture": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "domain": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -280,6 +303,13 @@
                 "type": "keyword"
               }
             }
+          },
+          "type": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "uptime": {
+            "type": "long"
           }
         }
       },

--- a/generated/network/ecs/ecs_flat.yml
+++ b/generated/network/ecs/ecs_flat.yml
@@ -592,6 +592,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -629,6 +644,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -744,6 +772,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -756,6 +842,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -934,6 +1040,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -964,6 +1082,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -1142,6 +1274,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 http.request.body.bytes:
   dashed_name: http-request-body-bytes
   description: Size in bytes of the request body.
@@ -1732,6 +1887,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/generated/network/ecs/subset/network/ecs_flat.yml
+++ b/generated/network/ecs/subset/network/ecs_flat.yml
@@ -592,6 +592,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -629,6 +644,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -744,6 +772,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -756,6 +842,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -934,6 +1040,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -964,6 +1082,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -1142,6 +1274,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 http.request.body.bytes:
   dashed_name: http-request-body-bytes
   description: Size in bytes of the request body.
@@ -1732,6 +1887,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/generated/network/elasticsearch/7/template.json
+++ b/generated/network/elasticsearch/7/template.json
@@ -179,10 +179,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "code": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "created": {
             "type": "date"
           },
           "dataset": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "hash": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -201,7 +209,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "outcome": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "provider": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "sequence": {
+            "type": "long"
+          },
+          "severity": {
             "type": "long"
           },
           "type": {
@@ -230,6 +249,10 @@
             },
             "type": "object"
           },
+          "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "id": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -243,6 +266,10 @@
       "host": {
         "properties": {
           "architecture": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "domain": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -323,6 +350,13 @@
                 "type": "keyword"
               }
             }
+          },
+          "type": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "uptime": {
+            "type": "long"
           }
         }
       },
@@ -573,6 +607,58 @@
             "type": "object"
           },
           "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "email": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "full_name": {
+            "fields": {
+              "text": {
+                "norms": false,
+                "type": "text"
+              }
+            },
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "group": {
+            "properties": {
+              "Ext": {
+                "properties": {
+                  "real": {
+                    "properties": {
+                      "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "domain": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "hash": {
             "ignore_above": 1024,
             "type": "keyword"
           },

--- a/generated/policy/ecs/ecs_flat.yml
+++ b/generated/policy/ecs/ecs_flat.yml
@@ -615,6 +615,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -652,6 +667,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -767,6 +795,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -779,6 +865,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:

--- a/generated/policy/ecs/subset/policy/ecs_flat.yml
+++ b/generated/policy/ecs/subset/policy/ecs_flat.yml
@@ -615,6 +615,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -652,6 +667,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -767,6 +795,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -779,6 +865,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:

--- a/generated/policy/elasticsearch/7/template.json
+++ b/generated/policy/elasticsearch/7/template.json
@@ -229,10 +229,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "code": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "created": {
             "type": "date"
           },
           "dataset": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "hash": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -251,7 +259,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "outcome": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "provider": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "sequence": {
+            "type": "long"
+          },
+          "severity": {
             "type": "long"
           },
           "type": {

--- a/generated/process/ecs/ecs_flat.yml
+++ b/generated/process/ecs/ecs_flat.yml
@@ -370,6 +370,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -407,6 +422,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -522,6 +550,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -534,6 +620,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -712,6 +818,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -742,6 +860,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -920,6 +1052,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -986,6 +1141,16 @@ process.Ext.code_signature:
   normalize: []
   short: Nested version of ECS code_signature fieldset.
   type: nested
+process.Ext.code_signature.exists:
+  dashed_name: process-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
 process.Ext.code_signature.status:
   dashed_name: process-Ext-code-signature-status
   description: 'Additional information about the certificate status.
@@ -1012,6 +1177,33 @@ process.Ext.code_signature.subject_name:
   normalize: []
   short: Subject name of the code signer
   type: keyword
+process.Ext.code_signature.trusted:
+  dashed_name: process-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.Ext.code_signature.valid:
+  dashed_name: process-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 process.Ext.session:
   dashed_name: process-Ext-session
   description: Session information for the current process
@@ -1075,6 +1267,88 @@ process.args:
   - array
   short: Array of process arguments.
   type: keyword
+process.args_count:
+  dashed_name: process-args-count
+  description: 'Length of the process.args array.
+
+    This field can be useful for querying or performing bucket analysis on how many
+    arguments were provided to start a process. More arguments may be an indication
+    of suspicious activity.'
+  example: 4
+  flat_name: process.args_count
+  level: extended
+  name: args_count
+  normalize: []
+  short: Length of the process.args array.
+  type: long
+process.code_signature.exists:
+  dashed_name: process-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.code_signature.exists
+  level: core
+  name: exists
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.code_signature.status:
+  dashed_name: process-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.code_signature.status
+  ignore_above: 1024
+  level: extended
+  name: status
+  normalize: []
+  original_fieldset: code_signature
+  short: Additional information about the certificate status.
+  type: keyword
+process.code_signature.subject_name:
+  dashed_name: process-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.code_signature.subject_name
+  ignore_above: 1024
+  level: core
+  name: subject_name
+  normalize: []
+  original_fieldset: code_signature
+  short: Subject name of the code signer
+  type: keyword
+process.code_signature.trusted:
+  dashed_name: process-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.code_signature.trusted
+  level: extended
+  name: trusted
+  normalize: []
+  original_fieldset: code_signature
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.code_signature.valid:
+  dashed_name: process-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.code_signature.valid
+  level: extended
+  name: valid
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 process.command_line:
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
@@ -1185,6 +1459,17 @@ process.hash.sha256:
   original_fieldset: hash
   short: SHA256 hash.
   type: keyword
+process.hash.sha512:
+  dashed_name: process-hash-sha512
+  description: SHA512 hash.
+  flat_name: process.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
 process.name:
   dashed_name: process-name
   description: 'Process name.
@@ -1218,6 +1503,84 @@ process.parent.Ext:
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
+process.parent.Ext.code_signature:
+  dashed_name: process-parent-Ext-code-signature
+  description: Nested version of ECS code_signature fieldset.
+  flat_name: process.parent.Ext.code_signature
+  level: custom
+  name: Ext.code_signature
+  normalize: []
+  original_fieldset: process
+  short: Nested version of ECS code_signature fieldset.
+  type: nested
+process.parent.Ext.code_signature.exists:
+  dashed_name: process-parent-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.parent.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  original_fieldset: process
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.parent.Ext.code_signature.status:
+  dashed_name: process-parent-Ext-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.parent.Ext.code_signature.status
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.status
+  normalize: []
+  original_fieldset: process
+  short: Additional information about the certificate status.
+  type: keyword
+process.parent.Ext.code_signature.subject_name:
+  dashed_name: process-parent-Ext-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.parent.Ext.code_signature.subject_name
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.subject_name
+  normalize: []
+  original_fieldset: process
+  short: Subject name of the code signer
+  type: keyword
+process.parent.Ext.code_signature.trusted:
+  dashed_name: process-parent-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.parent.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  original_fieldset: process
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.parent.Ext.code_signature.valid:
+  dashed_name: process-parent-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.parent.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  original_fieldset: process
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
   description: The field set containing process info in case of any pid spoofing.
@@ -1241,6 +1604,134 @@ process.parent.Ext.real.pid:
   original_fieldset: process
   short: The real pid of the process if ppid spoofing is happening.
   type: long
+process.parent.args:
+  dashed_name: process-parent-args
+  description: 'Array of process arguments, starting with the absolute path to the
+    executable.
+
+    May be filtered to protect sensitive information.'
+  example:
+  - /usr/bin/ssh
+  - -l
+  - user
+  - 10.0.0.16
+  flat_name: process.parent.args
+  ignore_above: 1024
+  level: extended
+  name: args
+  normalize:
+  - array
+  original_fieldset: process
+  short: Array of process arguments.
+  type: keyword
+process.parent.args_count:
+  dashed_name: process-parent-args-count
+  description: 'Length of the process.args array.
+
+    This field can be useful for querying or performing bucket analysis on how many
+    arguments were provided to start a process. More arguments may be an indication
+    of suspicious activity.'
+  example: 4
+  flat_name: process.parent.args_count
+  level: extended
+  name: args_count
+  normalize: []
+  original_fieldset: process
+  short: Length of the process.args array.
+  type: long
+process.parent.code_signature.exists:
+  dashed_name: process-parent-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.parent.code_signature.exists
+  level: core
+  name: exists
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.parent.code_signature.status:
+  dashed_name: process-parent-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.parent.code_signature.status
+  ignore_above: 1024
+  level: extended
+  name: status
+  normalize: []
+  original_fieldset: code_signature
+  short: Additional information about the certificate status.
+  type: keyword
+process.parent.code_signature.subject_name:
+  dashed_name: process-parent-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.parent.code_signature.subject_name
+  ignore_above: 1024
+  level: core
+  name: subject_name
+  normalize: []
+  original_fieldset: code_signature
+  short: Subject name of the code signer
+  type: keyword
+process.parent.code_signature.trusted:
+  dashed_name: process-parent-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.parent.code_signature.trusted
+  level: extended
+  name: trusted
+  normalize: []
+  original_fieldset: code_signature
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.parent.code_signature.valid:
+  dashed_name: process-parent-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.parent.code_signature.valid
+  level: extended
+  name: valid
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
+process.parent.command_line:
+  dashed_name: process-parent-command-line
+  description: 'Full command line that started the process, including the absolute
+    path to the executable, and all arguments.
+
+    Some arguments may be filtered to protect sensitive information.'
+  example: /usr/bin/ssh -l user 10.0.0.16
+  flat_name: process.parent.command_line
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.parent.command_line.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
+  - flat_name: process.parent.command_line.text
+    name: text
+    norms: false
+    type: text
+  name: command_line
+  normalize: []
+  original_fieldset: process
+  short: Full command line that started the process.
+  type: keyword
 process.parent.entity_id:
   dashed_name: process-parent-entity-id
   description: 'Unique identifier for the process.
@@ -1283,6 +1774,64 @@ process.parent.executable:
   original_fieldset: process
   short: Absolute path to the process executable.
   type: keyword
+process.parent.exit_code:
+  dashed_name: process-parent-exit-code
+  description: 'The exit code of the process, if this is a termination event.
+
+    The field should be absent if there is no exit code for the event (e.g. process
+    start).'
+  example: 137
+  flat_name: process.parent.exit_code
+  level: extended
+  name: exit_code
+  normalize: []
+  original_fieldset: process
+  short: The exit code of the process.
+  type: long
+process.parent.hash.md5:
+  dashed_name: process-parent-hash-md5
+  description: MD5 hash.
+  flat_name: process.parent.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+process.parent.hash.sha1:
+  dashed_name: process-parent-hash-sha1
+  description: SHA1 hash.
+  flat_name: process.parent.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+process.parent.hash.sha256:
+  dashed_name: process-parent-hash-sha256
+  description: SHA256 hash.
+  flat_name: process.parent.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+process.parent.hash.sha512:
+  dashed_name: process-parent-hash-sha512
+  description: SHA512 hash.
+  flat_name: process.parent.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
 process.parent.name:
   dashed_name: process-parent-name
   description: 'Process name.
@@ -1307,6 +1856,77 @@ process.parent.name:
   original_fieldset: process
   short: Process name.
   type: keyword
+process.parent.pe.company:
+  dashed_name: process-parent-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: process.parent.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.description:
+  dashed_name: process-parent-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: process.parent.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.file_version:
+  dashed_name: process-parent-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: process.parent.pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+process.parent.pe.original_file_name:
+  dashed_name: process-parent-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: process.parent.pe.original_file_name
+  ignore_above: 1024
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.product:
+  dashed_name: process-parent-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: process.parent.pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+process.parent.pgid:
+  dashed_name: process-parent-pgid
+  description: Identifier of the group of processes the process belongs to.
+  flat_name: process.parent.pgid
+  format: string
+  level: extended
+  name: pgid
+  normalize: []
+  original_fieldset: process
+  short: Identifier of the group of processes the process belongs to.
+  type: long
 process.parent.pid:
   dashed_name: process-parent-pid
   description: Process id.
@@ -1319,6 +1939,130 @@ process.parent.pid:
   original_fieldset: process
   short: Process id.
   type: long
+process.parent.ppid:
+  dashed_name: process-parent-ppid
+  description: Parent process' pid.
+  example: 4241
+  flat_name: process.parent.ppid
+  format: string
+  level: extended
+  name: ppid
+  normalize: []
+  original_fieldset: process
+  short: Parent process' pid.
+  type: long
+process.parent.thread.id:
+  dashed_name: process-parent-thread-id
+  description: Thread ID.
+  example: 4242
+  flat_name: process.parent.thread.id
+  format: string
+  level: extended
+  name: thread.id
+  normalize: []
+  original_fieldset: process
+  short: Thread ID.
+  type: long
+process.parent.thread.name:
+  dashed_name: process-parent-thread-name
+  description: Thread name.
+  example: thread-0
+  flat_name: process.parent.thread.name
+  ignore_above: 1024
+  level: extended
+  name: thread.name
+  normalize: []
+  original_fieldset: process
+  short: Thread name.
+  type: keyword
+process.parent.title:
+  dashed_name: process-parent-title
+  description: 'Process title.
+
+    The proctitle, some times the same as process name. Can also be different: for
+    example a browser setting its title to the web page currently opened.'
+  flat_name: process.parent.title
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.parent.title.text
+    name: text
+    norms: false
+    type: text
+  name: title
+  normalize: []
+  original_fieldset: process
+  short: Process title.
+  type: keyword
+process.parent.uptime:
+  dashed_name: process-parent-uptime
+  description: Seconds the process has been up.
+  example: 1325
+  flat_name: process.parent.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  original_fieldset: process
+  short: Seconds the process has been up.
+  type: long
+process.parent.working_directory:
+  dashed_name: process-parent-working-directory
+  description: The working directory of the process.
+  example: /home/alice
+  flat_name: process.parent.working_directory
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.parent.working_directory.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
+  - flat_name: process.parent.working_directory.text
+    name: text
+    norms: false
+    type: text
+  name: working_directory
+  normalize: []
+  original_fieldset: process
+  short: The working directory of the process.
+  type: keyword
+process.pe.company:
+  dashed_name: process-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: process.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+process.pe.description:
+  dashed_name: process-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: process.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+process.pe.file_version:
+  dashed_name: process-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: process.pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
 process.pe.original_file_name:
   dashed_name: process-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -1331,6 +2075,28 @@ process.pe.original_file_name:
   original_fieldset: pe
   short: Internal name of the file, provided at compile-time.
   type: keyword
+process.pe.product:
+  dashed_name: process-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: process.pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+process.pgid:
+  dashed_name: process-pgid
+  description: Identifier of the group of processes the process belongs to.
+  flat_name: process.pgid
+  format: string
+  level: extended
+  name: pgid
+  normalize: []
+  short: Identifier of the group of processes the process belongs to.
+  type: long
 process.pid:
   dashed_name: process-pid
   description: Process id.
@@ -1341,6 +2107,17 @@ process.pid:
   name: pid
   normalize: []
   short: Process id.
+  type: long
+process.ppid:
+  dashed_name: process-ppid
+  description: Parent process' pid.
+  example: 4241
+  flat_name: process.ppid
+  format: string
+  level: extended
+  name: ppid
+  normalize: []
+  short: Parent process' pid.
   type: long
 process.thread.id:
   dashed_name: process-thread-id
@@ -1353,6 +2130,66 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+process.thread.name:
+  dashed_name: process-thread-name
+  description: Thread name.
+  example: thread-0
+  flat_name: process.thread.name
+  ignore_above: 1024
+  level: extended
+  name: thread.name
+  normalize: []
+  short: Thread name.
+  type: keyword
+process.title:
+  dashed_name: process-title
+  description: 'Process title.
+
+    The proctitle, some times the same as process name. Can also be different: for
+    example a browser setting its title to the web page currently opened.'
+  flat_name: process.title
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.title.text
+    name: text
+    norms: false
+    type: text
+  name: title
+  normalize: []
+  short: Process title.
+  type: keyword
+process.uptime:
+  dashed_name: process-uptime
+  description: Seconds the process has been up.
+  example: 1325
+  flat_name: process.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the process has been up.
+  type: long
+process.working_directory:
+  dashed_name: process-working-directory
+  description: The working directory of the process.
+  example: /home/alice
+  flat_name: process.working_directory
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.working_directory.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
+  - flat_name: process.working_directory.text
+    name: text
+    norms: false
+    type: text
+  name: working_directory
+  normalize: []
+  short: The working directory of the process.
+  type: keyword
 source.geo.city_name:
   dashed_name: source-geo-city-name
   description: City name.
@@ -1503,6 +2340,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/generated/process/ecs/subset/process/ecs_flat.yml
+++ b/generated/process/ecs/subset/process/ecs_flat.yml
@@ -370,6 +370,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -407,6 +422,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -522,6 +550,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -534,6 +620,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -712,6 +818,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -742,6 +860,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -920,6 +1052,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -986,6 +1141,16 @@ process.Ext.code_signature:
   normalize: []
   short: Nested version of ECS code_signature fieldset.
   type: nested
+process.Ext.code_signature.exists:
+  dashed_name: process-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
 process.Ext.code_signature.status:
   dashed_name: process-Ext-code-signature-status
   description: 'Additional information about the certificate status.
@@ -1012,6 +1177,33 @@ process.Ext.code_signature.subject_name:
   normalize: []
   short: Subject name of the code signer
   type: keyword
+process.Ext.code_signature.trusted:
+  dashed_name: process-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.Ext.code_signature.valid:
+  dashed_name: process-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 process.Ext.session:
   dashed_name: process-Ext-session
   description: Session information for the current process
@@ -1075,6 +1267,88 @@ process.args:
   - array
   short: Array of process arguments.
   type: keyword
+process.args_count:
+  dashed_name: process-args-count
+  description: 'Length of the process.args array.
+
+    This field can be useful for querying or performing bucket analysis on how many
+    arguments were provided to start a process. More arguments may be an indication
+    of suspicious activity.'
+  example: 4
+  flat_name: process.args_count
+  level: extended
+  name: args_count
+  normalize: []
+  short: Length of the process.args array.
+  type: long
+process.code_signature.exists:
+  dashed_name: process-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.code_signature.exists
+  level: core
+  name: exists
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.code_signature.status:
+  dashed_name: process-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.code_signature.status
+  ignore_above: 1024
+  level: extended
+  name: status
+  normalize: []
+  original_fieldset: code_signature
+  short: Additional information about the certificate status.
+  type: keyword
+process.code_signature.subject_name:
+  dashed_name: process-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.code_signature.subject_name
+  ignore_above: 1024
+  level: core
+  name: subject_name
+  normalize: []
+  original_fieldset: code_signature
+  short: Subject name of the code signer
+  type: keyword
+process.code_signature.trusted:
+  dashed_name: process-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.code_signature.trusted
+  level: extended
+  name: trusted
+  normalize: []
+  original_fieldset: code_signature
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.code_signature.valid:
+  dashed_name: process-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.code_signature.valid
+  level: extended
+  name: valid
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 process.command_line:
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
@@ -1185,6 +1459,17 @@ process.hash.sha256:
   original_fieldset: hash
   short: SHA256 hash.
   type: keyword
+process.hash.sha512:
+  dashed_name: process-hash-sha512
+  description: SHA512 hash.
+  flat_name: process.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
 process.name:
   dashed_name: process-name
   description: 'Process name.
@@ -1218,6 +1503,84 @@ process.parent.Ext:
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
+process.parent.Ext.code_signature:
+  dashed_name: process-parent-Ext-code-signature
+  description: Nested version of ECS code_signature fieldset.
+  flat_name: process.parent.Ext.code_signature
+  level: custom
+  name: Ext.code_signature
+  normalize: []
+  original_fieldset: process
+  short: Nested version of ECS code_signature fieldset.
+  type: nested
+process.parent.Ext.code_signature.exists:
+  dashed_name: process-parent-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.parent.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  original_fieldset: process
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.parent.Ext.code_signature.status:
+  dashed_name: process-parent-Ext-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.parent.Ext.code_signature.status
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.status
+  normalize: []
+  original_fieldset: process
+  short: Additional information about the certificate status.
+  type: keyword
+process.parent.Ext.code_signature.subject_name:
+  dashed_name: process-parent-Ext-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.parent.Ext.code_signature.subject_name
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.subject_name
+  normalize: []
+  original_fieldset: process
+  short: Subject name of the code signer
+  type: keyword
+process.parent.Ext.code_signature.trusted:
+  dashed_name: process-parent-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.parent.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  original_fieldset: process
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.parent.Ext.code_signature.valid:
+  dashed_name: process-parent-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.parent.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  original_fieldset: process
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
   description: The field set containing process info in case of any pid spoofing.
@@ -1241,6 +1604,134 @@ process.parent.Ext.real.pid:
   original_fieldset: process
   short: The real pid of the process if ppid spoofing is happening.
   type: long
+process.parent.args:
+  dashed_name: process-parent-args
+  description: 'Array of process arguments, starting with the absolute path to the
+    executable.
+
+    May be filtered to protect sensitive information.'
+  example:
+  - /usr/bin/ssh
+  - -l
+  - user
+  - 10.0.0.16
+  flat_name: process.parent.args
+  ignore_above: 1024
+  level: extended
+  name: args
+  normalize:
+  - array
+  original_fieldset: process
+  short: Array of process arguments.
+  type: keyword
+process.parent.args_count:
+  dashed_name: process-parent-args-count
+  description: 'Length of the process.args array.
+
+    This field can be useful for querying or performing bucket analysis on how many
+    arguments were provided to start a process. More arguments may be an indication
+    of suspicious activity.'
+  example: 4
+  flat_name: process.parent.args_count
+  level: extended
+  name: args_count
+  normalize: []
+  original_fieldset: process
+  short: Length of the process.args array.
+  type: long
+process.parent.code_signature.exists:
+  dashed_name: process-parent-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.parent.code_signature.exists
+  level: core
+  name: exists
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.parent.code_signature.status:
+  dashed_name: process-parent-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.parent.code_signature.status
+  ignore_above: 1024
+  level: extended
+  name: status
+  normalize: []
+  original_fieldset: code_signature
+  short: Additional information about the certificate status.
+  type: keyword
+process.parent.code_signature.subject_name:
+  dashed_name: process-parent-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.parent.code_signature.subject_name
+  ignore_above: 1024
+  level: core
+  name: subject_name
+  normalize: []
+  original_fieldset: code_signature
+  short: Subject name of the code signer
+  type: keyword
+process.parent.code_signature.trusted:
+  dashed_name: process-parent-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.parent.code_signature.trusted
+  level: extended
+  name: trusted
+  normalize: []
+  original_fieldset: code_signature
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.parent.code_signature.valid:
+  dashed_name: process-parent-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.parent.code_signature.valid
+  level: extended
+  name: valid
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
+process.parent.command_line:
+  dashed_name: process-parent-command-line
+  description: 'Full command line that started the process, including the absolute
+    path to the executable, and all arguments.
+
+    Some arguments may be filtered to protect sensitive information.'
+  example: /usr/bin/ssh -l user 10.0.0.16
+  flat_name: process.parent.command_line
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.parent.command_line.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
+  - flat_name: process.parent.command_line.text
+    name: text
+    norms: false
+    type: text
+  name: command_line
+  normalize: []
+  original_fieldset: process
+  short: Full command line that started the process.
+  type: keyword
 process.parent.entity_id:
   dashed_name: process-parent-entity-id
   description: 'Unique identifier for the process.
@@ -1283,6 +1774,64 @@ process.parent.executable:
   original_fieldset: process
   short: Absolute path to the process executable.
   type: keyword
+process.parent.exit_code:
+  dashed_name: process-parent-exit-code
+  description: 'The exit code of the process, if this is a termination event.
+
+    The field should be absent if there is no exit code for the event (e.g. process
+    start).'
+  example: 137
+  flat_name: process.parent.exit_code
+  level: extended
+  name: exit_code
+  normalize: []
+  original_fieldset: process
+  short: The exit code of the process.
+  type: long
+process.parent.hash.md5:
+  dashed_name: process-parent-hash-md5
+  description: MD5 hash.
+  flat_name: process.parent.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+process.parent.hash.sha1:
+  dashed_name: process-parent-hash-sha1
+  description: SHA1 hash.
+  flat_name: process.parent.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+process.parent.hash.sha256:
+  dashed_name: process-parent-hash-sha256
+  description: SHA256 hash.
+  flat_name: process.parent.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+process.parent.hash.sha512:
+  dashed_name: process-parent-hash-sha512
+  description: SHA512 hash.
+  flat_name: process.parent.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
 process.parent.name:
   dashed_name: process-parent-name
   description: 'Process name.
@@ -1307,6 +1856,77 @@ process.parent.name:
   original_fieldset: process
   short: Process name.
   type: keyword
+process.parent.pe.company:
+  dashed_name: process-parent-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: process.parent.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.description:
+  dashed_name: process-parent-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: process.parent.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.file_version:
+  dashed_name: process-parent-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: process.parent.pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+process.parent.pe.original_file_name:
+  dashed_name: process-parent-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: process.parent.pe.original_file_name
+  ignore_above: 1024
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.product:
+  dashed_name: process-parent-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: process.parent.pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+process.parent.pgid:
+  dashed_name: process-parent-pgid
+  description: Identifier of the group of processes the process belongs to.
+  flat_name: process.parent.pgid
+  format: string
+  level: extended
+  name: pgid
+  normalize: []
+  original_fieldset: process
+  short: Identifier of the group of processes the process belongs to.
+  type: long
 process.parent.pid:
   dashed_name: process-parent-pid
   description: Process id.
@@ -1319,6 +1939,130 @@ process.parent.pid:
   original_fieldset: process
   short: Process id.
   type: long
+process.parent.ppid:
+  dashed_name: process-parent-ppid
+  description: Parent process' pid.
+  example: 4241
+  flat_name: process.parent.ppid
+  format: string
+  level: extended
+  name: ppid
+  normalize: []
+  original_fieldset: process
+  short: Parent process' pid.
+  type: long
+process.parent.thread.id:
+  dashed_name: process-parent-thread-id
+  description: Thread ID.
+  example: 4242
+  flat_name: process.parent.thread.id
+  format: string
+  level: extended
+  name: thread.id
+  normalize: []
+  original_fieldset: process
+  short: Thread ID.
+  type: long
+process.parent.thread.name:
+  dashed_name: process-parent-thread-name
+  description: Thread name.
+  example: thread-0
+  flat_name: process.parent.thread.name
+  ignore_above: 1024
+  level: extended
+  name: thread.name
+  normalize: []
+  original_fieldset: process
+  short: Thread name.
+  type: keyword
+process.parent.title:
+  dashed_name: process-parent-title
+  description: 'Process title.
+
+    The proctitle, some times the same as process name. Can also be different: for
+    example a browser setting its title to the web page currently opened.'
+  flat_name: process.parent.title
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.parent.title.text
+    name: text
+    norms: false
+    type: text
+  name: title
+  normalize: []
+  original_fieldset: process
+  short: Process title.
+  type: keyword
+process.parent.uptime:
+  dashed_name: process-parent-uptime
+  description: Seconds the process has been up.
+  example: 1325
+  flat_name: process.parent.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  original_fieldset: process
+  short: Seconds the process has been up.
+  type: long
+process.parent.working_directory:
+  dashed_name: process-parent-working-directory
+  description: The working directory of the process.
+  example: /home/alice
+  flat_name: process.parent.working_directory
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.parent.working_directory.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
+  - flat_name: process.parent.working_directory.text
+    name: text
+    norms: false
+    type: text
+  name: working_directory
+  normalize: []
+  original_fieldset: process
+  short: The working directory of the process.
+  type: keyword
+process.pe.company:
+  dashed_name: process-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: process.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+process.pe.description:
+  dashed_name: process-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: process.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+process.pe.file_version:
+  dashed_name: process-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: process.pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
 process.pe.original_file_name:
   dashed_name: process-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -1331,6 +2075,28 @@ process.pe.original_file_name:
   original_fieldset: pe
   short: Internal name of the file, provided at compile-time.
   type: keyword
+process.pe.product:
+  dashed_name: process-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: process.pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+process.pgid:
+  dashed_name: process-pgid
+  description: Identifier of the group of processes the process belongs to.
+  flat_name: process.pgid
+  format: string
+  level: extended
+  name: pgid
+  normalize: []
+  short: Identifier of the group of processes the process belongs to.
+  type: long
 process.pid:
   dashed_name: process-pid
   description: Process id.
@@ -1341,6 +2107,17 @@ process.pid:
   name: pid
   normalize: []
   short: Process id.
+  type: long
+process.ppid:
+  dashed_name: process-ppid
+  description: Parent process' pid.
+  example: 4241
+  flat_name: process.ppid
+  format: string
+  level: extended
+  name: ppid
+  normalize: []
+  short: Parent process' pid.
   type: long
 process.thread.id:
   dashed_name: process-thread-id
@@ -1353,6 +2130,66 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+process.thread.name:
+  dashed_name: process-thread-name
+  description: Thread name.
+  example: thread-0
+  flat_name: process.thread.name
+  ignore_above: 1024
+  level: extended
+  name: thread.name
+  normalize: []
+  short: Thread name.
+  type: keyword
+process.title:
+  dashed_name: process-title
+  description: 'Process title.
+
+    The proctitle, some times the same as process name. Can also be different: for
+    example a browser setting its title to the web page currently opened.'
+  flat_name: process.title
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.title.text
+    name: text
+    norms: false
+    type: text
+  name: title
+  normalize: []
+  short: Process title.
+  type: keyword
+process.uptime:
+  dashed_name: process-uptime
+  description: Seconds the process has been up.
+  example: 1325
+  flat_name: process.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the process has been up.
+  type: long
+process.working_directory:
+  dashed_name: process-working-directory
+  description: The working directory of the process.
+  example: /home/alice
+  flat_name: process.working_directory
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.working_directory.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
+  - flat_name: process.working_directory.text
+    name: text
+    norms: false
+    type: text
+  name: working_directory
+  normalize: []
+  short: The working directory of the process.
+  type: keyword
 source.geo.city_name:
   dashed_name: source-geo-city-name
   description: City name.
@@ -1503,6 +2340,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/generated/process/elasticsearch/7/template.json
+++ b/generated/process/elasticsearch/7/template.json
@@ -108,10 +108,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "code": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "created": {
             "type": "date"
           },
           "dataset": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "hash": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -130,7 +138,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "outcome": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "provider": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "sequence": {
+            "type": "long"
+          },
+          "severity": {
             "type": "long"
           },
           "type": {
@@ -159,6 +178,10 @@
             },
             "type": "object"
           },
+          "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "id": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -172,6 +195,10 @@
       "host": {
         "properties": {
           "architecture": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "domain": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -252,6 +279,13 @@
                 "type": "keyword"
               }
             }
+          },
+          "type": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "uptime": {
+            "type": "long"
           }
         }
       },
@@ -281,6 +315,9 @@
               },
               "code_signature": {
                 "properties": {
+                  "exists": {
+                    "type": "boolean"
+                  },
                   "status": {
                     "ignore_above": 1024,
                     "type": "keyword"
@@ -288,6 +325,12 @@
                   "subject_name": {
                     "ignore_above": 1024,
                     "type": "keyword"
+                  },
+                  "trusted": {
+                    "type": "boolean"
+                  },
+                  "valid": {
+                    "type": "boolean"
                   }
                 },
                 "type": "nested"
@@ -317,6 +360,30 @@
           "args": {
             "ignore_above": 1024,
             "type": "keyword"
+          },
+          "args_count": {
+            "type": "long"
+          },
+          "code_signature": {
+            "properties": {
+              "exists": {
+                "type": "boolean"
+              },
+              "status": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "subject_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "trusted": {
+                "type": "boolean"
+              },
+              "valid": {
+                "type": "boolean"
+              }
+            }
           },
           "command_line": {
             "fields": {
@@ -368,6 +435,10 @@
               "sha256": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "sha512": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
           },
@@ -390,6 +461,28 @@
             "properties": {
               "Ext": {
                 "properties": {
+                  "code_signature": {
+                    "properties": {
+                      "exists": {
+                        "type": "boolean"
+                      },
+                      "status": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "subject_name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "trusted": {
+                        "type": "boolean"
+                      },
+                      "valid": {
+                        "type": "boolean"
+                      }
+                    },
+                    "type": "nested"
+                  },
                   "real": {
                     "properties": {
                       "pid": {
@@ -400,6 +493,49 @@
                   }
                 },
                 "type": "object"
+              },
+              "args": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "args_count": {
+                "type": "long"
+              },
+              "code_signature": {
+                "properties": {
+                  "exists": {
+                    "type": "boolean"
+                  },
+                  "status": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "subject_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "trusted": {
+                    "type": "boolean"
+                  },
+                  "valid": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "command_line": {
+                "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "entity_id": {
                 "ignore_above": 1024,
@@ -420,6 +556,29 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "exit_code": {
+                "type": "long"
+              },
+              "hash": {
+                "properties": {
+                  "md5": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "sha1": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "sha256": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "sha512": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
               "name": {
                 "fields": {
                   "caseless": {
@@ -435,28 +594,151 @@
                 "ignore_above": 1024,
                 "type": "keyword"
               },
+              "pe": {
+                "properties": {
+                  "company": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "description": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "file_version": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "original_file_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "product": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "pgid": {
+                "type": "long"
+              },
               "pid": {
                 "type": "long"
-              }
-            }
-          },
-          "pe": {
-            "properties": {
-              "original_file_name": {
+              },
+              "ppid": {
+                "type": "long"
+              },
+              "thread": {
+                "properties": {
+                  "id": {
+                    "type": "long"
+                  },
+                  "name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  }
+                }
+              },
+              "title": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "uptime": {
+                "type": "long"
+              },
+              "working_directory": {
+                "fields": {
+                  "caseless": {
+                    "ignore_above": 1024,
+                    "normalizer": "lowercase",
+                    "type": "keyword"
+                  },
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
                 "ignore_above": 1024,
                 "type": "keyword"
               }
             }
           },
+          "pe": {
+            "properties": {
+              "company": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "description": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "file_version": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "original_file_name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "product": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "pgid": {
+            "type": "long"
+          },
           "pid": {
+            "type": "long"
+          },
+          "ppid": {
             "type": "long"
           },
           "thread": {
             "properties": {
               "id": {
                 "type": "long"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
               }
             }
+          },
+          "title": {
+            "fields": {
+              "text": {
+                "norms": false,
+                "type": "text"
+              }
+            },
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "uptime": {
+            "type": "long"
+          },
+          "working_directory": {
+            "fields": {
+              "caseless": {
+                "ignore_above": 1024,
+                "normalizer": "lowercase",
+                "type": "keyword"
+              },
+              "text": {
+                "norms": false,
+                "type": "text"
+              }
+            },
+            "ignore_above": 1024,
+            "type": "keyword"
           }
         }
       },
@@ -520,6 +802,58 @@
             "type": "object"
           },
           "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "email": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "full_name": {
+            "fields": {
+              "text": {
+                "norms": false,
+                "type": "text"
+              }
+            },
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "group": {
+            "properties": {
+              "Ext": {
+                "properties": {
+                  "real": {
+                    "properties": {
+                      "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "domain": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "hash": {
             "ignore_above": 1024,
             "type": "keyword"
           },

--- a/generated/registry/ecs/ecs_flat.yml
+++ b/generated/registry/ecs/ecs_flat.yml
@@ -370,6 +370,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -407,6 +422,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -522,6 +550,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -534,6 +620,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -712,6 +818,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -742,6 +860,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -920,6 +1052,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -1269,6 +1424,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/generated/registry/ecs/subset/registry/ecs_flat.yml
+++ b/generated/registry/ecs/subset/registry/ecs_flat.yml
@@ -370,6 +370,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -407,6 +422,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -522,6 +550,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -534,6 +620,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -712,6 +818,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -742,6 +860,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -920,6 +1052,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -1269,6 +1424,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/generated/registry/elasticsearch/7/template.json
+++ b/generated/registry/elasticsearch/7/template.json
@@ -108,10 +108,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "code": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "created": {
             "type": "date"
           },
           "dataset": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "hash": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -130,7 +138,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "outcome": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "provider": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "sequence": {
+            "type": "long"
+          },
+          "severity": {
             "type": "long"
           },
           "type": {
@@ -159,6 +178,10 @@
             },
             "type": "object"
           },
+          "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "id": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -172,6 +195,10 @@
       "host": {
         "properties": {
           "architecture": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "domain": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -252,6 +279,13 @@
                 "type": "keyword"
               }
             }
+          },
+          "type": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "uptime": {
+            "type": "long"
           }
         }
       },
@@ -408,6 +442,58 @@
             "type": "object"
           },
           "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "email": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "full_name": {
+            "fields": {
+              "text": {
+                "norms": false,
+                "type": "text"
+              }
+            },
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "group": {
+            "properties": {
+              "Ext": {
+                "properties": {
+                  "real": {
+                    "properties": {
+                      "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "domain": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "hash": {
             "ignore_above": 1024,
             "type": "keyword"
           },

--- a/generated/security/ecs/ecs_flat.yml
+++ b/generated/security/ecs/ecs_flat.yml
@@ -370,6 +370,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -407,6 +422,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -522,6 +550,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -534,6 +620,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -712,6 +818,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -742,6 +860,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -920,6 +1052,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -1191,6 +1346,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/generated/security/ecs/subset/security/ecs_flat.yml
+++ b/generated/security/ecs/subset/security/ecs_flat.yml
@@ -370,6 +370,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -407,6 +422,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -522,6 +550,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -534,6 +620,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -712,6 +818,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -742,6 +860,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -920,6 +1052,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -1191,6 +1346,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/generated/security/elasticsearch/7/template.json
+++ b/generated/security/elasticsearch/7/template.json
@@ -108,10 +108,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "code": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "created": {
             "type": "date"
           },
           "dataset": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "hash": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -130,7 +138,18 @@
             "ignore_above": 1024,
             "type": "keyword"
           },
+          "outcome": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "provider": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "sequence": {
+            "type": "long"
+          },
+          "severity": {
             "type": "long"
           },
           "type": {
@@ -159,6 +178,10 @@
             },
             "type": "object"
           },
+          "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "id": {
             "ignore_above": 1024,
             "type": "keyword"
@@ -172,6 +195,10 @@
       "host": {
         "properties": {
           "architecture": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "domain": {
             "ignore_above": 1024,
             "type": "keyword"
           },
@@ -252,6 +279,13 @@
                 "type": "keyword"
               }
             }
+          },
+          "type": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "uptime": {
+            "type": "long"
           }
         }
       },
@@ -376,6 +410,58 @@
             "type": "object"
           },
           "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "email": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "full_name": {
+            "fields": {
+              "text": {
+                "norms": false,
+                "type": "text"
+              }
+            },
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "group": {
+            "properties": {
+              "Ext": {
+                "properties": {
+                  "real": {
+                    "properties": {
+                      "id": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "object"
+                  }
+                },
+                "type": "object"
+              },
+              "domain": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "hash": {
             "ignore_above": 1024,
             "type": "keyword"
           },

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -187,6 +187,14 @@
 
         This field is an array. This will allow proper categorization of some events that fall in multiple categories.'
       example: authentication
+    - name: code
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identification code for this event, if one exists.
+
+        Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID.'
+      example: 4648
     - name: created
       level: core
       type: date
@@ -208,6 +216,12 @@
 
         It''s recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name.'
       example: apache.access
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
+      example: 123456789012345678901234567890ABCD
     - name: id
       level: core
       type: keyword
@@ -256,6 +270,14 @@
 
         Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense.'
       example: success
+    - name: provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Source of the event.
+
+        Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+      example: kernel
     - name: sequence
       level: extended
       type: long
@@ -263,6 +285,16 @@
       description: 'Sequence number of the event.
 
         The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision.'
+    - name: severity
+      level: core
+      type: long
+      format: string
+      description: 'The numeric severity of the event according to your event source.
+
+        What the different severity values mean can be different between sources and use cases. It''s up to the implementer to make sure severities are consistent across events from the same source.
+
+        The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`.'
+      example: 7
     - name: type
       level: core
       type: keyword
@@ -347,6 +379,54 @@
       ignore_above: 1024
       description: Windows zone identifier for a file
       default_field: false
+    - name: accessed
+      level: extended
+      type: date
+      description: 'Last time the file was accessed.
+
+        Note that not all filesystems keep track of access time.'
+    - name: attributes
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Array of file attributes.
+
+        Attributes names will vary by platform. Here''s a non-exhaustive list of values that are expected in this field: archive, compressed, directory, encrypted, execute, hidden, read, readonly, system, write.'
+      example: '["readonly", "system"]'
+      default_field: false
+    - name: created
+      level: extended
+      type: date
+      description: 'File creation time.
+
+        Note that not all filesystems store the creation time.'
+    - name: ctime
+      level: extended
+      type: date
+      description: 'Last time the file attributes or metadata changed.
+
+        Note that changes to the file content will update `mtime`. This implies `ctime` will be adjusted at the same time, since `mtime` is an attribute of the file.'
+    - name: device
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Device that is the source of the file.
+      example: sda
+    - name: directory
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Directory where the file is located. It should include the drive letter, when appropriate.
+      example: /home/alice
+    - name: drive_letter
+      level: extended
+      type: keyword
+      ignore_above: 1
+      description: 'Drive letter where the file is located. This field is only relevant on Windows.
+
+        The value should be uppercase, and not include the colon.'
+      example: C
+      default_field: false
     - name: extension
       level: extended
       type: keyword
@@ -380,18 +460,33 @@
       type: keyword
       ignore_above: 1024
       description: SHA256 hash.
+    - name: hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
     - name: inode
       level: extended
       type: keyword
       ignore_above: 1024
       description: Inode representing the file in the filesystem.
       example: '256383'
+    - name: mime_type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used.
+      default_field: false
     - name: mode
       level: extended
       type: keyword
       ignore_above: 1024
       description: Mode of the file in octal representation.
       example: '0640'
+    - name: mtime
+      level: extended
+      type: date
+      description: Last time the file content was modified.
     - name: name
       level: extended
       type: keyword
@@ -420,6 +515,69 @@
           default_field: false
       description: Full path to the file, including the file name. It should include the drive letter, when appropriate.
       example: /home/alice/example.png
+    - name: pe.company
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      default_field: false
+    - name: pe.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      default_field: false
+    - name: pe.file_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      default_field: false
+    - name: pe.original_file_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      default_field: false
+    - name: pe.product
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft® Windows® Operating System"
+      default_field: false
+    - name: size
+      level: extended
+      type: long
+      description: 'File size in bytes.
+
+        Only relevant when `file.type` is "file".'
+      example: 16384
+    - name: target_path
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: caseless
+          type: keyword
+          default_field: false
+          normalizer: lowercase
+          ignore_above: 1024
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+      description: Target path for symlinks.
+    - name: type
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: File type (file, dir, or symlink).
+      example: file
     - name: uid
       level: extended
       type: keyword
@@ -454,6 +612,13 @@
       ignore_above: 1024
       description: Name of the group.
       default_field: false
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: id
       level: extended
       type: keyword
@@ -478,6 +643,15 @@
       ignore_above: 1024
       description: Operating system architecture.
       example: x86_64
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the domain of which the host is a member.
+
+        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      example: CONTOSO
+      default_field: false
     - name: hostname
       level: core
       type: keyword
@@ -578,6 +752,18 @@
       ignore_above: 1024
       description: Operating system version as a raw string.
       example: 10.14.1
+    - name: type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Type of host.
+
+        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+    - name: uptime
+      level: extended
+      type: long
+      description: Seconds the host has been up.
+      example: 1325
 - name: process
   title: Process
   group: 2
@@ -758,6 +944,68 @@
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
+    - name: email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User email address.
+    - name: full_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+      description: User's full name, if available.
+      example: Albert Einstein
+    - name: group.Ext
+      level: custom
+      type: object
+      description: Object for all custom defined fields to live in.
+      default_field: false
+    - name: group.Ext.real
+      level: custom
+      type: object
+      description: Group info prior to any setgid operations.
+      default_field: false
+    - name: group.Ext.real.id
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+      default_field: false
+    - name: group.Ext.real.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
+    - name: group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+    - name: group.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+    - name: group.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique user hash to correlate information for a user in anonymized form.
+
+        Useful if `user.id` or `user.name` contain confidential information and cannot be used.'
     - name: id
       level: core
       type: keyword

--- a/package/endpoint/data_stream/library/fields/fields.yml
+++ b/package/endpoint/data_stream/library/fields/fields.yml
@@ -155,6 +155,12 @@
       type: nested
       description: Nested version of ECS code_signature fieldset.
       default_field: false
+    - name: Ext.code_signature.exists
+      level: custom
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
     - name: Ext.code_signature.status
       level: custom
       type: keyword
@@ -170,6 +176,36 @@
       ignore_above: 1024
       description: Subject name of the code signer
       example: Microsoft Corporation
+      default_field: false
+    - name: Ext.code_signature.trusted
+      level: custom
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: Ext.code_signature.valid
+      level: custom
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      default_field: false
+    - name: pe.company
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      default_field: false
+    - name: pe.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
       default_field: false
     - name: pe.file_version
       level: extended
@@ -233,6 +269,14 @@
 
         This field is an array. This will allow proper categorization of some events that fall in multiple categories.'
       example: authentication
+    - name: code
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identification code for this event, if one exists.
+
+        Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID.'
+      example: 4648
     - name: created
       level: core
       type: date
@@ -254,6 +298,12 @@
 
         It''s recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name.'
       example: apache.access
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
+      example: 123456789012345678901234567890ABCD
     - name: id
       level: core
       type: keyword
@@ -288,6 +338,28 @@
 
         If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module.'
       example: apache
+    - name: outcome
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.
+
+        `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.
+
+        Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective.
+
+        Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.
+
+        Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense.'
+      example: success
+    - name: provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Source of the event.
+
+        Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+      example: kernel
     - name: sequence
       level: extended
       type: long
@@ -295,6 +367,16 @@
       description: 'Sequence number of the event.
 
         The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision.'
+    - name: severity
+      level: core
+      type: long
+      format: string
+      description: 'The numeric severity of the event according to your event source.
+
+        What the different severity values mean can be different between sources and use cases. It''s up to the implementer to make sure severities are consistent across events from the same source.
+
+        The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`.'
+      example: 7
     - name: type
       level: core
       type: keyword
@@ -322,6 +404,12 @@
       type: nested
       description: Nested version of ECS code_signature fieldset.
       default_field: false
+    - name: Ext.code_signature.exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
     - name: Ext.code_signature.status
       level: custom
       type: keyword
@@ -338,6 +426,22 @@
       description: Subject name of the code signer
       example: Microsoft Corporation
       default_field: false
+    - name: Ext.code_signature.trusted
+      level: custom
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: Ext.code_signature.valid
+      level: custom
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      default_field: false
     - name: hash.md5
       level: extended
       type: keyword
@@ -353,6 +457,11 @@
       type: keyword
       ignore_above: 1024
       description: SHA256 hash.
+    - name: hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
     - name: name
       level: extended
       type: keyword
@@ -375,6 +484,20 @@
           default_field: false
       description: Full path to the file, including the file name. It should include the drive letter, when appropriate.
       example: /home/alice/example.png
+    - name: pe.company
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      default_field: false
+    - name: pe.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      default_field: false
     - name: pe.file_version
       level: extended
       type: keyword
@@ -424,6 +547,13 @@
       ignore_above: 1024
       description: Name of the group.
       default_field: false
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: id
       level: extended
       type: keyword
@@ -448,6 +578,15 @@
       ignore_above: 1024
       description: Operating system architecture.
       example: x86_64
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the domain of which the host is a member.
+
+        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      example: CONTOSO
+      default_field: false
     - name: hostname
       level: core
       type: keyword
@@ -548,6 +687,18 @@
       ignore_above: 1024
       description: Operating system version as a raw string.
       example: 10.14.1
+    - name: type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Type of host.
+
+        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+    - name: uptime
+      level: extended
+      type: long
+      description: Seconds the host has been up.
+      example: 1325
 - name: process
   title: Process
   group: 2
@@ -720,6 +871,68 @@
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
+    - name: email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User email address.
+    - name: full_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+      description: User's full name, if available.
+      example: Albert Einstein
+    - name: group.Ext
+      level: custom
+      type: object
+      description: Object for all custom defined fields to live in.
+      default_field: false
+    - name: group.Ext.real
+      level: custom
+      type: object
+      description: Group info prior to any setgid operations.
+      default_field: false
+    - name: group.Ext.real.id
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+      default_field: false
+    - name: group.Ext.real.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
+    - name: group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+    - name: group.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+    - name: group.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique user hash to correlate information for a user in anonymized form.
+
+        Useful if `user.id` or `user.name` contain confidential information and cannot be used.'
     - name: id
       level: core
       type: keyword

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -233,6 +233,14 @@
 
         This field is an array. This will allow proper categorization of some events that fall in multiple categories.'
       example: authentication
+    - name: code
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identification code for this event, if one exists.
+
+        Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID.'
+      example: 4648
     - name: created
       level: core
       type: date
@@ -258,6 +266,12 @@
       level: extended
       type: date
       description: event.end contains the date when the event ended or when the activity was last observed.
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
+      example: 123456789012345678901234567890ABCD
     - name: id
       level: core
       type: keyword
@@ -292,6 +306,28 @@
 
         If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module.'
       example: apache
+    - name: outcome
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.
+
+        `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.
+
+        Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective.
+
+        Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.
+
+        Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense.'
+      example: success
+    - name: provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Source of the event.
+
+        Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+      example: kernel
     - name: sequence
       level: extended
       type: long
@@ -299,6 +335,16 @@
       description: 'Sequence number of the event.
 
         The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision.'
+    - name: severity
+      level: core
+      type: long
+      format: string
+      description: 'The numeric severity of the event according to your event source.
+
+        What the different severity values mean can be different between sources and use cases. It''s up to the implementer to make sure severities are consistent across events from the same source.
+
+        The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`.'
+      example: 7
     - name: start
       level: extended
       type: date
@@ -326,6 +372,15 @@
       ignore_above: 1024
       description: Operating system architecture.
       example: x86_64
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the domain of which the host is a member.
+
+        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      example: CONTOSO
+      default_field: false
     - name: hostname
       level: core
       type: keyword
@@ -426,3 +481,15 @@
       ignore_above: 1024
       description: Operating system version as a raw string.
       example: 10.14.1
+    - name: type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Type of host.
+
+        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+    - name: uptime
+      level: extended
+      type: long
+      description: Seconds the host has been up.
+      example: 1325

--- a/package/endpoint/data_stream/network/fields/fields.yml
+++ b/package/endpoint/data_stream/network/fields/fields.yml
@@ -294,6 +294,14 @@
 
         This field is an array. This will allow proper categorization of some events that fall in multiple categories.'
       example: authentication
+    - name: code
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identification code for this event, if one exists.
+
+        Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID.'
+      example: 4648
     - name: created
       level: core
       type: date
@@ -315,6 +323,12 @@
 
         It''s recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name.'
       example: apache.access
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
+      example: 123456789012345678901234567890ABCD
     - name: id
       level: core
       type: keyword
@@ -349,6 +363,28 @@
 
         If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module.'
       example: apache
+    - name: outcome
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.
+
+        `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.
+
+        Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective.
+
+        Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.
+
+        Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense.'
+      example: success
+    - name: provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Source of the event.
+
+        Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+      example: kernel
     - name: sequence
       level: extended
       type: long
@@ -356,6 +392,16 @@
       description: 'Sequence number of the event.
 
         The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision.'
+    - name: severity
+      level: core
+      type: long
+      format: string
+      description: 'The numeric severity of the event according to your event source.
+
+        What the different severity values mean can be different between sources and use cases. It''s up to the implementer to make sure severities are consistent across events from the same source.
+
+        The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`.'
+      example: 7
     - name: type
       level: core
       type: keyword
@@ -393,6 +439,13 @@
       ignore_above: 1024
       description: Name of the group.
       default_field: false
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: id
       level: extended
       type: keyword
@@ -417,6 +470,15 @@
       ignore_above: 1024
       description: Operating system architecture.
       example: x86_64
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the domain of which the host is a member.
+
+        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      example: CONTOSO
+      default_field: false
     - name: hostname
       level: core
       type: keyword
@@ -517,6 +579,18 @@
       ignore_above: 1024
       description: Operating system version as a raw string.
       example: 10.14.1
+    - name: type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Type of host.
+
+        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+    - name: uptime
+      level: extended
+      type: long
+      description: Seconds the host has been up.
+      example: 1325
 - name: http
   title: HTTP
   group: 2
@@ -875,6 +949,68 @@
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
+    - name: email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User email address.
+    - name: full_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+      description: User's full name, if available.
+      example: Albert Einstein
+    - name: group.Ext
+      level: custom
+      type: object
+      description: Object for all custom defined fields to live in.
+      default_field: false
+    - name: group.Ext.real
+      level: custom
+      type: object
+      description: Group info prior to any setgid operations.
+      default_field: false
+    - name: group.Ext.real.id
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+      default_field: false
+    - name: group.Ext.real.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
+    - name: group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+    - name: group.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+    - name: group.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique user hash to correlate information for a user in anonymized form.
+
+        Useful if `user.id` or `user.name` contain confidential information and cannot be used.'
     - name: id
       level: core
       type: keyword

--- a/package/endpoint/data_stream/policy/fields/fields.yml
+++ b/package/endpoint/data_stream/policy/fields/fields.yml
@@ -318,6 +318,14 @@
 
         This field is an array. This will allow proper categorization of some events that fall in multiple categories.'
       example: authentication
+    - name: code
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identification code for this event, if one exists.
+
+        Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID.'
+      example: 4648
     - name: created
       level: core
       type: date
@@ -339,6 +347,12 @@
 
         It''s recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name.'
       example: apache.access
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
+      example: 123456789012345678901234567890ABCD
     - name: id
       level: core
       type: keyword
@@ -373,6 +387,28 @@
 
         If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module.'
       example: apache
+    - name: outcome
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.
+
+        `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.
+
+        Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective.
+
+        Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.
+
+        Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense.'
+      example: success
+    - name: provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Source of the event.
+
+        Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+      example: kernel
     - name: sequence
       level: extended
       type: long
@@ -380,6 +416,16 @@
       description: 'Sequence number of the event.
 
         The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision.'
+    - name: severity
+      level: core
+      type: long
+      format: string
+      description: 'The numeric severity of the event according to your event source.
+
+        What the different severity values mean can be different between sources and use cases. It''s up to the implementer to make sure severities are consistent across events from the same source.
+
+        The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`.'
+      example: 7
     - name: type
       level: core
       type: keyword

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -171,6 +171,14 @@
 
         This field is an array. This will allow proper categorization of some events that fall in multiple categories.'
       example: authentication
+    - name: code
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identification code for this event, if one exists.
+
+        Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID.'
+      example: 4648
     - name: created
       level: core
       type: date
@@ -192,6 +200,12 @@
 
         It''s recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name.'
       example: apache.access
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
+      example: 123456789012345678901234567890ABCD
     - name: id
       level: core
       type: keyword
@@ -226,6 +240,28 @@
 
         If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module.'
       example: apache
+    - name: outcome
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.
+
+        `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.
+
+        Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective.
+
+        Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.
+
+        Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense.'
+      example: success
+    - name: provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Source of the event.
+
+        Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+      example: kernel
     - name: sequence
       level: extended
       type: long
@@ -233,6 +269,16 @@
       description: 'Sequence number of the event.
 
         The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision.'
+    - name: severity
+      level: core
+      type: long
+      format: string
+      description: 'The numeric severity of the event according to your event source.
+
+        What the different severity values mean can be different between sources and use cases. It''s up to the implementer to make sure severities are consistent across events from the same source.
+
+        The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`.'
+      example: 7
     - name: type
       level: core
       type: keyword
@@ -270,6 +316,13 @@
       ignore_above: 1024
       description: Name of the group.
       default_field: false
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: id
       level: extended
       type: keyword
@@ -294,6 +347,15 @@
       ignore_above: 1024
       description: Operating system architecture.
       example: x86_64
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the domain of which the host is a member.
+
+        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      example: CONTOSO
+      default_field: false
     - name: hostname
       level: core
       type: keyword
@@ -394,6 +456,18 @@
       ignore_above: 1024
       description: Operating system version as a raw string.
       example: 10.14.1
+    - name: type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Type of host.
+
+        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+    - name: uptime
+      level: extended
+      type: long
+      description: Seconds the host has been up.
+      example: 1325
 - name: package
   title: Package
   group: 2
@@ -436,6 +510,12 @@
       type: nested
       description: Nested version of ECS code_signature fieldset.
       default_field: false
+    - name: Ext.code_signature.exists
+      level: custom
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
     - name: Ext.code_signature.status
       level: custom
       type: keyword
@@ -451,6 +531,22 @@
       ignore_above: 1024
       description: Subject name of the code signer
       example: Microsoft Corporation
+      default_field: false
+    - name: Ext.code_signature.trusted
+      level: custom
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: Ext.code_signature.valid
+      level: custom
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
       default_field: false
     - name: Ext.session
       level: custom
@@ -489,6 +585,52 @@
         - -l
         - user
         - 10.0.0.16
+    - name: args_count
+      level: extended
+      type: long
+      description: 'Length of the process.args array.
+
+        This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.'
+      example: 4
+      default_field: false
+    - name: code_signature.exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: code_signature.status
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: code_signature.subject_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: code_signature.trusted
+      level: extended
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: code_signature.valid
+      level: extended
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      default_field: false
     - name: command_line
       level: extended
       type: keyword
@@ -556,6 +698,11 @@
       type: keyword
       ignore_above: 1024
       description: SHA256 hash.
+    - name: hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
     - name: name
       level: extended
       type: keyword
@@ -579,6 +726,49 @@
       type: object
       description: Object for all custom defined fields to live in.
       default_field: false
+    - name: parent.Ext.code_signature
+      level: custom
+      type: nested
+      description: Nested version of ECS code_signature fieldset.
+      default_field: false
+    - name: parent.Ext.code_signature.exists
+      level: custom
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: parent.Ext.code_signature.status
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: parent.Ext.code_signature.subject_name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: parent.Ext.code_signature.trusted
+      level: custom
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: parent.Ext.code_signature.valid
+      level: custom
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      default_field: false
     - name: parent.Ext.real
       level: custom
       type: object
@@ -588,6 +778,82 @@
       level: custom
       type: long
       description: For process.parent this will be the ppid of the process that actually spawned the current process.
+      default_field: false
+    - name: parent.args
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Array of process arguments, starting with the absolute path to the executable.
+
+        May be filtered to protect sensitive information.'
+      example:
+        - /usr/bin/ssh
+        - -l
+        - user
+        - 10.0.0.16
+      default_field: false
+    - name: parent.args_count
+      level: extended
+      type: long
+      description: 'Length of the process.args array.
+
+        This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.'
+      example: 4
+      default_field: false
+    - name: parent.code_signature.exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: parent.code_signature.status
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: parent.code_signature.subject_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: parent.code_signature.trusted
+      level: extended
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: parent.code_signature.valid
+      level: extended
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      default_field: false
+    - name: parent.command_line
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: caseless
+          type: keyword
+          normalizer: lowercase
+          ignore_above: 1024
+        - name: text
+          type: text
+          norms: false
+      description: 'Full command line that started the process, including the absolute path to the executable, and all arguments.
+
+        Some arguments may be filtered to protect sensitive information.'
+      example: /usr/bin/ssh -l user 10.0.0.16
       default_field: false
     - name: parent.entity_id
       level: extended
@@ -615,6 +881,38 @@
       description: Absolute path to the process executable.
       example: /usr/bin/ssh
       default_field: false
+    - name: parent.exit_code
+      level: extended
+      type: long
+      description: 'The exit code of the process, if this is a termination event.
+
+        The field should be absent if there is no exit code for the event (e.g. process start).'
+      example: 137
+      default_field: false
+    - name: parent.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: parent.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: parent.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: parent.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
     - name: parent.name
       level: extended
       type: keyword
@@ -632,12 +930,128 @@
         Sometimes called program name or similar.'
       example: ssh
       default_field: false
+    - name: parent.pe.company
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      default_field: false
+    - name: parent.pe.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      default_field: false
+    - name: parent.pe.file_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      default_field: false
+    - name: parent.pe.original_file_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      default_field: false
+    - name: parent.pe.product
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft® Windows® Operating System"
+      default_field: false
+    - name: parent.pgid
+      level: extended
+      type: long
+      format: string
+      description: Identifier of the group of processes the process belongs to.
+      default_field: false
     - name: parent.pid
       level: core
       type: long
       format: string
       description: Process id.
       example: 4242
+      default_field: false
+    - name: parent.ppid
+      level: extended
+      type: long
+      format: string
+      description: Parent process' pid.
+      example: 4241
+      default_field: false
+    - name: parent.thread.id
+      level: extended
+      type: long
+      format: string
+      description: Thread ID.
+      example: 4242
+      default_field: false
+    - name: parent.thread.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Thread name.
+      example: thread-0
+      default_field: false
+    - name: parent.title
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+      description: 'Process title.
+
+        The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened.'
+      default_field: false
+    - name: parent.uptime
+      level: extended
+      type: long
+      description: Seconds the process has been up.
+      example: 1325
+      default_field: false
+    - name: parent.working_directory
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: caseless
+          type: keyword
+          normalizer: lowercase
+          ignore_above: 1024
+        - name: text
+          type: text
+          norms: false
+      description: The working directory of the process.
+      example: /home/alice
+      default_field: false
+    - name: pe.company
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      default_field: false
+    - name: pe.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      default_field: false
+    - name: pe.file_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
       default_field: false
     - name: pe.original_file_name
       level: extended
@@ -646,18 +1060,75 @@
       description: Internal name of the file, provided at compile-time.
       example: MSPAINT.EXE
       default_field: false
+    - name: pe.product
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft® Windows® Operating System"
+      default_field: false
+    - name: pgid
+      level: extended
+      type: long
+      format: string
+      description: Identifier of the group of processes the process belongs to.
     - name: pid
       level: core
       type: long
       format: string
       description: Process id.
       example: 4242
+    - name: ppid
+      level: extended
+      type: long
+      format: string
+      description: Parent process' pid.
+      example: 4241
     - name: thread.id
       level: extended
       type: long
       format: string
       description: Thread ID.
       example: 4242
+    - name: thread.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Thread name.
+      example: thread-0
+    - name: title
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+      description: 'Process title.
+
+        The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened.'
+    - name: uptime
+      level: extended
+      type: long
+      description: Seconds the process has been up.
+      example: 1325
+    - name: working_directory
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: caseless
+          type: keyword
+          default_field: false
+          normalizer: lowercase
+          ignore_above: 1024
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+      description: The working directory of the process.
+      example: /home/alice
 - name: source
   title: Source
   group: 2
@@ -754,6 +1225,68 @@
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
+    - name: email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User email address.
+    - name: full_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+      description: User's full name, if available.
+      example: Albert Einstein
+    - name: group.Ext
+      level: custom
+      type: object
+      description: Object for all custom defined fields to live in.
+      default_field: false
+    - name: group.Ext.real
+      level: custom
+      type: object
+      description: Group info prior to any setgid operations.
+      default_field: false
+    - name: group.Ext.real.id
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+      default_field: false
+    - name: group.Ext.real.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
+    - name: group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+    - name: group.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+    - name: group.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique user hash to correlate information for a user in anonymized form.
+
+        Useful if `user.id` or `user.name` contain confidential information and cannot be used.'
     - name: id
       level: core
       type: keyword

--- a/package/endpoint/data_stream/registry/fields/fields.yml
+++ b/package/endpoint/data_stream/registry/fields/fields.yml
@@ -171,6 +171,14 @@
 
         This field is an array. This will allow proper categorization of some events that fall in multiple categories.'
       example: authentication
+    - name: code
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identification code for this event, if one exists.
+
+        Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID.'
+      example: 4648
     - name: created
       level: core
       type: date
@@ -192,6 +200,12 @@
 
         It''s recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name.'
       example: apache.access
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
+      example: 123456789012345678901234567890ABCD
     - name: id
       level: core
       type: keyword
@@ -226,6 +240,28 @@
 
         If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module.'
       example: apache
+    - name: outcome
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.
+
+        `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.
+
+        Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective.
+
+        Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.
+
+        Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense.'
+      example: success
+    - name: provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Source of the event.
+
+        Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+      example: kernel
     - name: sequence
       level: extended
       type: long
@@ -233,6 +269,16 @@
       description: 'Sequence number of the event.
 
         The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision.'
+    - name: severity
+      level: core
+      type: long
+      format: string
+      description: 'The numeric severity of the event according to your event source.
+
+        What the different severity values mean can be different between sources and use cases. It''s up to the implementer to make sure severities are consistent across events from the same source.
+
+        The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`.'
+      example: 7
     - name: type
       level: core
       type: keyword
@@ -270,6 +316,13 @@
       ignore_above: 1024
       description: Name of the group.
       default_field: false
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: id
       level: extended
       type: keyword
@@ -294,6 +347,15 @@
       ignore_above: 1024
       description: Operating system architecture.
       example: x86_64
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the domain of which the host is a member.
+
+        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      example: CONTOSO
+      default_field: false
     - name: hostname
       level: core
       type: keyword
@@ -394,6 +456,18 @@
       ignore_above: 1024
       description: Operating system version as a raw string.
       example: 10.14.1
+    - name: type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Type of host.
+
+        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+    - name: uptime
+      level: extended
+      type: long
+      description: Seconds the host has been up.
+      example: 1325
 - name: process
   title: Process
   group: 2
@@ -618,6 +692,68 @@
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
+    - name: email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User email address.
+    - name: full_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+      description: User's full name, if available.
+      example: Albert Einstein
+    - name: group.Ext
+      level: custom
+      type: object
+      description: Object for all custom defined fields to live in.
+      default_field: false
+    - name: group.Ext.real
+      level: custom
+      type: object
+      description: Group info prior to any setgid operations.
+      default_field: false
+    - name: group.Ext.real.id
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+      default_field: false
+    - name: group.Ext.real.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
+    - name: group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+    - name: group.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+    - name: group.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique user hash to correlate information for a user in anonymized form.
+
+        Useful if `user.id` or `user.name` contain confidential information and cannot be used.'
     - name: id
       level: core
       type: keyword

--- a/package/endpoint/data_stream/security/fields/fields.yml
+++ b/package/endpoint/data_stream/security/fields/fields.yml
@@ -171,6 +171,14 @@
 
         This field is an array. This will allow proper categorization of some events that fall in multiple categories.'
       example: authentication
+    - name: code
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Identification code for this event, if one exists.
+
+        Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID.'
+      example: 4648
     - name: created
       level: core
       type: date
@@ -192,6 +200,12 @@
 
         It''s recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name.'
       example: apache.access
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
+      example: 123456789012345678901234567890ABCD
     - name: id
       level: core
       type: keyword
@@ -226,6 +240,28 @@
 
         If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module.'
       example: apache
+    - name: outcome
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy.
+
+        `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event.
+
+        Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective.
+
+        Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer.
+
+        Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense.'
+      example: success
+    - name: provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Source of the event.
+
+        Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+      example: kernel
     - name: sequence
       level: extended
       type: long
@@ -233,6 +269,16 @@
       description: 'Sequence number of the event.
 
         The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision.'
+    - name: severity
+      level: core
+      type: long
+      format: string
+      description: 'The numeric severity of the event according to your event source.
+
+        What the different severity values mean can be different between sources and use cases. It''s up to the implementer to make sure severities are consistent across events from the same source.
+
+        The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`.'
+      example: 7
     - name: type
       level: core
       type: keyword
@@ -270,6 +316,13 @@
       ignore_above: 1024
       description: Name of the group.
       default_field: false
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
     - name: id
       level: extended
       type: keyword
@@ -294,6 +347,15 @@
       ignore_above: 1024
       description: Operating system architecture.
       example: x86_64
+    - name: domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the domain of which the host is a member.
+
+        For example, on Windows this could be the host''s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host''s LDAP provider.'
+      example: CONTOSO
+      default_field: false
     - name: hostname
       level: core
       type: keyword
@@ -394,6 +456,18 @@
       ignore_above: 1024
       description: Operating system version as a raw string.
       example: 10.14.1
+    - name: type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Type of host.
+
+        For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment.'
+    - name: uptime
+      level: extended
+      type: long
+      description: Seconds the host has been up.
+      example: 1325
 - name: process
   title: Process
   group: 2
@@ -566,6 +640,68 @@
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
+    - name: email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User email address.
+    - name: full_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+          default_field: false
+      description: User's full name, if available.
+      example: Albert Einstein
+    - name: group.Ext
+      level: custom
+      type: object
+      description: Object for all custom defined fields to live in.
+      default_field: false
+    - name: group.Ext.real
+      level: custom
+      type: object
+      description: Group info prior to any setgid operations.
+      default_field: false
+    - name: group.Ext.real.id
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+      default_field: false
+    - name: group.Ext.real.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
+    - name: group.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the group is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+    - name: group.id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier for the group on the system/platform.
+    - name: group.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+    - name: hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique user hash to correlate information for a user in anonymized form.
+
+        Useful if `user.id` or `user.name` contain confidential information and cannot be used.'
     - name: id
       level: core
       type: keyword

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -534,14 +534,18 @@ sent by the endpoint.
 | event.Ext.correlation.id | ID of event that this event is correlated to, e.g. quarantine event associated with an unquarantine event | keyword |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.code | Identification code for this event, if one exists. Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID. | keyword |
 | event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |
+| event.hash | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity. | keyword |
 | event.id | Unique ID to describe the event. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` < `event.created` < `event.ingested`. | date |
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
 | event.outcome | This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy. `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event. Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective. Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer. Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense. | keyword |
+| event.provider | Source of the event. Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing). | keyword |
 | event.sequence | Sequence number of the event. The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision. | long |
+| event.severity | The numeric severity of the event according to your event source. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source. The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`. | long |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
 | file.Ext | Object for all custom defined fields to live in. | object |
 | file.Ext.original | Original file information during a modification event. | object |
@@ -554,25 +558,45 @@ sent by the endpoint.
 | file.Ext.original.uid | The user ID (UID) or security identifier (SID) of the file owner. | keyword |
 | file.Ext.windows | Platform-specific Windows fields | object |
 | file.Ext.windows.zone_identifier | Windows zone identifier for a file | keyword |
+| file.accessed | Last time the file was accessed. Note that not all filesystems keep track of access time. | date |
+| file.attributes | Array of file attributes. Attributes names will vary by platform. Here's a non-exhaustive list of values that are expected in this field: archive, compressed, directory, encrypted, execute, hidden, read, readonly, system, write. | keyword |
+| file.created | File creation time. Note that not all filesystems store the creation time. | date |
+| file.ctime | Last time the file attributes or metadata changed. Note that changes to the file content will update `mtime`. This implies `ctime` will be adjusted at the same time, since `mtime` is an attribute of the file. | date |
+| file.device | Device that is the source of the file. | keyword |
+| file.directory | Directory where the file is located. It should include the drive letter, when appropriate. | keyword |
+| file.drive_letter | Drive letter where the file is located. This field is only relevant on Windows. The value should be uppercase, and not include the colon. | keyword |
 | file.extension | File extension. | keyword |
 | file.gid | Primary group ID (GID) of the file. | keyword |
 | file.group | Primary group name of the file. | keyword |
 | file.hash.md5 | MD5 hash. | keyword |
 | file.hash.sha1 | SHA1 hash. | keyword |
 | file.hash.sha256 | SHA256 hash. | keyword |
+| file.hash.sha512 | SHA512 hash. | keyword |
 | file.inode | Inode representing the file in the filesystem. | keyword |
+| file.mime_type | MIME type should identify the format of the file or stream of bytes using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official types], where possible. When more than one type is applicable, the most specific type should be used. | keyword |
 | file.mode | Mode of the file in octal representation. | keyword |
+| file.mtime | Last time the file content was modified. | date |
 | file.name | Name of the file including the extension, without the directory. | keyword |
 | file.owner | File owner's username. | keyword |
 | file.path | Full path to the file, including the file name. It should include the drive letter, when appropriate. | keyword |
+| file.pe.company | Internal company name of the file, provided at compile-time. | keyword |
+| file.pe.description | Internal description of the file, provided at compile-time. | keyword |
+| file.pe.file_version | Internal version of the file, provided at compile-time. | keyword |
+| file.pe.original_file_name | Internal name of the file, provided at compile-time. | keyword |
+| file.pe.product | Internal product name of the file, provided at compile-time. | keyword |
+| file.size | File size in bytes. Only relevant when `file.type` is "file". | long |
+| file.target_path | Target path for symlinks. | keyword |
+| file.type | File type (file, dir, or symlink). | keyword |
 | file.uid | The user ID (UID) or security identifier (SID) of the file owner. | keyword |
 | group.Ext | Object for all custom defined fields to live in. | object |
 | group.Ext.real | Group info prior to any setgid operations. | object |
 | group.Ext.real.id | Unique identifier for the group on the system/platform. | keyword |
 | group.Ext.real.name | Name of the group. | keyword |
+| group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
 | group.id | Unique identifier for the group on the system/platform. | keyword |
 | group.name | Name of the group. | keyword |
 | host.architecture | Operating system architecture. | keyword |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
@@ -586,6 +610,8 @@ sent by the endpoint.
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| host.uptime | Seconds the host has been up. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 | process.Ext | Object for all custom defined fields to live in. | object |
 | process.Ext.ancestry | An array of entity_ids indicating the ancestors for this event | keyword |
@@ -608,6 +634,16 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.email | User email address. | keyword |
+| user.full_name | User's full name, if available. | keyword |
+| user.group.Ext | Object for all custom defined fields to live in. | object |
+| user.group.Ext.real | Group info prior to any setgid operations. | object |
+| user.group.Ext.real.id | Unique identifier for the group on the system/platform. | keyword |
+| user.group.Ext.real.name | Name of the group. | keyword |
+| user.group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.group.id | Unique identifier for the group on the system/platform. | keyword |
+| user.group.name | Name of the group. | keyword |
+| user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 
@@ -635,31 +671,47 @@ sent by the endpoint.
 | destination.geo.region_name | Region name. | keyword |
 | dll.Ext | Object for all custom defined fields to live in. | object |
 | dll.Ext.code_signature | Nested version of ECS code_signature fieldset. | nested |
+| dll.Ext.code_signature.exists | Boolean to capture if a signature is present. | boolean |
 | dll.Ext.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
 | dll.Ext.code_signature.subject_name | Subject name of the code signer | keyword |
+| dll.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
+| dll.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
+| dll.pe.company | Internal company name of the file, provided at compile-time. | keyword |
+| dll.pe.description | Internal description of the file, provided at compile-time. | keyword |
 | dll.pe.file_version | Internal version of the file, provided at compile-time. | keyword |
 | dll.pe.original_file_name | Internal name of the file, provided at compile-time. | keyword |
 | dll.pe.product | Internal product name of the file, provided at compile-time. | keyword |
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.code | Identification code for this event, if one exists. Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID. | keyword |
 | event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |
+| event.hash | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity. | keyword |
 | event.id | Unique ID to describe the event. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` < `event.created` < `event.ingested`. | date |
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
+| event.outcome | This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy. `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event. Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective. Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer. Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense. | keyword |
+| event.provider | Source of the event. Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing). | keyword |
 | event.sequence | Sequence number of the event. The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision. | long |
+| event.severity | The numeric severity of the event according to your event source. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source. The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`. | long |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
 | file.Ext | Object for all custom defined fields to live in. | object |
 | file.Ext.code_signature | Nested version of ECS code_signature fieldset. | nested |
+| file.Ext.code_signature.exists | Boolean to capture if a signature is present. | boolean |
 | file.Ext.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
 | file.Ext.code_signature.subject_name | Subject name of the code signer | keyword |
+| file.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
+| file.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | file.hash.md5 | MD5 hash. | keyword |
 | file.hash.sha1 | SHA1 hash. | keyword |
 | file.hash.sha256 | SHA256 hash. | keyword |
+| file.hash.sha512 | SHA512 hash. | keyword |
 | file.name | Name of the file including the extension, without the directory. | keyword |
 | file.path | Full path to the file, including the file name. It should include the drive letter, when appropriate. | keyword |
+| file.pe.company | Internal company name of the file, provided at compile-time. | keyword |
+| file.pe.description | Internal description of the file, provided at compile-time. | keyword |
 | file.pe.file_version | Internal version of the file, provided at compile-time. | keyword |
 | file.pe.original_file_name | Internal name of the file, provided at compile-time. | keyword |
 | file.pe.product | Internal product name of the file, provided at compile-time. | keyword |
@@ -667,9 +719,11 @@ sent by the endpoint.
 | group.Ext.real | Group info prior to any setgid operations. | object |
 | group.Ext.real.id | Unique identifier for the group on the system/platform. | keyword |
 | group.Ext.real.name | Name of the group. | keyword |
+| group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
 | group.id | Unique identifier for the group on the system/platform. | keyword |
 | group.name | Name of the group. | keyword |
 | host.architecture | Operating system architecture. | keyword |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
@@ -683,6 +737,8 @@ sent by the endpoint.
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| host.uptime | Seconds the host has been up. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 | process.Ext | Object for all custom defined fields to live in. | object |
 | process.Ext.ancestry | An array of entity_ids indicating the ancestors for this event | keyword |
@@ -704,6 +760,16 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.email | User email address. | keyword |
+| user.full_name | User's full name, if available. | keyword |
+| user.group.Ext | Object for all custom defined fields to live in. | object |
+| user.group.Ext.real | Group info prior to any setgid operations. | object |
+| user.group.Ext.real.id | Unique identifier for the group on the system/platform. | keyword |
+| user.group.Ext.real.name | Name of the group. | keyword |
+| user.group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.group.id | Unique identifier for the group on the system/platform. | keyword |
+| user.group.name | Name of the group. | keyword |
+| user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 
@@ -749,21 +815,28 @@ sent by the endpoint.
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.code | Identification code for this event, if one exists. Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID. | keyword |
 | event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |
+| event.hash | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity. | keyword |
 | event.id | Unique ID to describe the event. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` < `event.created` < `event.ingested`. | date |
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
+| event.outcome | This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy. `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event. Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective. Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer. Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense. | keyword |
+| event.provider | Source of the event. Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing). | keyword |
 | event.sequence | Sequence number of the event. The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision. | long |
+| event.severity | The numeric severity of the event according to your event source. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source. The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`. | long |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
 | group.Ext | Object for all custom defined fields to live in. | object |
 | group.Ext.real | Group info prior to any setgid operations. | object |
 | group.Ext.real.id | Unique identifier for the group on the system/platform. | keyword |
 | group.Ext.real.name | Name of the group. | keyword |
+| group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
 | group.id | Unique identifier for the group on the system/platform. | keyword |
 | group.name | Name of the group. | keyword |
 | host.architecture | Operating system architecture. | keyword |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
@@ -777,6 +850,8 @@ sent by the endpoint.
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| host.uptime | Seconds the host has been up. | long |
 | http.request.body.bytes | Size in bytes of the request body. | long |
 | http.request.body.content | The full HTTP request body. | keyword |
 | http.request.bytes | Total size in bytes of the request (body and headers). | long |
@@ -823,6 +898,16 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.email | User email address. | keyword |
+| user.full_name | User's full name, if available. | keyword |
+| user.group.Ext | Object for all custom defined fields to live in. | object |
+| user.group.Ext.real | Group info prior to any setgid operations. | object |
+| user.group.Ext.real.id | Unique identifier for the group on the system/platform. | keyword |
+| user.group.Ext.real.name | Name of the group. | keyword |
+| user.group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.group.id | Unique identifier for the group on the system/platform. | keyword |
+| user.group.name | Name of the group. | keyword |
+| user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 
@@ -851,21 +936,28 @@ sent by the endpoint.
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.code | Identification code for this event, if one exists. Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID. | keyword |
 | event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |
+| event.hash | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity. | keyword |
 | event.id | Unique ID to describe the event. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` < `event.created` < `event.ingested`. | date |
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
+| event.outcome | This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy. `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event. Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective. Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer. Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense. | keyword |
+| event.provider | Source of the event. Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing). | keyword |
 | event.sequence | Sequence number of the event. The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision. | long |
+| event.severity | The numeric severity of the event according to your event source. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source. The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`. | long |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
 | group.Ext | Object for all custom defined fields to live in. | object |
 | group.Ext.real | Group info prior to any setgid operations. | object |
 | group.Ext.real.id | Unique identifier for the group on the system/platform. | keyword |
 | group.Ext.real.name | Name of the group. | keyword |
+| group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
 | group.id | Unique identifier for the group on the system/platform. | keyword |
 | group.name | Name of the group. | keyword |
 | host.architecture | Operating system architecture. | keyword |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
@@ -879,19 +971,30 @@ sent by the endpoint.
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| host.uptime | Seconds the host has been up. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 | package.name | Package name | keyword |
 | process.Ext | Object for all custom defined fields to live in. | object |
 | process.Ext.ancestry | An array of entity_ids indicating the ancestors for this event | keyword |
 | process.Ext.authentication_id | Process authentication ID | keyword |
 | process.Ext.code_signature | Nested version of ECS code_signature fieldset. | nested |
+| process.Ext.code_signature.exists | Boolean to capture if a signature is present. | boolean |
 | process.Ext.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
 | process.Ext.code_signature.subject_name | Subject name of the code signer | keyword |
+| process.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
+| process.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.Ext.session | Session information for the current process | keyword |
 | process.Ext.token.elevation | Whether the token is elevated or not | boolean |
 | process.Ext.token.elevation_type | What level of elevation the token has | keyword |
 | process.Ext.token.integrity_level_name | Human readable integrity level. | keyword |
 | process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
+| process.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
+| process.code_signature.exists | Boolean to capture if a signature is present. | boolean |
+| process.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
+| process.code_signature.subject_name | Subject name of the code signer | keyword |
+| process.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
+| process.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | keyword |
 | process.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |
 | process.executable | Absolute path to the process executable. | keyword |
@@ -899,17 +1002,59 @@ sent by the endpoint.
 | process.hash.md5 | MD5 hash. | keyword |
 | process.hash.sha1 | SHA1 hash. | keyword |
 | process.hash.sha256 | SHA256 hash. | keyword |
+| process.hash.sha512 | SHA512 hash. | keyword |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
 | process.parent.Ext | Object for all custom defined fields to live in. | object |
+| process.parent.Ext.code_signature | Nested version of ECS code_signature fieldset. | nested |
+| process.parent.Ext.code_signature.exists | Boolean to capture if a signature is present. | boolean |
+| process.parent.Ext.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
+| process.parent.Ext.code_signature.subject_name | Subject name of the code signer | keyword |
+| process.parent.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
+| process.parent.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.parent.Ext.real | The field set containing process info in case of any pid spoofing. This is mainly useful for process.parent. | object |
 | process.parent.Ext.real.pid | For process.parent this will be the ppid of the process that actually spawned the current process. | long |
+| process.parent.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
+| process.parent.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
+| process.parent.code_signature.exists | Boolean to capture if a signature is present. | boolean |
+| process.parent.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
+| process.parent.code_signature.subject_name | Subject name of the code signer | keyword |
+| process.parent.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
+| process.parent.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
+| process.parent.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | keyword |
 | process.parent.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |
 | process.parent.executable | Absolute path to the process executable. | keyword |
+| process.parent.exit_code | The exit code of the process, if this is a termination event. The field should be absent if there is no exit code for the event (e.g. process start). | long |
+| process.parent.hash.md5 | MD5 hash. | keyword |
+| process.parent.hash.sha1 | SHA1 hash. | keyword |
+| process.parent.hash.sha256 | SHA256 hash. | keyword |
+| process.parent.hash.sha512 | SHA512 hash. | keyword |
 | process.parent.name | Process name. Sometimes called program name or similar. | keyword |
+| process.parent.pe.company | Internal company name of the file, provided at compile-time. | keyword |
+| process.parent.pe.description | Internal description of the file, provided at compile-time. | keyword |
+| process.parent.pe.file_version | Internal version of the file, provided at compile-time. | keyword |
+| process.parent.pe.original_file_name | Internal name of the file, provided at compile-time. | keyword |
+| process.parent.pe.product | Internal product name of the file, provided at compile-time. | keyword |
+| process.parent.pgid | Identifier of the group of processes the process belongs to. | long |
 | process.parent.pid | Process id. | long |
+| process.parent.ppid | Parent process' pid. | long |
+| process.parent.thread.id | Thread ID. | long |
+| process.parent.thread.name | Thread name. | keyword |
+| process.parent.title | Process title. The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened. | keyword |
+| process.parent.uptime | Seconds the process has been up. | long |
+| process.parent.working_directory | The working directory of the process. | keyword |
+| process.pe.company | Internal company name of the file, provided at compile-time. | keyword |
+| process.pe.description | Internal description of the file, provided at compile-time. | keyword |
+| process.pe.file_version | Internal version of the file, provided at compile-time. | keyword |
 | process.pe.original_file_name | Internal name of the file, provided at compile-time. | keyword |
+| process.pe.product | Internal product name of the file, provided at compile-time. | keyword |
+| process.pgid | Identifier of the group of processes the process belongs to. | long |
 | process.pid | Process id. | long |
+| process.ppid | Parent process' pid. | long |
 | process.thread.id | Thread ID. | long |
+| process.thread.name | Thread name. | keyword |
+| process.title | Process title. The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened. | keyword |
+| process.uptime | Seconds the process has been up. | long |
+| process.working_directory | The working directory of the process. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_name | Name of the continent. | keyword |
 | source.geo.country_iso_code | Country ISO code. | keyword |
@@ -923,6 +1068,16 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.email | User email address. | keyword |
+| user.full_name | User's full name, if available. | keyword |
+| user.group.Ext | Object for all custom defined fields to live in. | object |
+| user.group.Ext.real | Group info prior to any setgid operations. | object |
+| user.group.Ext.real.id | Unique identifier for the group on the system/platform. | keyword |
+| user.group.Ext.real.name | Name of the group. | keyword |
+| user.group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.group.id | Unique identifier for the group on the system/platform. | keyword |
+| user.group.name | Name of the group. | keyword |
+| user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 
@@ -951,21 +1106,28 @@ sent by the endpoint.
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.code | Identification code for this event, if one exists. Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID. | keyword |
 | event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |
+| event.hash | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity. | keyword |
 | event.id | Unique ID to describe the event. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` < `event.created` < `event.ingested`. | date |
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
+| event.outcome | This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy. `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event. Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective. Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer. Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense. | keyword |
+| event.provider | Source of the event. Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing). | keyword |
 | event.sequence | Sequence number of the event. The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision. | long |
+| event.severity | The numeric severity of the event according to your event source. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source. The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`. | long |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
 | group.Ext | Object for all custom defined fields to live in. | object |
 | group.Ext.real | Group info prior to any setgid operations. | object |
 | group.Ext.real.id | Unique identifier for the group on the system/platform. | keyword |
 | group.Ext.real.name | Name of the group. | keyword |
+| group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
 | group.id | Unique identifier for the group on the system/platform. | keyword |
 | group.name | Name of the group. | keyword |
 | host.architecture | Operating system architecture. | keyword |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
@@ -979,6 +1141,8 @@ sent by the endpoint.
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| host.uptime | Seconds the host has been up. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 | process.Ext | Object for all custom defined fields to live in. | object |
 | process.Ext.ancestry | An array of entity_ids indicating the ancestors for this event | keyword |
@@ -1006,6 +1170,16 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.email | User email address. | keyword |
+| user.full_name | User's full name, if available. | keyword |
+| user.group.Ext | Object for all custom defined fields to live in. | object |
+| user.group.Ext.real | Group info prior to any setgid operations. | object |
+| user.group.Ext.real.id | Unique identifier for the group on the system/platform. | keyword |
+| user.group.Ext.real.name | Name of the group. | keyword |
+| user.group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.group.id | Unique identifier for the group on the system/platform. | keyword |
+| user.group.name | Name of the group. | keyword |
+| user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 
@@ -1034,21 +1208,28 @@ sent by the endpoint.
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.code | Identification code for this event, if one exists. Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID. | keyword |
 | event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |
+| event.hash | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity. | keyword |
 | event.id | Unique ID to describe the event. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` < `event.created` < `event.ingested`. | date |
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
+| event.outcome | This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy. `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event. Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective. Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer. Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense. | keyword |
+| event.provider | Source of the event. Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing). | keyword |
 | event.sequence | Sequence number of the event. The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision. | long |
+| event.severity | The numeric severity of the event according to your event source. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source. The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`. | long |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
 | group.Ext | Object for all custom defined fields to live in. | object |
 | group.Ext.real | Group info prior to any setgid operations. | object |
 | group.Ext.real.id | Unique identifier for the group on the system/platform. | keyword |
 | group.Ext.real.name | Name of the group. | keyword |
+| group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
 | group.id | Unique identifier for the group on the system/platform. | keyword |
 | group.name | Name of the group. | keyword |
 | host.architecture | Operating system architecture. | keyword |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
@@ -1062,6 +1243,8 @@ sent by the endpoint.
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| host.uptime | Seconds the host has been up. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 | process.Ext | Object for all custom defined fields to live in. | object |
 | process.Ext.ancestry | An array of entity_ids indicating the ancestors for this event | keyword |
@@ -1083,6 +1266,16 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.email | User email address. | keyword |
+| user.full_name | User's full name, if available. | keyword |
+| user.group.Ext | Object for all custom defined fields to live in. | object |
+| user.group.Ext.real | Group info prior to any setgid operations. | object |
+| user.group.Ext.real.id | Unique identifier for the group on the system/platform. | keyword |
+| user.group.Ext.real.name | Name of the group. | keyword |
+| user.group.domain | Name of the directory the group is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.group.id | Unique identifier for the group on the system/platform. | keyword |
+| user.group.name | Name of the group. | keyword |
+| user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
 
@@ -1173,17 +1366,23 @@ Metrics documents contain performance information about the endpoint executable 
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.code | Identification code for this event, if one exists. Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID. | keyword |
 | event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |
 | event.end | event.end contains the date when the event ended or when the activity was last observed. | date |
+| event.hash | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity. | keyword |
 | event.id | Unique ID to describe the event. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` < `event.created` < `event.ingested`. | date |
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
+| event.outcome | This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy. `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event. Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective. Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer. Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense. | keyword |
+| event.provider | Source of the event. Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing). | keyword |
 | event.sequence | Sequence number of the event. The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision. | long |
+| event.severity | The numeric severity of the event according to your event source. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source. The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`. | long |
 | event.start | event.start contains the date when the event started or when the activity was first observed. | date |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
 | host.architecture | Operating system architecture. | keyword |
+| host.domain | Name of the domain of which the host is a member. For example, on Windows this could be the host's Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host's LDAP provider. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
@@ -1197,6 +1396,8 @@ Metrics documents contain performance information about the endpoint executable 
 | host.os.name | Operating system name, without the version. | keyword |
 | host.os.platform | Operating system platform (such centos, ubuntu, windows). | keyword |
 | host.os.version | Operating system version as a raw string. | keyword |
+| host.type | Type of host. For Cloud providers this can be the machine type like `t2.medium`. If vm, this could be the container, for example, or other information meaningful in your environment. | keyword |
+| host.uptime | Seconds the host has been up. | long |
 | message | For log events the message field contains the log message, optimized for viewing in a log viewer. For structured logs without an original message field, other fields can be concatenated to form a human-readable summary of the event. If multiple messages exist, they can be combined into one message. | text |
 
 
@@ -1222,13 +1423,18 @@ Metrics documents contain performance information about the endpoint executable 
 | ecs.version | ECS version this event conforms to. `ecs.version` is a required field and must exist in all events. When querying across multiple indices -- which may conform to slightly different ECS versions -- this field lets integrations adjust to the schema version of the events. | keyword |
 | event.action | The action captured by the event. This describes the information in the event. It is more specific than `event.category`. Examples are `group-add`, `process-started`, `file-created`. The value is normally defined by the implementer. | keyword |
 | event.category | This is one of four ECS Categorization Fields, and indicates the second level in the ECS category hierarchy. `event.category` represents the "big buckets" of ECS categories. For example, filtering on `event.category:process` yields all events relating to process activity. This field is closely related to `event.type`, which is used as a subcategory. This field is an array. This will allow proper categorization of some events that fall in multiple categories. | keyword |
+| event.code | Identification code for this event, if one exists. Some event sources use event codes to identify messages unambiguously, regardless of message language or wording adjustments over time. An example of this is the Windows Event ID. | keyword |
 | event.created | event.created contains the date/time when the event was first read by an agent, or by your pipeline. This field is distinct from @timestamp in that @timestamp typically contain the time extracted from the original event. In most situations, these two timestamps will be slightly different. The difference can be used to calculate the delay between your source generating an event, and the time when your agent first processed it. This can be used to monitor your agent's or pipeline's ability to keep up with your event source. In case the two timestamps are identical, @timestamp should be used. | date |
 | event.dataset | Name of the dataset. If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from. It's recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name. | keyword |
+| event.hash | Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity. | keyword |
 | event.id | Unique ID to describe the event. | keyword |
 | event.ingested | Timestamp when an event arrived in the central data store. This is different from `@timestamp`, which is when the event originally occurred.  It's also different from `event.created`, which is meant to capture the first time an agent saw the event. In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` < `event.created` < `event.ingested`. | date |
 | event.kind | This is one of four ECS Categorization Fields, and indicates the highest level in the ECS category hierarchy. `event.kind` gives high-level information about what type of information the event contains, without being specific to the contents of the event. For example, values of this field distinguish alert events from metric events. The value of this field can be used to inform how these kinds of events should be handled. They may warrant different retention, different access control, it may also help understand whether the data coming in at a regular interval or not. | keyword |
 | event.module | Name of the module this data is coming from. If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module. | keyword |
+| event.outcome | This is one of four ECS Categorization Fields, and indicates the lowest level in the ECS category hierarchy. `event.outcome` simply denotes whether the event represents a success or a failure from the perspective of the entity that produced the event. Note that when a single transaction is described in multiple events, each event may populate different values of `event.outcome`, according to their perspective. Also note that in the case of a compound event (a single event that contains multiple logical events), this field should be populated with the value that best captures the overall success or failure from the perspective of the event producer. Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense. | keyword |
+| event.provider | Source of the event. Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing). | keyword |
 | event.sequence | Sequence number of the event. The sequence number is a value published by some event sources, to make the exact ordering of events unambiguous, regardless of the timestamp precision. | long |
+| event.severity | The numeric severity of the event according to your event source. What the different severity values mean can be different between sources and use cases. It's up to the implementer to make sure severities are consistent across events from the same source. The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is meant to represent the severity according to the event source (e.g. firewall, IDS). If the event source does not publish its own severity, you may optionally copy the `log.syslog.severity.code` to `event.severity`. | long |
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
 | host.architecture | Operating system architecture. | keyword |
 | host.hostname | Hostname of the host. It normally contains what the `hostname` command returns on the host machine. | keyword |

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -370,6 +370,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -407,6 +422,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -565,6 +593,21 @@ event.outcome:
   normalize: []
   short: The outcome of the event. The lowest level categorization field in the hierarchy.
   type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -577,6 +620,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -828,6 +891,93 @@ file.Ext.windows.zone_identifier:
   normalize: []
   short: Windows zone identifier for a file
   type: keyword
+file.accessed:
+  dashed_name: file-accessed
+  description: 'Last time the file was accessed.
+
+    Note that not all filesystems keep track of access time.'
+  flat_name: file.accessed
+  level: extended
+  name: accessed
+  normalize: []
+  short: Last time the file was accessed.
+  type: date
+file.attributes:
+  dashed_name: file-attributes
+  description: 'Array of file attributes.
+
+    Attributes names will vary by platform. Here''s a non-exhaustive list of values
+    that are expected in this field: archive, compressed, directory, encrypted, execute,
+    hidden, read, readonly, system, write.'
+  example: '["readonly", "system"]'
+  flat_name: file.attributes
+  ignore_above: 1024
+  level: extended
+  name: attributes
+  normalize:
+  - array
+  short: Array of file attributes.
+  type: keyword
+file.created:
+  dashed_name: file-created
+  description: 'File creation time.
+
+    Note that not all filesystems store the creation time.'
+  flat_name: file.created
+  level: extended
+  name: created
+  normalize: []
+  short: File creation time.
+  type: date
+file.ctime:
+  dashed_name: file-ctime
+  description: 'Last time the file attributes or metadata changed.
+
+    Note that changes to the file content will update `mtime`. This implies `ctime`
+    will be adjusted at the same time, since `mtime` is an attribute of the file.'
+  flat_name: file.ctime
+  level: extended
+  name: ctime
+  normalize: []
+  short: Last time the file attributes or metadata changed.
+  type: date
+file.device:
+  dashed_name: file-device
+  description: Device that is the source of the file.
+  example: sda
+  flat_name: file.device
+  ignore_above: 1024
+  level: extended
+  name: device
+  normalize: []
+  short: Device that is the source of the file.
+  type: keyword
+file.directory:
+  dashed_name: file-directory
+  description: Directory where the file is located. It should include the drive letter,
+    when appropriate.
+  example: /home/alice
+  flat_name: file.directory
+  ignore_above: 1024
+  level: extended
+  name: directory
+  normalize: []
+  short: Directory where the file is located.
+  type: keyword
+file.drive_letter:
+  dashed_name: file-drive-letter
+  description: 'Drive letter where the file is located. This field is only relevant
+    on Windows.
+
+    The value should be uppercase, and not include the colon.'
+  example: C
+  flat_name: file.drive_letter
+  ignore_above: 1
+  level: extended
+  name: drive_letter
+  normalize: []
+  short: Drive letter where the file is located.
+  type: keyword
 file.extension:
   dashed_name: file-extension
   description: File extension.
@@ -894,6 +1044,17 @@ file.hash.sha256:
   original_fieldset: hash
   short: SHA256 hash.
   type: keyword
+file.hash.sha512:
+  dashed_name: file-hash-sha512
+  description: SHA512 hash.
+  flat_name: file.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
 file.inode:
   dashed_name: file-inode
   description: Inode representing the file in the filesystem.
@@ -904,6 +1065,19 @@ file.inode:
   name: inode
   normalize: []
   short: Inode representing the file in the filesystem.
+  type: keyword
+file.mime_type:
+  dashed_name: file-mime-type
+  description: MIME type should identify the format of the file or stream of bytes
+    using https://www.iana.org/assignments/media-types/media-types.xhtml[IANA official
+    types], where possible. When more than one type is applicable, the most specific
+    type should be used.
+  flat_name: file.mime_type
+  ignore_above: 1024
+  level: extended
+  name: mime_type
+  normalize: []
+  short: Media type of file, document, or arrangement of bytes.
   type: keyword
 file.mode:
   dashed_name: file-mode
@@ -916,6 +1090,15 @@ file.mode:
   normalize: []
   short: Mode of the file in octal representation.
   type: keyword
+file.mtime:
+  dashed_name: file-mtime
+  description: Last time the file content was modified.
+  flat_name: file.mtime
+  level: extended
+  name: mtime
+  normalize: []
+  short: Last time the file content was modified.
+  type: date
 file.name:
   dashed_name: file-name
   description: Name of the file including the extension, without the directory.
@@ -959,6 +1142,109 @@ file.path:
   name: path
   normalize: []
   short: Full path to the file, including the file name.
+  type: keyword
+file.pe.company:
+  dashed_name: file-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: file.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+file.pe.description:
+  dashed_name: file-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: file.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+file.pe.file_version:
+  dashed_name: file-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: file.pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+file.pe.original_file_name:
+  dashed_name: file-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: file.pe.original_file_name
+  ignore_above: 1024
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: keyword
+file.pe.product:
+  dashed_name: file-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: file.pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+file.size:
+  dashed_name: file-size
+  description: 'File size in bytes.
+
+    Only relevant when `file.type` is "file".'
+  example: 16384
+  flat_name: file.size
+  level: extended
+  name: size
+  normalize: []
+  short: File size in bytes.
+  type: long
+file.target_path:
+  dashed_name: file-target-path
+  description: Target path for symlinks.
+  flat_name: file.target_path
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: file.target_path.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
+  - flat_name: file.target_path.text
+    name: text
+    norms: false
+    type: text
+  name: target_path
+  normalize: []
+  short: Target path for symlinks.
+  type: keyword
+file.type:
+  dashed_name: file-type
+  description: File type (file, dir, or symlink).
+  example: file
+  flat_name: file.type
+  ignore_above: 1024
+  level: extended
+  name: type
+  normalize: []
+  short: File type (file, dir, or symlink).
   type: keyword
 file.uid:
   dashed_name: file-uid
@@ -1009,6 +1295,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -1039,6 +1337,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -1217,6 +1529,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -1502,6 +1837,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -202,6 +202,16 @@ dll.Ext.code_signature:
   normalize: []
   short: Nested version of ECS code_signature fieldset.
   type: nested
+dll.Ext.code_signature.exists:
+  dashed_name: dll-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: dll.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
 dll.Ext.code_signature.status:
   dashed_name: dll-Ext-code-signature-status
   description: 'Additional information about the certificate status.
@@ -227,6 +237,57 @@ dll.Ext.code_signature.subject_name:
   name: Ext.code_signature.subject_name
   normalize: []
   short: Subject name of the code signer
+  type: keyword
+dll.Ext.code_signature.trusted:
+  dashed_name: dll-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: dll.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+dll.Ext.code_signature.valid:
+  dashed_name: dll-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: dll.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
+dll.pe.company:
+  dashed_name: dll-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: dll.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+dll.pe.description:
+  dashed_name: dll-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: dll.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
   type: keyword
 dll.pe.file_version:
   dashed_name: dll-pe-file-version
@@ -450,6 +511,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -487,6 +563,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -602,6 +691,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -614,6 +761,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -772,6 +939,16 @@ file.Ext.code_signature:
   normalize: []
   short: Nested version of ECS code_signature fieldset.
   type: nested
+file.Ext.code_signature.exists:
+  dashed_name: file-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: file.Ext.code_signature.exists
+  level: core
+  name: Ext.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
 file.Ext.code_signature.status:
   dashed_name: file-Ext-code-signature-status
   description: 'Additional information about the certificate status.
@@ -798,6 +975,33 @@ file.Ext.code_signature.subject_name:
   normalize: []
   short: Subject name of the code signer
   type: keyword
+file.Ext.code_signature.trusted:
+  dashed_name: file-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: file.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+file.Ext.code_signature.valid:
+  dashed_name: file-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: file.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 file.hash.md5:
   dashed_name: file-hash-md5
   description: MD5 hash.
@@ -831,6 +1035,17 @@ file.hash.sha256:
   original_fieldset: hash
   short: SHA256 hash.
   type: keyword
+file.hash.sha512:
+  dashed_name: file-hash-sha512
+  description: SHA512 hash.
+  flat_name: file.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
 file.name:
   dashed_name: file-name
   description: Name of the file including the extension, without the directory.
@@ -863,6 +1078,30 @@ file.path:
   name: path
   normalize: []
   short: Full path to the file, including the file name.
+  type: keyword
+file.pe.company:
+  dashed_name: file-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: file.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+file.pe.description:
+  dashed_name: file-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: file.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
   type: keyword
 file.pe.file_version:
   dashed_name: file-pe-file-version
@@ -938,6 +1177,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -968,6 +1219,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -1146,6 +1411,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -1417,6 +1705,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -477,6 +477,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -526,6 +541,19 @@ event.end:
   short: event.end contains the date when the event ended or when the activity was
     last observed.
   type: date
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  type: keyword
 event.id:
   dashed_name: event-id
   description: Unique ID to describe the event.
@@ -640,6 +668,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -652,6 +738,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.start:
   dashed_name: event-start
@@ -813,6 +919,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -991,6 +1111,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized

--- a/schemas/v1/network/network.yaml
+++ b/schemas/v1/network/network.yaml
@@ -592,6 +592,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -629,6 +644,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -744,6 +772,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -756,6 +842,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -934,6 +1040,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -964,6 +1082,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -1142,6 +1274,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 http.request.body.bytes:
   dashed_name: http-request-body-bytes
   description: Size in bytes of the request body.
@@ -1732,6 +1887,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -615,6 +615,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -652,6 +667,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -767,6 +795,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -779,6 +865,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -370,6 +370,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -407,6 +422,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -522,6 +550,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -534,6 +620,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -712,6 +818,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -742,6 +860,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -920,6 +1052,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -986,6 +1141,16 @@ process.Ext.code_signature:
   normalize: []
   short: Nested version of ECS code_signature fieldset.
   type: nested
+process.Ext.code_signature.exists:
+  dashed_name: process-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
 process.Ext.code_signature.status:
   dashed_name: process-Ext-code-signature-status
   description: 'Additional information about the certificate status.
@@ -1012,6 +1177,33 @@ process.Ext.code_signature.subject_name:
   normalize: []
   short: Subject name of the code signer
   type: keyword
+process.Ext.code_signature.trusted:
+  dashed_name: process-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.Ext.code_signature.valid:
+  dashed_name: process-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 process.Ext.session:
   dashed_name: process-Ext-session
   description: Session information for the current process
@@ -1075,6 +1267,88 @@ process.args:
   - array
   short: Array of process arguments.
   type: keyword
+process.args_count:
+  dashed_name: process-args-count
+  description: 'Length of the process.args array.
+
+    This field can be useful for querying or performing bucket analysis on how many
+    arguments were provided to start a process. More arguments may be an indication
+    of suspicious activity.'
+  example: 4
+  flat_name: process.args_count
+  level: extended
+  name: args_count
+  normalize: []
+  short: Length of the process.args array.
+  type: long
+process.code_signature.exists:
+  dashed_name: process-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.code_signature.exists
+  level: core
+  name: exists
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.code_signature.status:
+  dashed_name: process-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.code_signature.status
+  ignore_above: 1024
+  level: extended
+  name: status
+  normalize: []
+  original_fieldset: code_signature
+  short: Additional information about the certificate status.
+  type: keyword
+process.code_signature.subject_name:
+  dashed_name: process-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.code_signature.subject_name
+  ignore_above: 1024
+  level: core
+  name: subject_name
+  normalize: []
+  original_fieldset: code_signature
+  short: Subject name of the code signer
+  type: keyword
+process.code_signature.trusted:
+  dashed_name: process-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.code_signature.trusted
+  level: extended
+  name: trusted
+  normalize: []
+  original_fieldset: code_signature
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.code_signature.valid:
+  dashed_name: process-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.code_signature.valid
+  level: extended
+  name: valid
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 process.command_line:
   dashed_name: process-command-line
   description: 'Full command line that started the process, including the absolute
@@ -1185,6 +1459,17 @@ process.hash.sha256:
   original_fieldset: hash
   short: SHA256 hash.
   type: keyword
+process.hash.sha512:
+  dashed_name: process-hash-sha512
+  description: SHA512 hash.
+  flat_name: process.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
 process.name:
   dashed_name: process-name
   description: 'Process name.
@@ -1218,6 +1503,84 @@ process.parent.Ext:
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
+process.parent.Ext.code_signature:
+  dashed_name: process-parent-Ext-code-signature
+  description: Nested version of ECS code_signature fieldset.
+  flat_name: process.parent.Ext.code_signature
+  level: custom
+  name: Ext.code_signature
+  normalize: []
+  original_fieldset: process
+  short: Nested version of ECS code_signature fieldset.
+  type: nested
+process.parent.Ext.code_signature.exists:
+  dashed_name: process-parent-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.parent.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  original_fieldset: process
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.parent.Ext.code_signature.status:
+  dashed_name: process-parent-Ext-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.parent.Ext.code_signature.status
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.status
+  normalize: []
+  original_fieldset: process
+  short: Additional information about the certificate status.
+  type: keyword
+process.parent.Ext.code_signature.subject_name:
+  dashed_name: process-parent-Ext-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.parent.Ext.code_signature.subject_name
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.subject_name
+  normalize: []
+  original_fieldset: process
+  short: Subject name of the code signer
+  type: keyword
+process.parent.Ext.code_signature.trusted:
+  dashed_name: process-parent-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.parent.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  original_fieldset: process
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.parent.Ext.code_signature.valid:
+  dashed_name: process-parent-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.parent.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  original_fieldset: process
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
   description: The field set containing process info in case of any pid spoofing.
@@ -1241,6 +1604,134 @@ process.parent.Ext.real.pid:
   original_fieldset: process
   short: The real pid of the process if ppid spoofing is happening.
   type: long
+process.parent.args:
+  dashed_name: process-parent-args
+  description: 'Array of process arguments, starting with the absolute path to the
+    executable.
+
+    May be filtered to protect sensitive information.'
+  example:
+  - /usr/bin/ssh
+  - -l
+  - user
+  - 10.0.0.16
+  flat_name: process.parent.args
+  ignore_above: 1024
+  level: extended
+  name: args
+  normalize:
+  - array
+  original_fieldset: process
+  short: Array of process arguments.
+  type: keyword
+process.parent.args_count:
+  dashed_name: process-parent-args-count
+  description: 'Length of the process.args array.
+
+    This field can be useful for querying or performing bucket analysis on how many
+    arguments were provided to start a process. More arguments may be an indication
+    of suspicious activity.'
+  example: 4
+  flat_name: process.parent.args_count
+  level: extended
+  name: args_count
+  normalize: []
+  original_fieldset: process
+  short: Length of the process.args array.
+  type: long
+process.parent.code_signature.exists:
+  dashed_name: process-parent-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.parent.code_signature.exists
+  level: core
+  name: exists
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.parent.code_signature.status:
+  dashed_name: process-parent-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.parent.code_signature.status
+  ignore_above: 1024
+  level: extended
+  name: status
+  normalize: []
+  original_fieldset: code_signature
+  short: Additional information about the certificate status.
+  type: keyword
+process.parent.code_signature.subject_name:
+  dashed_name: process-parent-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.parent.code_signature.subject_name
+  ignore_above: 1024
+  level: core
+  name: subject_name
+  normalize: []
+  original_fieldset: code_signature
+  short: Subject name of the code signer
+  type: keyword
+process.parent.code_signature.trusted:
+  dashed_name: process-parent-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.parent.code_signature.trusted
+  level: extended
+  name: trusted
+  normalize: []
+  original_fieldset: code_signature
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.parent.code_signature.valid:
+  dashed_name: process-parent-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.parent.code_signature.valid
+  level: extended
+  name: valid
+  normalize: []
+  original_fieldset: code_signature
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
+process.parent.command_line:
+  dashed_name: process-parent-command-line
+  description: 'Full command line that started the process, including the absolute
+    path to the executable, and all arguments.
+
+    Some arguments may be filtered to protect sensitive information.'
+  example: /usr/bin/ssh -l user 10.0.0.16
+  flat_name: process.parent.command_line
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.parent.command_line.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
+  - flat_name: process.parent.command_line.text
+    name: text
+    norms: false
+    type: text
+  name: command_line
+  normalize: []
+  original_fieldset: process
+  short: Full command line that started the process.
+  type: keyword
 process.parent.entity_id:
   dashed_name: process-parent-entity-id
   description: 'Unique identifier for the process.
@@ -1283,6 +1774,64 @@ process.parent.executable:
   original_fieldset: process
   short: Absolute path to the process executable.
   type: keyword
+process.parent.exit_code:
+  dashed_name: process-parent-exit-code
+  description: 'The exit code of the process, if this is a termination event.
+
+    The field should be absent if there is no exit code for the event (e.g. process
+    start).'
+  example: 137
+  flat_name: process.parent.exit_code
+  level: extended
+  name: exit_code
+  normalize: []
+  original_fieldset: process
+  short: The exit code of the process.
+  type: long
+process.parent.hash.md5:
+  dashed_name: process-parent-hash-md5
+  description: MD5 hash.
+  flat_name: process.parent.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+process.parent.hash.sha1:
+  dashed_name: process-parent-hash-sha1
+  description: SHA1 hash.
+  flat_name: process.parent.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+process.parent.hash.sha256:
+  dashed_name: process-parent-hash-sha256
+  description: SHA256 hash.
+  flat_name: process.parent.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+process.parent.hash.sha512:
+  dashed_name: process-parent-hash-sha512
+  description: SHA512 hash.
+  flat_name: process.parent.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
 process.parent.name:
   dashed_name: process-parent-name
   description: 'Process name.
@@ -1307,6 +1856,77 @@ process.parent.name:
   original_fieldset: process
   short: Process name.
   type: keyword
+process.parent.pe.company:
+  dashed_name: process-parent-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: process.parent.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.description:
+  dashed_name: process-parent-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: process.parent.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.file_version:
+  dashed_name: process-parent-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: process.parent.pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+process.parent.pe.original_file_name:
+  dashed_name: process-parent-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: process.parent.pe.original_file_name
+  ignore_above: 1024
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: keyword
+process.parent.pe.product:
+  dashed_name: process-parent-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: process.parent.pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+process.parent.pgid:
+  dashed_name: process-parent-pgid
+  description: Identifier of the group of processes the process belongs to.
+  flat_name: process.parent.pgid
+  format: string
+  level: extended
+  name: pgid
+  normalize: []
+  original_fieldset: process
+  short: Identifier of the group of processes the process belongs to.
+  type: long
 process.parent.pid:
   dashed_name: process-parent-pid
   description: Process id.
@@ -1319,6 +1939,130 @@ process.parent.pid:
   original_fieldset: process
   short: Process id.
   type: long
+process.parent.ppid:
+  dashed_name: process-parent-ppid
+  description: Parent process' pid.
+  example: 4241
+  flat_name: process.parent.ppid
+  format: string
+  level: extended
+  name: ppid
+  normalize: []
+  original_fieldset: process
+  short: Parent process' pid.
+  type: long
+process.parent.thread.id:
+  dashed_name: process-parent-thread-id
+  description: Thread ID.
+  example: 4242
+  flat_name: process.parent.thread.id
+  format: string
+  level: extended
+  name: thread.id
+  normalize: []
+  original_fieldset: process
+  short: Thread ID.
+  type: long
+process.parent.thread.name:
+  dashed_name: process-parent-thread-name
+  description: Thread name.
+  example: thread-0
+  flat_name: process.parent.thread.name
+  ignore_above: 1024
+  level: extended
+  name: thread.name
+  normalize: []
+  original_fieldset: process
+  short: Thread name.
+  type: keyword
+process.parent.title:
+  dashed_name: process-parent-title
+  description: 'Process title.
+
+    The proctitle, some times the same as process name. Can also be different: for
+    example a browser setting its title to the web page currently opened.'
+  flat_name: process.parent.title
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.parent.title.text
+    name: text
+    norms: false
+    type: text
+  name: title
+  normalize: []
+  original_fieldset: process
+  short: Process title.
+  type: keyword
+process.parent.uptime:
+  dashed_name: process-parent-uptime
+  description: Seconds the process has been up.
+  example: 1325
+  flat_name: process.parent.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  original_fieldset: process
+  short: Seconds the process has been up.
+  type: long
+process.parent.working_directory:
+  dashed_name: process-parent-working-directory
+  description: The working directory of the process.
+  example: /home/alice
+  flat_name: process.parent.working_directory
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.parent.working_directory.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
+  - flat_name: process.parent.working_directory.text
+    name: text
+    norms: false
+    type: text
+  name: working_directory
+  normalize: []
+  original_fieldset: process
+  short: The working directory of the process.
+  type: keyword
+process.pe.company:
+  dashed_name: process-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: process.pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+process.pe.description:
+  dashed_name: process-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: process.pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+process.pe.file_version:
+  dashed_name: process-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: process.pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
 process.pe.original_file_name:
   dashed_name: process-pe-original-file-name
   description: Internal name of the file, provided at compile-time.
@@ -1331,6 +2075,28 @@ process.pe.original_file_name:
   original_fieldset: pe
   short: Internal name of the file, provided at compile-time.
   type: keyword
+process.pe.product:
+  dashed_name: process-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: process.pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+process.pgid:
+  dashed_name: process-pgid
+  description: Identifier of the group of processes the process belongs to.
+  flat_name: process.pgid
+  format: string
+  level: extended
+  name: pgid
+  normalize: []
+  short: Identifier of the group of processes the process belongs to.
+  type: long
 process.pid:
   dashed_name: process-pid
   description: Process id.
@@ -1341,6 +2107,17 @@ process.pid:
   name: pid
   normalize: []
   short: Process id.
+  type: long
+process.ppid:
+  dashed_name: process-ppid
+  description: Parent process' pid.
+  example: 4241
+  flat_name: process.ppid
+  format: string
+  level: extended
+  name: ppid
+  normalize: []
+  short: Parent process' pid.
   type: long
 process.thread.id:
   dashed_name: process-thread-id
@@ -1353,6 +2130,66 @@ process.thread.id:
   normalize: []
   short: Thread ID.
   type: long
+process.thread.name:
+  dashed_name: process-thread-name
+  description: Thread name.
+  example: thread-0
+  flat_name: process.thread.name
+  ignore_above: 1024
+  level: extended
+  name: thread.name
+  normalize: []
+  short: Thread name.
+  type: keyword
+process.title:
+  dashed_name: process-title
+  description: 'Process title.
+
+    The proctitle, some times the same as process name. Can also be different: for
+    example a browser setting its title to the web page currently opened.'
+  flat_name: process.title
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.title.text
+    name: text
+    norms: false
+    type: text
+  name: title
+  normalize: []
+  short: Process title.
+  type: keyword
+process.uptime:
+  dashed_name: process-uptime
+  description: Seconds the process has been up.
+  example: 1325
+  flat_name: process.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the process has been up.
+  type: long
+process.working_directory:
+  dashed_name: process-working-directory
+  description: The working directory of the process.
+  example: /home/alice
+  flat_name: process.working_directory
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: process.working_directory.caseless
+    ignore_above: 1024
+    name: caseless
+    normalizer: lowercase
+    type: keyword
+  - flat_name: process.working_directory.text
+    name: text
+    norms: false
+    type: text
+  name: working_directory
+  normalize: []
+  short: The working directory of the process.
+  type: keyword
 source.geo.city_name:
   dashed_name: source-geo-city-name
   description: City name.
@@ -1503,6 +2340,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/schemas/v1/registry/registry.yaml
+++ b/schemas/v1/registry/registry.yaml
@@ -370,6 +370,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -407,6 +422,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -522,6 +550,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -534,6 +620,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -712,6 +818,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -742,6 +860,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -920,6 +1052,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -1269,6 +1424,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id

--- a/schemas/v1/security/security.yaml
+++ b/schemas/v1/security/security.yaml
@@ -370,6 +370,21 @@ event.category:
   - array
   short: Event category. The second categorization field in the hierarchy.
   type: keyword
+event.code:
+  dashed_name: event-code
+  description: 'Identification code for this event, if one exists.
+
+    Some event sources use event codes to identify messages unambiguously, regardless
+    of message language or wording adjustments over time. An example of this is the
+    Windows Event ID.'
+  example: 4648
+  flat_name: event.code
+  ignore_above: 1024
+  level: extended
+  name: code
+  normalize: []
+  short: Identification code for this event.
+  type: keyword
 event.created:
   dashed_name: event-created
   description: 'event.created contains the date/time when the event was first read
@@ -407,6 +422,19 @@ event.dataset:
   name: dataset
   normalize: []
   short: Name of the dataset.
+  type: keyword
+event.hash:
+  dashed_name: event-hash
+  description: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
+  example: 123456789012345678901234567890ABCD
+  flat_name: event.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate
+    log integrity.
   type: keyword
 event.id:
   dashed_name: event-id
@@ -522,6 +550,64 @@ event.module:
   normalize: []
   short: Name of the module this data is coming from.
   type: keyword
+event.outcome:
+  allowed_values:
+  - description: Indicates that this event describes a failed result. A common example
+      is `event.category:file AND event.type:access AND event.outcome:failure` to
+      indicate that a file access was attempted, but was not successful.
+    name: failure
+  - description: Indicates that this event describes a successful result. A common
+      example is `event.category:file AND event.type:create AND event.outcome:success`
+      to indicate that a file was successfully created.
+    name: success
+  - description: Indicates that this event describes only an attempt for which the
+      result is unknown from the perspective of the event producer. For example, if
+      the event contains information only about the request side of a transaction
+      that results in a response, populating `event.outcome:unknown` in the request
+      event is appropriate. The unknown value should not be used when an outcome doesn't
+      make logical sense for the event. In such cases `event.outcome` should not be
+      populated.
+    name: unknown
+  dashed_name: event-outcome
+  description: 'This is one of four ECS Categorization Fields, and indicates the lowest
+    level in the ECS category hierarchy.
+
+    `event.outcome` simply denotes whether the event represents a success or a failure
+    from the perspective of the entity that produced the event.
+
+    Note that when a single transaction is described in multiple events, each event
+    may populate different values of `event.outcome`, according to their perspective.
+
+    Also note that in the case of a compound event (a single event that contains multiple
+    logical events), this field should be populated with the value that best captures
+    the overall success or failure from the perspective of the event producer.
+
+    Further note that not all events will have an associated outcome. For example,
+    this field is generally not populated for metric events, events with `event.type:info`,
+    or any events for which an outcome does not make logical sense.'
+  example: success
+  flat_name: event.outcome
+  ignore_above: 1024
+  level: core
+  name: outcome
+  normalize: []
+  short: The outcome of the event. The lowest level categorization field in the hierarchy.
+  type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.sequence:
   dashed_name: event-sequence
   description: 'Sequence number of the event.
@@ -534,6 +620,26 @@ event.sequence:
   name: sequence
   normalize: []
   short: Sequence number of the event.
+  type: long
+event.severity:
+  dashed_name: event-severity
+  description: 'The numeric severity of the event according to your event source.
+
+    What the different severity values mean can be different between sources and use
+    cases. It''s up to the implementer to make sure severities are consistent across
+    events from the same source.
+
+    The Syslog severity belongs in `log.syslog.severity.code`. `event.severity` is
+    meant to represent the severity according to the event source (e.g. firewall,
+    IDS). If the event source does not publish its own severity, you may optionally
+    copy the `log.syslog.severity.code` to `event.severity`.'
+  example: 7
+  flat_name: event.severity
+  format: string
+  level: core
+  name: severity
+  normalize: []
+  short: Numeric severity of the event.
   type: long
 event.type:
   allowed_values:
@@ -712,6 +818,18 @@ group.Ext.real.name:
   normalize: []
   short: Name of the group.
   type: keyword
+group.domain:
+  dashed_name: group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
+  type: keyword
 group.id:
   dashed_name: group-id
   description: Unique identifier for the group on the system/platform.
@@ -742,6 +860,20 @@ host.architecture:
   name: architecture
   normalize: []
   short: Operating system architecture.
+  type: keyword
+host.domain:
+  dashed_name: host-domain
+  description: 'Name of the domain of which the host is a member.
+
+    For example, on Windows this could be the host''s Active Directory domain or NetBIOS
+    domain name. For Linux this could be the domain of the host''s LDAP provider.'
+  example: CONTOSO
+  flat_name: host.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  short: Name of the directory the group is a member of.
   type: keyword
 host.hostname:
   dashed_name: host-hostname
@@ -920,6 +1052,29 @@ host.os.version:
   original_fieldset: os
   short: Operating system version as a raw string.
   type: keyword
+host.type:
+  dashed_name: host-type
+  description: 'Type of host.
+
+    For Cloud providers this can be the machine type like `t2.medium`. If vm, this
+    could be the container, for example, or other information meaningful in your environment.'
+  flat_name: host.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of host.
+  type: keyword
+host.uptime:
+  dashed_name: host-uptime
+  description: Seconds the host has been up.
+  example: 1325
+  flat_name: host.uptime
+  level: extended
+  name: uptime
+  normalize: []
+  short: Seconds the host has been up.
+  type: long
 message:
   dashed_name: message
   description: 'For log events the message field contains the log message, optimized
@@ -1191,6 +1346,123 @@ user.domain:
   name: domain
   normalize: []
   short: Name of the directory the user is a member of.
+  type: keyword
+user.email:
+  dashed_name: user-email
+  description: User email address.
+  flat_name: user.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  short: User email address.
+  type: keyword
+user.full_name:
+  dashed_name: user-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.full_name.text
+    name: text
+    norms: false
+    type: text
+  name: full_name
+  normalize: []
+  short: User's full name, if available.
+  type: keyword
+user.group.Ext:
+  dashed_name: user-group-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: user.group.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  original_fieldset: group
+  short: Object for all custom defined fields to live in.
+  type: object
+user.group.Ext.real:
+  dashed_name: user-group-Ext-real
+  description: Group info prior to any setgid operations.
+  flat_name: user.group.Ext.real
+  level: custom
+  name: Ext.real
+  normalize: []
+  original_fieldset: group
+  short: Group info prior to any setgid operations.
+  type: object
+user.group.Ext.real.id:
+  dashed_name: user-group-Ext-real-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.Ext.real.id
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.Ext.real.name:
+  dashed_name: user-group-Ext-real-name
+  description: Name of the group.
+  flat_name: user.group.Ext.real.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.real.name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.group.domain:
+  dashed_name: user-group-domain
+  description: 'Name of the directory the group is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.group.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: group
+  short: Name of the directory the group is a member of.
+  type: keyword
+user.group.id:
+  dashed_name: user-group-id
+  description: Unique identifier for the group on the system/platform.
+  flat_name: user.group.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  original_fieldset: group
+  short: Unique identifier for the group on the system/platform.
+  type: keyword
+user.group.name:
+  dashed_name: user-group-name
+  description: Name of the group.
+  flat_name: user.group.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+user.hash:
+  dashed_name: user-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  short: Unique user hash to correlate information for a user in anonymized form.
   type: keyword
 user.id:
   dashed_name: user-id


### PR DESCRIPTION
This PR tries to align the mapping for alerts and events. I split this up into 2 commits, one that just has the subset changes and the other has the generated files. Hopefully that makes it a bit easier to review.

I did not change `metadata` because some additional things have to happen to generate the mappings for the transform that is used. I'll do that in a follow up PR.

_**NOTE:**_ There shouldn't be any _**deletions**_ in the generated files.

The general way to review this is look at the `malware_event.yml` https://github.com/elastic/endpoint-package/blob/master/custom_subsets/elastic_endpoint/alerts/malware_event.yaml file and make sure the `process`, `host`, `user`, `group`, and `file` fields in the other directories (file, library, process etc) are pretty close. I didn't copy over all the `Ext` fields because most of them will only apply to the alerts. But most of the core ecs fields should be there for alerts and events. 

Things that changed:
- I tried to organize the fields in alphabetical order for the things that I touched
- More `host` fields
- More `pe` fields
- More `file` fields
- More `hash` fields
- More `events` fields
- More `code_signature` fields

Long term we might want to implement way better way to keep these in sync, like some sort of _include_ functionality or something.