### PR TITLE
Add defense evasion list to process creation events

### DIFF
--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -186,7 +186,7 @@
         
     - name: Ext.defense_evasions
       level: custom
-      type: array
+      type: keyword
       short: List of defense evasions found in this process.
       description: >
         List of defense evasions found in this process.  

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -183,3 +183,12 @@
       short: The real pid of the process if ppid spoofing is happening.
       description: >
         For process.parent this will be the ppid of the process that actually spawned the current process.
+        
+    - name: Ext.defense_evasions
+      level: custom
+      type: array
+      short: List of defense evasions found in this process.
+      description: >
+        List of defense evasions found in this process.  
+        These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior.
+        Examples tools that can cause defense evasions include Process Doppelgänging and Process Herpaderping.

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -150,6 +150,7 @@ fields:
               subject_name: {}
               trusted: {}
               valid: {}
+          defense_evasions: {}
           session: {}
           token:
             fields:

--- a/generated/process/ecs/ecs_flat.yml
+++ b/generated/process/ecs/ecs_flat.yml
@@ -1211,11 +1211,12 @@ process.Ext.defense_evasions:
     \ tools that can cause defense evasions include Process Doppelg\xE4nging and Process\
     \ Herpaderping."
   flat_name: process.Ext.defense_evasions
+  ignore_above: 1024
   level: custom
   name: Ext.defense_evasions
   normalize: []
   short: List of defense evasions found in this process.
-  type: array
+  type: keyword
 process.Ext.session:
   dashed_name: process-Ext-session
   description: Session information for the current process

--- a/generated/process/ecs/ecs_flat.yml
+++ b/generated/process/ecs/ecs_flat.yml
@@ -1204,6 +1204,18 @@ process.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.Ext.defense_evasions:
+  dashed_name: process-Ext-defense-evasions
+  description: "List of defense evasions found in this process.   These defense evasions\
+    \ can make it harder to inspect a process and/or cause abnormal OS behavior. Examples\
+    \ tools that can cause defense evasions include Process Doppelg\xE4nging and Process\
+    \ Herpaderping."
+  flat_name: process.Ext.defense_evasions
+  level: custom
+  name: Ext.defense_evasions
+  normalize: []
+  short: List of defense evasions found in this process.
+  type: array
 process.Ext.session:
   dashed_name: process-Ext-session
   description: Session information for the current process

--- a/generated/process/ecs/subset/process/ecs_flat.yml
+++ b/generated/process/ecs/subset/process/ecs_flat.yml
@@ -1211,11 +1211,12 @@ process.Ext.defense_evasions:
     \ tools that can cause defense evasions include Process Doppelg\xE4nging and Process\
     \ Herpaderping."
   flat_name: process.Ext.defense_evasions
+  ignore_above: 1024
   level: custom
   name: Ext.defense_evasions
   normalize: []
   short: List of defense evasions found in this process.
-  type: array
+  type: keyword
 process.Ext.session:
   dashed_name: process-Ext-session
   description: Session information for the current process

--- a/generated/process/ecs/subset/process/ecs_flat.yml
+++ b/generated/process/ecs/subset/process/ecs_flat.yml
@@ -1204,6 +1204,18 @@ process.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.Ext.defense_evasions:
+  dashed_name: process-Ext-defense-evasions
+  description: "List of defense evasions found in this process.   These defense evasions\
+    \ can make it harder to inspect a process and/or cause abnormal OS behavior. Examples\
+    \ tools that can cause defense evasions include Process Doppelg\xE4nging and Process\
+    \ Herpaderping."
+  flat_name: process.Ext.defense_evasions
+  level: custom
+  name: Ext.defense_evasions
+  normalize: []
+  short: List of defense evasions found in this process.
+  type: array
 process.Ext.session:
   dashed_name: process-Ext-session
   description: Session information for the current process

--- a/generated/process/elasticsearch/7/template.json
+++ b/generated/process/elasticsearch/7/template.json
@@ -335,6 +335,9 @@
                 },
                 "type": "nested"
               },
