### PR TITLE
Changing file header bytes name

### DIFF
--- a/custom_schemas/custom_file.yml
+++ b/custom_schemas/custom_file.yml
@@ -174,12 +174,12 @@
       description: >
         Entropy calculation of file's header and footer used to check file integrity.
 
-    - name: Ext.header_trailer_data
+    - name: Ext.header_data
       level: custom
       type: text
-      short: File bytes from header and footer
+      short: Header bytes
       description: >
-        File header and footer bytes used to check file integrity.
+        First 16 bytes of file used to check file integrity.
 
     - name: Ext.monotonic_id
       level: custom

--- a/custom_subsets/elastic_endpoint/file/file.yaml
+++ b/custom_subsets/elastic_endpoint/file/file.yaml
@@ -152,7 +152,7 @@ fields:
       uid: {}
       Ext:
         fields:
-          header_trailer_data: {}
+          header_data: {}
           entropy: {}
           monotonic_id: {}
           windows:

--- a/generated/file/ecs/ecs_flat.yml
+++ b/generated/file/ecs/ecs_flat.yml
@@ -829,15 +829,15 @@ file.Ext.entropy:
   normalize: []
   short: File entropy value
   type: double
-file.Ext.header_trailer_data:
-  dashed_name: file-Ext-header-trailer-data
-  description: File header and footer bytes used to check file integrity.
-  flat_name: file.Ext.header_trailer_data
+file.Ext.header_data:
+  dashed_name: file-Ext-header-data
+  description: First 16 bytes of file used to check file integrity.
+  flat_name: file.Ext.header_data
   level: custom
-  name: Ext.header_trailer_data
+  name: Ext.header_data
   normalize: []
   norms: false
-  short: File bytes from header and footer
+  short: Header bytes
   type: text
 file.Ext.monotonic_id:
   dashed_name: file-Ext-monotonic-id

--- a/generated/file/ecs/subset/file/ecs_flat.yml
+++ b/generated/file/ecs/subset/file/ecs_flat.yml
@@ -799,15 +799,15 @@ file.Ext.entropy:
   normalize: []
   short: File entropy value
   type: double
-file.Ext.header_trailer_data:
-  dashed_name: file-Ext-header-trailer-data
-  description: File header and footer bytes used to check file integrity.
-  flat_name: file.Ext.header_trailer_data
+file.Ext.header_data:
+  dashed_name: file-Ext-header-data
+  description: First 16 bytes of file used to check file integrity.
+  flat_name: file.Ext.header_data
   level: custom
-  name: Ext.header_trailer_data
+  name: Ext.header_data
   normalize: []
   norms: false
-  short: File bytes from header and footer
+  short: Header bytes
   type: text
 file.Ext.monotonic_id:
   dashed_name: file-Ext-monotonic-id

--- a/generated/file/elasticsearch/7/template.json
+++ b/generated/file/elasticsearch/7/template.json
@@ -179,7 +179,7 @@
               "entropy": {
                 "type": "double"
               },
-              "header_trailer_data": {
+              "header_data": {
                 "norms": false,
                 "type": "text"
               },

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -322,10 +322,10 @@
       type: double
       description: Entropy calculation of file's header and footer used to check file integrity.
       default_field: false
-    - name: Ext.header_trailer_data
+    - name: Ext.header_data
       level: custom
       type: text
-      description: File header and footer bytes used to check file integrity.
+      description: First 16 bytes of file used to check file integrity.
       default_field: false
     - name: Ext.monotonic_id
       level: custom

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -554,7 +554,7 @@ sent by the endpoint.
 | event.type | This is one of four ECS Categorization Fields, and indicates the third level in the ECS category hierarchy. `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization. This field is an array. This will allow proper categorization of some events that fall in multiple event types. | keyword |
 | file.Ext | Object for all custom defined fields to live in. | object |
 | file.Ext.entropy | Entropy calculation of file's header and footer used to check file integrity. | double |
-| file.Ext.header_trailer_data | File header and footer bytes used to check file integrity. | text |
+| file.Ext.header_data | First 16 bytes of file used to check file integrity. | text |
 | file.Ext.monotonic_id | File event monotonic ID. | unsigned_long |
 | file.Ext.original | Original file information during a modification event. | object |
 | file.Ext.original.gid | Primary group ID (GID) of the file. | keyword |

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -799,15 +799,15 @@ file.Ext.entropy:
   normalize: []
   short: File entropy value
   type: double
-file.Ext.header_trailer_data:
-  dashed_name: file-Ext-header-trailer-data
-  description: File header and footer bytes used to check file integrity.
-  flat_name: file.Ext.header_trailer_data
+file.Ext.header_data:
+  dashed_name: file-Ext-header-data
+  description: First 16 bytes of file used to check file integrity.
+  flat_name: file.Ext.header_data
   level: custom
-  name: Ext.header_trailer_data
+  name: Ext.header_data
   normalize: []
   norms: false
-  short: File bytes from header and footer
+  short: Header bytes
   type: text
 file.Ext.monotonic_id:
   dashed_name: file-Ext-monotonic-id


### PR DESCRIPTION
The first time around, I was planning to include both header and trailer bytes.  The trailer bytes ended up being unnecessary.  Changing to header_trailer_data --> header_data to more accurately describe the field.