### PR TITLE
[7.10] Adding missing dll fields (#109)

### DIFF
--- a/custom_subsets/elastic_endpoint/library/library.yaml
+++ b/custom_subsets/elastic_endpoint/library/library.yaml
@@ -139,6 +139,14 @@ fields:
               valid: {}
   dll:
     fields:
+      hash:
+        fields:
+          md5: {}
+          sha1: {}
+          sha256: {}
+          sha512: {}
+      name: {}
+      path: {}
       pe:
         fields:
           company: {}

--- a/generated/library/ecs/ecs_flat.yml
+++ b/generated/library/ecs/ecs_flat.yml
@@ -265,6 +265,74 @@ dll.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+dll.hash.md5:
+  dashed_name: dll-hash-md5
+  description: MD5 hash.
+  flat_name: dll.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+dll.hash.sha1:
+  dashed_name: dll-hash-sha1
+  description: SHA1 hash.
+  flat_name: dll.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+dll.hash.sha256:
+  dashed_name: dll-hash-sha256
+  description: SHA256 hash.
+  flat_name: dll.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+dll.hash.sha512:
+  dashed_name: dll-hash-sha512
+  description: SHA512 hash.
+  flat_name: dll.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+dll.name:
+  dashed_name: dll-name
+  description: 'Name of the library.
+
+    This generally maps to the name of the file on disk.'
+  example: kernel32.dll
+  flat_name: dll.name
+  ignore_above: 1024
+  level: core
+  name: name
+  normalize: []
+  short: Name of the library.
+  type: keyword
+dll.path:
+  dashed_name: dll-path
+  description: Full file path of the library.
+  example: C:\Windows\System32\kernel32.dll
+  flat_name: dll.path
+  ignore_above: 1024
+  level: extended
+  name: path
+  normalize: []
+  short: Full file path of the library.
+  type: keyword
 dll.pe.company:
   dashed_name: dll-pe-company
   description: Internal company name of the file, provided at compile-time.

--- a/generated/library/ecs/subset/library/ecs_flat.yml
+++ b/generated/library/ecs/subset/library/ecs_flat.yml
@@ -265,6 +265,74 @@ dll.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+dll.hash.md5:
+  dashed_name: dll-hash-md5
+  description: MD5 hash.
+  flat_name: dll.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+dll.hash.sha1:
+  dashed_name: dll-hash-sha1
+  description: SHA1 hash.
+  flat_name: dll.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+dll.hash.sha256:
+  dashed_name: dll-hash-sha256
+  description: SHA256 hash.
+  flat_name: dll.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+dll.hash.sha512:
+  dashed_name: dll-hash-sha512
+  description: SHA512 hash.
+  flat_name: dll.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+dll.name:
+  dashed_name: dll-name
+  description: 'Name of the library.
+
+    This generally maps to the name of the file on disk.'
+  example: kernel32.dll
+  flat_name: dll.name
+  ignore_above: 1024
+  level: core
+  name: name
+  normalize: []
+  short: Name of the library.
+  type: keyword
+dll.path:
+  dashed_name: dll-path
+  description: Full file path of the library.
+  example: C:\Windows\System32\kernel32.dll
+  flat_name: dll.path
+  ignore_above: 1024
+  level: extended
+  name: path
+  normalize: []
+  short: Full file path of the library.
+  type: keyword
 dll.pe.company:
   dashed_name: dll-pe-company
   description: Internal company name of the file, provided at compile-time.

--- a/generated/library/elasticsearch/7/template.json
+++ b/generated/library/elasticsearch/7/template.json
@@ -119,6 +119,34 @@
             },
             "type": "object"
           },
+          "hash": {
+            "properties": {
+              "md5": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "sha1": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "sha256": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "sha512": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
+          "name": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "path": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
           "pe": {
             "properties": {
               "company": {

--- a/package/endpoint/data_stream/library/fields/fields.yml
+++ b/package/endpoint/data_stream/library/fields/fields.yml
@@ -193,6 +193,46 @@
         Leave unpopulated if a certificate was unchecked.'
       example: 'true'
       default_field: false
+    - name: hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the library.
+
+        This generally maps to the name of the file on disk.'
+      example: kernel32.dll
+      default_field: false
+    - name: path
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Full file path of the library.
+      example: C:\Windows\System32\kernel32.dll
+      default_field: false
     - name: pe.company
       level: extended
       type: keyword

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -662,6 +662,12 @@ sent by the endpoint.
 | dll.Ext.code_signature.subject_name | Subject name of the code signer | keyword |
 | dll.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | dll.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
+| dll.hash.md5 | MD5 hash. | keyword |
+| dll.hash.sha1 | SHA1 hash. | keyword |
+| dll.hash.sha256 | SHA256 hash. | keyword |
+| dll.hash.sha512 | SHA512 hash. | keyword |
+| dll.name | Name of the library. This generally maps to the name of the file on disk. | keyword |
+| dll.path | Full file path of the library. | keyword |
 | dll.pe.company | Internal company name of the file, provided at compile-time. | keyword |
 | dll.pe.description | Internal description of the file, provided at compile-time. | keyword |
 | dll.pe.file_version | Internal version of the file, provided at compile-time. | keyword |

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -265,6 +265,74 @@ dll.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+dll.hash.md5:
+  dashed_name: dll-hash-md5
+  description: MD5 hash.
+  flat_name: dll.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+dll.hash.sha1:
+  dashed_name: dll-hash-sha1
+  description: SHA1 hash.
+  flat_name: dll.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+dll.hash.sha256:
+  dashed_name: dll-hash-sha256
+  description: SHA256 hash.
+  flat_name: dll.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+dll.hash.sha512:
+  dashed_name: dll-hash-sha512
+  description: SHA512 hash.
+  flat_name: dll.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+dll.name:
+  dashed_name: dll-name
+  description: 'Name of the library.
+
+    This generally maps to the name of the file on disk.'
+  example: kernel32.dll
+  flat_name: dll.name
+  ignore_above: 1024
+  level: core
+  name: name
+  normalize: []
+  short: Name of the library.
+  type: keyword
+dll.path:
+  dashed_name: dll-path
+  description: Full file path of the library.
+  example: C:\Windows\System32\kernel32.dll
+  flat_name: dll.path
+  ignore_above: 1024
+  level: extended
+  name: path
+  normalize: []
+  short: Full file path of the library.
+  type: keyword
 dll.pe.company:
   dashed_name: dll-pe-company
   description: Internal company name of the file, provided at compile-time.


### PR DESCRIPTION
Backports the following commits to 7.10:
 - Adding missing dll fields (#109)