### PR TITLE
Add call_stack module_name to custom schema

### DIFF
--- a/custom_schemas/custom_call_stack.yml
+++ b/custom_schemas/custom_call_stack.yml
@@ -16,6 +16,12 @@
       type: keyword
       description: >
         The DLL/module containing `instruction_pointer`.
+        
+    - name: module_name
+      level: custom
+      type: keyword
+      description: >
+        The basename of the DLL/module containing `instruction_pointer`.
 
     - name: instruction_pointer
       level: custom


### PR DESCRIPTION
Add module basenames (as `module_name`) to callstacks.  This makes allowlisting easier because the Endpoint doesn't support wildcards or regex inside `nested` fields.  Example data:

```
               "call_stack": [
                    {
                        "instruction_pointer": 2004921788,
                        "memory_section": {
                            "memory_address": 2004488192,
                            "memory_size": 1130496,
                            "protection": "R-X"
                        },
                        "module_name": "ntdll.dll",
                        "module_path": "c:\\windows\\syswow64\\ntdll.dll",
                        "symbol_info": "c:\\windows\\syswow64\\ntdll.dll!ZwCreateThreadEx+0xc"
                    },
                    {
                        "instruction_pointer": 1991001032,
                        "memory_section": {
                            "memory_address": 1990983680,
                            "memory_size": 397312,
                            "protection": "R-X"
                        },
                        "module_name": "kernel32.dll",
                        "module_path": "c:\\windows\\syswow64\\kernel32.dll",
                        "symbol_info": "c:\\windows\\syswow64\\kernel32.dll!CreateRemoteThread+0x28"
                    },
```