### PR TITLE
metadata transform: only grab documents newer than 90d

### DIFF
--- a/package/endpoint/elasticsearch/transform/metadata_current/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_current/default.json
@@ -1,6 +1,13 @@
 {
     "source": {
-        "index": "metrics-endpoint.metadata-default*"
+        "index": "metrics-endpoint.metadata-default*",
+        "query": {
+            "range": {
+                "@timestamp": {
+                    "gt": "now-90d/d"
+                }
+            }
+        }
     },
     "dest": {
         "index": "metrics-endpoint.metadata_current_default"


### PR DESCRIPTION
Alters the Metadata transform query to [not include documents older than 90 days](https://github.com/elastic/security-team/issues/698)


Functional proof:


https://user-images.githubusercontent.com/315796/104203128-ca3eaf80-53f9-11eb-95ee-a34273386158.mp4

