### PR TITLE
[Security Solution] Make Endpoint metadata transform delay and frequency fields faster

### DIFF
--- a/package/endpoint/elasticsearch/transform/metadata_current/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_current/default.json
@@ -19,11 +19,11 @@
         "sort": "@timestamp"
     },
     "description": "collapse and update the latest document for each host",
-    "frequency": "1m",
+    "frequency": "10s",
     "sync": {
         "time": {
             "field": "event.ingested",
-            "delay": "60s"
+            "delay": "10s"
         }
     }
 }


### PR DESCRIPTION
This PR is meant to make the transform that operates on Endpoint metadata faster.  This will improve performance and improve the UX for users since the UI will appear more responsive when using the Endpoint list.

This was tested with a cloud server with ~280k unique Endpoint metadata docs.  There are over a million docs in the metadata source index.  The transform keeps up with the amount of data and properly indexes new Endpoint docs that are streamed.  In addition, when connecting real endpoints, the UI is more responsive since the transform will reflect Endpoint changes more quickly.

Testing methods:
- Continually stream new metadata docs into ES using our generator.  This allows us to easily control the amount of unique Endpoints we stream in and what to expect from the UI.  The transform kept up and the correctly number of Endpoint was reflected each time
- Add a real Endpoint and continually make changes to it so that it streams new docs.  The transform handled it completely and the UX/UI was much more responsive
- Entirely remove a transform and create a new one, thus forcing the new transform to create a new checkpoint on a source index with over 1 million docs.  This simulates an upgrade.  The transform was able to handle this scenario within a few minutes and the UI reflected the changes correctly.

Unique docs:
![image](https://user-images.githubusercontent.com/56395104/121016959-c0cc3000-c76a-11eb-85b3-04430d1733ad.png)

Note the source index shows 280k even (as opposed to 279,999 from the UI above) because one of the Endpoints was unenrolled:
![image](https://user-images.githubusercontent.com/56395104/121017252-13a5e780-c76b-11eb-8d9b-c6d49aa26f42.png)

One million docs in source index:
![image](https://user-images.githubusercontent.com/56395104/121017129-ebb68400-c76a-11eb-818d-bdf61d5a3a1a.png)

Transform:
![image](https://user-images.githubusercontent.com/56395104/121018047-f7567a80-c76b-11eb-95b7-8da095f0d8ea.png)
