### PR TITLE
Pinning ECS version to 1.7.0 a working version for the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ clean:
 	rm -rf $(GO_TOOLS)
 
 $(REAL_ECS_DIR):
-	git clone --branch master https://github.com/elastic/ecs.git $(REAL_ECS_DIR)
+	git clone --branch v1.7.0 https://github.com/elastic/ecs.git $(REAL_ECS_DIR)
 
 .PHONY: setup-go-tools
 setup-go-tools:

--- a/generated/alerts/elasticsearch/7/template.json
+++ b/generated/alerts/elasticsearch/7/template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "ecs-*"
+    "try-ecs-*"
   ],
   "mappings": {
     "_meta": {

--- a/generated/file/elasticsearch/7/template.json
+++ b/generated/file/elasticsearch/7/template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "ecs-*"
+    "try-ecs-*"
   ],
   "mappings": {
     "_meta": {

--- a/generated/library/elasticsearch/7/template.json
+++ b/generated/library/elasticsearch/7/template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "ecs-*"
+    "try-ecs-*"
   ],
   "mappings": {
     "_meta": {

--- a/generated/metadata/elasticsearch/7/template.json
+++ b/generated/metadata/elasticsearch/7/template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "ecs-*"
+    "try-ecs-*"
   ],
   "mappings": {
     "_meta": {

--- a/generated/metrics/elasticsearch/7/template.json
+++ b/generated/metrics/elasticsearch/7/template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "ecs-*"
+    "try-ecs-*"
   ],
   "mappings": {
     "_meta": {

--- a/generated/network/elasticsearch/7/template.json
+++ b/generated/network/elasticsearch/7/template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "ecs-*"
+    "try-ecs-*"
   ],
   "mappings": {
     "_meta": {

--- a/generated/policy/elasticsearch/7/template.json
+++ b/generated/policy/elasticsearch/7/template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "ecs-*"
+    "try-ecs-*"
   ],
   "mappings": {
     "_meta": {

--- a/generated/process/elasticsearch/7/template.json
+++ b/generated/process/elasticsearch/7/template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "ecs-*"
+    "try-ecs-*"
   ],
   "mappings": {
     "_meta": {

--- a/generated/registry/elasticsearch/7/template.json
+++ b/generated/registry/elasticsearch/7/template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "ecs-*"
+    "try-ecs-*"
   ],
   "mappings": {
     "_meta": {

--- a/generated/security/elasticsearch/7/template.json
+++ b/generated/security/elasticsearch/7/template.json
@@ -1,6 +1,6 @@
 {
   "index_patterns": [
-    "ecs-*"
+    "try-ecs-*"
   ],
   "mappings": {
     "_meta": {


### PR DESCRIPTION
Pinning the ECS repo to `1.7.0` so the build will succeed and it gets us off the bleeding edge of master which is currently failing. This is temporary, in a follow up PR I'm going to bump the ECS schema version we use internally so we can be on `1.7.0` for everything.

NOTE: You'll need to `make clean` after this is merged.