### PR TITLE
Change endpoint metadata transform to use "latest" operator

### DIFF
--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
@@ -23,85 +23,21 @@
                 "@timestamp": {
                     "type": "date"
                 },
-                "HostDetails": {
+                "Endpoint": {
                     "properties": {
-                        "@timestamp": {
-                            "type": "date"
-                        },
-                        "Endpoint": {
+                        "policy": {
                             "properties": {
-                                "policy": {
-                                    "properties": {
-                                        "applied": {
-                                            "properties": {
-                                                "id": {
-                                                    "type": "keyword",
-                                                    "ignore_above": 1024
-                                                },
-                                                "name": {
-                                                    "type": "keyword",
-                                                    "ignore_above": 1024
-                                                },
-                                                "status": {
-                                                    "type": "keyword",
-                                                    "ignore_above": 1024
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "status": {
-                                    "type": "keyword",
-                                    "ignore_above": 1024
-                                }
-                            }
-                        },
-                        "agent": {
-                            "properties": {
-                                "id": {
-                                    "type": "keyword",
-                                    "ignore_above": 1024
-                                },
-                                "name": {
-                                    "type": "keyword",
-                                    "ignore_above": 1024
-                                },
-                                "type": {
-                                    "type": "keyword",
-                                    "ignore_above": 1024
-                                },
-                                "version": {
-                                    "type": "keyword",
-                                    "ignore_above": 1024
-                                }
-                            }
-                        },
-                        "data_stream": {
-                            "properties": {
-                                "dataset": {
-                                    "type": "constant_keyword"
-                                },
-                                "namespace": {
-                                    "type": "keyword"
-                                },
-                                "type": {
-                                    "type": "constant_keyword"
-                                }
-                            }
-                        },
-                        "ecs": {
-                            "properties": {
-                                "version": {
-                                    "type": "keyword",
-                                    "ignore_above": 1024
-                                }
-                            }
-                        },
-                        "elastic": {
-                            "properties": {
-                                "agent": {
+                                "applied": {
                                     "properties": {
                                         "id": {
+                                            "type": "keyword",
+                                            "ignore_above": 1024
+                                        },
+                                        "name": {
+                                            "type": "keyword",
+                                            "ignore_above": 1024
+                                        },
+                                        "status": {
                                             "type": "keyword",
                                             "ignore_above": 1024
                                         }
@@ -109,168 +45,218 @@
                                 }
                             }
                         },
-                        "event": {
-                            "properties": {
-                                "action": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "category": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "code": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "created": {
-                                    "type": "date"
-                                },
-                                "dataset": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "hash": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "id": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "ingested": {
-                                    "type": "date"
-                                },
-                                "kind": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "module": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "outcome": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "provider": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "sequence": {
-                                    "type": "long"
-                                },
-                                "severity": {
-                                    "type": "long"
-                                },
-                                "type": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                }
-                            }
-                        },
-                        "host": {
-                            "properties": {
-                                "architecture": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "domain": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "hostname": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "id": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "ip": {
-                                    "type": "ip"
-                                },
-                                "mac": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "name": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "os": {
-                                    "properties": {
-                                        "Ext": {
-                                            "properties": {
-                                                "variant": {
-                                                    "ignore_above": 1024,
-                                                    "type": "keyword"
-                                                }
-                                            }
-                                        },
-                                        "family": {
-                                            "ignore_above": 1024,
-                                            "type": "keyword"
-                                        },
-                                        "full": {
-                                            "fields": {
-                                                "caseless": {
-                                                    "ignore_above": 1024,
-                                                    "normalizer": "lowercase",
-                                                    "type": "keyword"
-                                                },
-                                                "text": {
-                                                    "norms": false,
-                                                    "type": "text"
-                                                }
-                                            },
-                                            "ignore_above": 1024,
-                                            "type": "keyword"
-                                        },
-                                        "kernel": {
-                                            "ignore_above": 1024,
-                                            "type": "keyword"
-                                        },
-                                        "name": {
-                                            "fields": {
-                                                "caseless": {
-                                                    "ignore_above": 1024,
-                                                    "normalizer": "lowercase",
-                                                    "type": "keyword"
-                                                },
-                                                "text": {
-                                                    "norms": false,
-                                                    "type": "text"
-                                                }
-                                            },
-                                            "ignore_above": 1024,
-                                            "type": "keyword"
-                                        },
-                                        "platform": {
-                                            "ignore_above": 1024,
-                                            "type": "keyword"
-                                        },
-                                        "version": {
-                                            "ignore_above": 1024,
-                                            "type": "keyword"
-                                        }
-                                    }
-                                },
-                                "type": {
-                                    "ignore_above": 1024,
-                                    "type": "keyword"
-                                },
-                                "uptime": {
-                                    "type": "long"
-                                }
-                            }
+                        "status": {
+                            "type": "keyword",
+                            "ignore_above": 1024
                         }
                     }
                 },
                 "agent": {
                     "properties": {
                         "id": {
+                            "type": "keyword",
+                            "ignore_above": 1024
+                        },
+                        "name": {
+                            "type": "keyword",
+                            "ignore_above": 1024
+                        },
+                        "type": {
+                            "type": "keyword",
+                            "ignore_above": 1024
+                        },
+                        "version": {
+                            "type": "keyword",
+                            "ignore_above": 1024
+                        }
+                    }
+                },
+                "data_stream": {
+                    "properties": {
+                        "dataset": {
+                            "type": "constant_keyword"
+                        },
+                        "namespace": {
                             "type": "keyword"
+                        },
+                        "type": {
+                            "type": "constant_keyword"
+                        }
+                    }
+                },
+                "ecs": {
+                    "properties": {
+                        "version": {
+                            "type": "keyword",
+                            "ignore_above": 1024
+                        }
+                    }
+                },
+                "elastic": {
+                    "properties": {
+                        "agent": {
+                            "properties": {
+                                "id": {
+                                    "type": "keyword",
+                                    "ignore_above": 1024
+                                }
+                            }
+                        }
+                    }
+                },
+                "event": {
+                    "properties": {
+                        "action": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "category": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "code": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "created": {
+                            "type": "date"
+                        },
+                        "dataset": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "hash": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "ingested": {
+                            "type": "date"
+                        },
+                        "kind": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "module": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "outcome": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "provider": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "sequence": {
+                            "type": "long"
+                        },
+                        "severity": {
+                            "type": "long"
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
+                    }
+                },
+                "host": {
+                    "properties": {
+                        "architecture": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "domain": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "hostname": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "id": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "ip": {
+                            "type": "ip"
+                        },
+                        "mac": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "os": {
+                            "properties": {
+                                "Ext": {
+                                    "properties": {
+                                        "variant": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        }
+                                    }
+                                },
+                                "family": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "full": {
+                                    "fields": {
+                                        "caseless": {
+                                            "ignore_above": 1024,
+                                            "normalizer": "lowercase",
+                                            "type": "keyword"
+                                        },
+                                        "text": {
+                                            "norms": false,
+                                            "type": "text"
+                                        }
+                                    },
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "kernel": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "name": {
+                                    "fields": {
+                                        "caseless": {
+                                            "ignore_above": 1024,
+                                            "normalizer": "lowercase",
+                                            "type": "keyword"
+                                        },
+                                        "text": {
+                                            "norms": false,
+                                            "type": "text"
+                                        }
+                                    },
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "platform": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                },
+                                "version": {
+                                    "ignore_above": 1024,
+                                    "type": "keyword"
+                                }
+                            }
+                        },
+                        "type": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        },
+                        "uptime": {
+                            "type": "long"
                         }
                     }
                 }

--- a/package/endpoint/elasticsearch/transform/metadata_current/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_current/default.json
@@ -12,24 +12,9 @@
     "dest": {
         "index": "metrics-endpoint.metadata_current_default"
     },
-    "pivot": {
-        "group_by": {
-            "agent.id": {
-                "terms": {
-                    "field": "agent.id"
-                }
-            }
-        },
-        "aggregations": {
-            "HostDetails": {
-                "scripted_metric": {
-                    "init_script": "state.timestamp_latest = 0L; state.last_doc=''",
-                    "map_script": "def current_date = doc['@timestamp'].getValue().toInstant().toEpochMilli(); if (current_date \u003e state.timestamp_latest) {state.timestamp_latest = current_date;state.last_doc = new HashMap(params['_source']);}",
-                    "combine_script": "return state",
-                    "reduce_script": "def last_doc = '';def timestamp_latest = 0L; for (s in states) {if (s.timestamp_latest \u003e (timestamp_latest)) {timestamp_latest = s.timestamp_latest; last_doc = s.last_doc;}} return last_doc"
-                }
-            }
-        }
+    "latest": {
+        "unique_key": ["agent.id"],
+        "sort": "@timestamp"
     },
     "description": "collapse and update the latest document for each host",
     "frequency": "1m",

--- a/package/endpoint/elasticsearch/transform/metadata_current/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_current/default.json
@@ -13,7 +13,9 @@
         "index": "metrics-endpoint.metadata_current_default"
     },
     "latest": {
-        "unique_key": ["agent.id"],
+        "unique_key": [
+            "agent.id"
+        ],
         "sort": "@timestamp"
     },
     "description": "collapse and update the latest document for each host",


### PR DESCRIPTION
the ML team added a native "latest" function of transforms, designed after our use case. This migrates our transform to start using it.

This involves a destination index schema change, Where the previous schema was:

```
{
  "agent":{ "id": "XYZ" },
  "HostDetails": { <sourcedoc> }
}
```

and agent.id is available as a field inside that sourcedoc. New schema becomes:
```
{ <sourcedoc> }
```

where `agent.id` remains available at the same place, now.


Kibana PR to sync up with the schema change: https://github.com/elastic/kibana/pull/88012