+              "defense_evasions": {
+                "type": "array"
+              },
               "session": {
                 "ignore_above": 1024,
                 "type": "keyword"

--- a/generated/process/elasticsearch/7/template.json
+++ b/generated/process/elasticsearch/7/template.json
@@ -336,7 +336,8 @@
                 "type": "nested"
               },
               "defense_evasions": {
-                "type": "array"
+                "ignore_above": 1024,
+                "type": "keyword"
               },
               "session": {
                 "ignore_above": 1024,

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -550,7 +550,8 @@
       default_field: false
     - name: Ext.defense_evasions
       level: custom
-      type: array
+      type: keyword
+      ignore_above: 1024
       description: "List of defense evasions found in this process.   These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior. Examples tools that can cause defense evasions include Process Doppelgänging and Process Herpaderping."
       default_field: false
     - name: Ext.session

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -548,6 +548,11 @@
         Leave unpopulated if a certificate was unchecked.'
       example: 'true'
       default_field: false
+    - name: Ext.defense_evasions
+      level: custom
+      type: array
+      description: "List of defense evasions found in this process.   These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior. Examples tools that can cause defense evasions include Process Doppelgänging and Process Herpaderping."
+      default_field: false
     - name: Ext.session
       level: custom
       type: keyword

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1008,7 +1008,7 @@ sent by the endpoint.
 | process.Ext.code_signature.subject_name | Subject name of the code signer | keyword |
 | process.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | process.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
-| process.Ext.defense_evasions | List of defense evasions found in this process.   These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior. Examples tools that can cause defense evasions include Process Doppelgänging and Process Herpaderping. | array |
+| process.Ext.defense_evasions | List of defense evasions found in this process.   These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior. Examples tools that can cause defense evasions include Process Doppelgänging and Process Herpaderping. | keyword |
 | process.Ext.session | Session information for the current process | keyword |
 | process.Ext.token.elevation | Whether the token is elevated or not | boolean |
 | process.Ext.token.elevation_type | What level of elevation the token has | keyword |

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1008,6 +1008,7 @@ sent by the endpoint.
 | process.Ext.code_signature.subject_name | Subject name of the code signer | keyword |
 | process.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | process.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
+| process.Ext.defense_evasions | List of defense evasions found in this process.   These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior. Examples tools that can cause defense evasions include Process Doppelgänging and Process Herpaderping. | array |
 | process.Ext.session | Session information for the current process | keyword |
 | process.Ext.token.elevation | Whether the token is elevated or not | boolean |
 | process.Ext.token.elevation_type | What level of elevation the token has | keyword |

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1211,11 +1211,12 @@ process.Ext.defense_evasions:
     \ tools that can cause defense evasions include Process Doppelg\xE4nging and Process\
     \ Herpaderping."
   flat_name: process.Ext.defense_evasions
+  ignore_above: 1024
   level: custom
   name: Ext.defense_evasions
   normalize: []
   short: List of defense evasions found in this process.
-  type: array
+  type: keyword
 process.Ext.session:
   dashed_name: process-Ext-session
   description: Session information for the current process

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1204,6 +1204,18 @@ process.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.Ext.defense_evasions:
+  dashed_name: process-Ext-defense-evasions
+  description: "List of defense evasions found in this process.   These defense evasions\
+    \ can make it harder to inspect a process and/or cause abnormal OS behavior. Examples\
+    \ tools that can cause defense evasions include Process Doppelg\xE4nging and Process\
+    \ Herpaderping."
+  flat_name: process.Ext.defense_evasions
+  level: custom
+  name: Ext.defense_evasions
+  normalize: []
+  short: List of defense evasions found in this process.
+  type: array
 process.Ext.session:
   dashed_name: process-Ext-session
   description: Session information for the current process


### PR DESCRIPTION
The description of the new field should explain this.  If it doesn't, I should update that instead of explaining it here.