### PR TITLE
[7.13] Bumping the manifest version for 7.13 (#147)

### DIFF
--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -16,7 +16,7 @@ policy_templates:
     description: Interact with the endpoint.
     multiple: false
 conditions:
-  kibana.version: "^7.12.0"
+  kibana.version: "^7.13.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
   # >= <the version> && < 8.0.0
 icons:


### PR DESCRIPTION
Backports the following commits to 7.13:
 - Bumping the manifest version for 7.13 (#147)