### PR TITLE
Bumping kibana condition to 7.11

### DIFF
--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -16,7 +16,7 @@ policy_templates:
     description: Interact with the endpoint.
     multiple: false
 conditions:
-  kibana.version: "^7.10.0"
+  kibana.version: "^7.11.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
   # >= <the version> && < 8.0.0
 icons:


### PR DESCRIPTION
This isn't super necessary but since we changed the metadata schema and a lot of testing already went into 7.10 we'll keep the changes for 7.11 only.