### PR TITLE
expand transform index search to account for namespaces

### DIFF
--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
@@ -82,7 +82,7 @@
                                     "type": "constant_keyword"
                                 },
                                 "namespace": {
-                                    "type": "constant_keyword"
+                                    "type": "keyword"
                                 },
                                 "type": {
                                     "type": "constant_keyword"

--- a/package/endpoint/elasticsearch/transform/metadata_current/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_current/default.json
@@ -1,6 +1,6 @@
 {
     "source": {
-        "index": "metrics-endpoint.metadata-default*"
+        "index": "metrics-endpoint.metadata-*"
     },
     "dest": {
         "index": "metrics-endpoint.metadata_current_default"


### PR DESCRIPTION
Adjust the transform so that it will also search for indices that may have something other than the `default` namespace.

See this bug:
https://github.com/elastic/kibana/issues/86237