### PR TITLE
Add DLL load_index

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 generated/** linguist-generated=true
-
+package/** linguist-generated=true
+package/endpoint/docs/README.md linguist-generated=true
+schemas/**

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+generated/* linguist-generated=true
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-generated/* linguist-generated=true
+generated/** linguist-generated=true
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 generated/** linguist-generated=true
 package/** linguist-generated=true
 package/endpoint/docs/README.md linguist-generated=true
-schemas/**
+schemas/** linguist-generated=true

--- a/custom_schemas/custom_dll.yml
+++ b/custom_schemas/custom_dll.yml
@@ -88,3 +88,13 @@
         This is useful for logging cryptographic errors with the certificate validity or trust status.
         Leave unpopulated if the validity or trust of the certificate was unchecked.
       example: ERROR_UNTRUSTED_ROOT
+
+    - name: Ext.load_index
+      level: custom
+      type: unsigned_long
+      short: Number of times this DLL has been loaded into the process
+      description: >
+        A DLL can be loaded into a process multiple times.
+        This field indicates the Nth time that this DLL has been loaded.
+        
+        The first load index is 1.

--- a/custom_subsets/elastic_endpoint/library/library.yaml
+++ b/custom_subsets/elastic_endpoint/library/library.yaml
@@ -172,3 +172,4 @@ fields:
               subject_name: {}
               trusted: {}
               valid: {}
+          load_index: {}

--- a/generated/library/ecs/ecs_flat.yml
+++ b/generated/library/ecs/ecs_flat.yml
@@ -265,6 +265,18 @@ dll.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+dll.Ext.load_index:
+  dashed_name: dll-Ext-load-index
+  description: 'A DLL can be loaded into a process multiple times. This field indicates
+    the Nth time that this DLL has been loaded.
+
+    The first load index is 1.'
+  flat_name: dll.Ext.load_index
+  level: custom
+  name: Ext.load_index
+  normalize: []
+  short: Number of times this DLL has been loaded into the process
+  type: unsigned_long
 dll.code_signature.exists:
   dashed_name: dll-code-signature-exists
   description: Boolean to capture if a signature is present.

--- a/generated/library/ecs/subset/library/ecs_flat.yml
+++ b/generated/library/ecs/subset/library/ecs_flat.yml
@@ -265,6 +265,18 @@ dll.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+dll.Ext.load_index:
+  dashed_name: dll-Ext-load-index
+  description: 'A DLL can be loaded into a process multiple times. This field indicates
+    the Nth time that this DLL has been loaded.
+
+    The first load index is 1.'
+  flat_name: dll.Ext.load_index
+  level: custom
+  name: Ext.load_index
+  normalize: []
+  short: Number of times this DLL has been loaded into the process
+  type: unsigned_long
 dll.code_signature.exists:
   dashed_name: dll-code-signature-exists
   description: Boolean to capture if a signature is present.

--- a/generated/library/elasticsearch/7/template.json
+++ b/generated/library/elasticsearch/7/template.json
@@ -115,6 +115,9 @@
                   }
                 },
                 "type": "nested"
+              },
+              "load_index": {
+                "type": "unsigned_long"
               }
             },
             "type": "object"

--- a/package/endpoint/data_stream/library/fields/fields.yml
+++ b/package/endpoint/data_stream/library/fields/fields.yml
@@ -193,6 +193,13 @@
         Leave unpopulated if a certificate was unchecked.'
       example: 'true'
       default_field: false
+    - name: Ext.load_index
+      level: custom
+      type: unsigned_long
+      description: 'A DLL can be loaded into a process multiple times. This field indicates the Nth time that this DLL has been loaded.
+
+        The first load index is 1.'
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -686,6 +686,7 @@ sent by the endpoint.
 | dll.Ext.code_signature.subject_name | Subject name of the code signer | keyword |
 | dll.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | dll.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
+| dll.Ext.load_index | A DLL can be loaded into a process multiple times. This field indicates the Nth time that this DLL has been loaded. The first load index is 1. | unsigned_long |
 | dll.code_signature.exists | Boolean to capture if a signature is present. | boolean |
 | dll.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
 | dll.code_signature.subject_name | Subject name of the code signer | keyword |

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -265,6 +265,18 @@ dll.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+dll.Ext.load_index:
+  dashed_name: dll-Ext-load-index
+  description: 'A DLL can be loaded into a process multiple times. This field indicates
+    the Nth time that this DLL has been loaded.
+
+    The first load index is 1.'
+  flat_name: dll.Ext.load_index
+  level: custom
+  name: Ext.load_index
+  normalize: []
+  short: Number of times this DLL has been loaded into the process
+  type: unsigned_long
 dll.code_signature.exists:
   dashed_name: dll-code-signature-exists
   description: Boolean to capture if a signature is present.


### PR DESCRIPTION
Relates to https://github.com/elastic/endpoint-dev/issues/8659

It can be useful to know when certain system DLLs (ntdll, kernel32) have been loaded a second time into any given process.  This can indicate malicious behavior.  These DLLs are normally loaded into each Windows process once at startup, so a "process creation" event generally implies one load of each of these DLLs, and is thus uninteresting and noisy.  Discussions with @joe-desimone led to a decision to only report on the second load of those two DLLs, to reduce noise and data volume.  I've already implemented this in the Endpoint here: https://github.com/elastic/endpoint-dev/pull/8661

This will eventually lead to rules where we say "I want to know about the load of kernel32", but only the second.  We need some way to clearly indicate to the user that this is in fact the second load of kernel32.  `load_index` is that indicator.