### PR TITLE
add transform retention policy (delete >90d)

### DIFF
--- a/package/endpoint/elasticsearch/transform/metadata_current/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_current/default.json
@@ -18,6 +18,12 @@
         ],
         "sort": "@timestamp"
     },
+    "retention_policy": {
+        "time": {
+            "field": "event.ingested",
+            "max_age": "90d"
+        }
+    },
     "description": "collapse and update the latest document for each host",
     "frequency": "1m",
     "sync": {


### PR DESCRIPTION
This deletes endpoint metadata documents when they are over 90d.

This uses the transform-native feature that was added: "retention policy".


Installing a transform with that definition went fine. Set one to 89d old, waiting for a day rollover to see if it gets deleted

![2021-02-16-090803_scrot](https://user-images.githubusercontent.com/315796/108074626-6e3dfb00-7037-11eb-9619-439bfdea4c96.png)
![2021-02-16-090825_scrot](https://user-images.githubusercontent.com/315796/108074628-6ed69180-7037-11eb-8547-c8771c7d05d5.png)
