### PR TITLE
Add Process protection level to events and alerts

### DIFF
--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -251,3 +251,12 @@
         List of defense evasions found in this process.  
         These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior.
         Examples tools that can cause defense evasions include Process Doppelganging and Process Herpaderping.
+
+    - name: Ext.protection
+      level: custom
+      type: keyword
+      short: OS-level protections granted to this process
+      description: >
+        Indicates the protection level of this process.  Uses the same syntax as Process Explorer.
+        Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light.
+

--- a/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
@@ -484,6 +484,7 @@ fields:
                       buffer: {}
                       decompressed_size: {}
                       encoding: {}
+          protection: {}
           token:
             fields:
               domain: {}
@@ -552,6 +553,7 @@ fields:
                     exceptionable: true
                   status:
                     exceptionable: true
+              protection: {}
   Target:
     fields:
       dll:

--- a/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
@@ -331,6 +331,7 @@ fields:
                 exceptionable: true
               status:
                 exceptionable: true
+          protection: {}
           token:
             fields:
               domain: {}
@@ -416,6 +417,7 @@ fields:
                     exceptionable: true
               dll:
                 fields: *dll-fields
+              protection: {}
               token:
                 fields:
                   domain: {}

--- a/custom_subsets/elastic_endpoint/alerts/ransomware_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/ransomware_event.yaml
@@ -298,6 +298,7 @@ fields:
                 exceptionable: true
               status:
                 exceptionable: true
+          protection: {}
           token:
             fields:
               domain: {}
@@ -366,6 +367,7 @@ fields:
                     exceptionable: true
                   status:
                     exceptionable: true
+              protection: {}
   user:
     fields:
       domain: {}

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -160,6 +160,7 @@ fields:
                 fields:
                   mapped_address: {}
                   mapped_size: {}
+          protection: {}
           session: {}
           token:
             fields:
@@ -221,6 +222,7 @@ fields:
                   trusted: {}
                   valid: {}
               user: {}
+              protection: {}
   package:
     fields:
       name: {}

--- a/generated/alerts/ecs/ecs_flat.yml
+++ b/generated/alerts/ecs/ecs_flat.yml
@@ -1231,6 +1231,19 @@ Target.process.Ext.malware_classification.version:
   original_fieldset: malware_classification
   short: The version of the model used.
   type: keyword
+Target.process.Ext.protection:
+  dashed_name: Target-process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: Target.process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
+  type: keyword
 Target.process.Ext.services:
   dashed_name: Target-process-Ext-services
   description: Services running in this process.
@@ -1962,6 +1975,19 @@ Target.process.parent.Ext.dll.pe.product:
   normalize: []
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
+  type: keyword
+Target.process.parent.Ext.protection:
+  dashed_name: Target-process-parent-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: Target.process.parent.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
   type: keyword
 Target.process.parent.Ext.real:
   dashed_name: Target-process-parent-Ext-real
@@ -6768,6 +6794,18 @@ process.Ext.malware_classification.version:
   original_fieldset: malware_classification
   short: The version of the model used.
   type: keyword
+process.Ext.protection:
+  dashed_name: process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  short: OS-level protections granted to this process
+  type: keyword
 process.Ext.services:
   dashed_name: process-Ext-services
   description: Services running in this process.
@@ -7489,6 +7527,19 @@ process.parent.Ext.dll.pe.product:
   normalize: []
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
+  type: keyword
+process.parent.Ext.protection:
+  dashed_name: process-parent-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.parent.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
   type: keyword
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real

--- a/generated/alerts/ecs/subset/malware_event/ecs_flat.yml
+++ b/generated/alerts/ecs/subset/malware_event/ecs_flat.yml
@@ -5170,6 +5170,18 @@ process.Ext.malware_classification.version:
   original_fieldset: malware_classification
   short: The version of the model used.
   type: keyword
+process.Ext.protection:
+  dashed_name: process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  short: OS-level protections granted to this process
+  type: keyword
 process.Ext.services:
   dashed_name: process-Ext-services
   description: Services running in this process.
@@ -5629,6 +5641,19 @@ process.parent.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.parent.Ext.protection:
+  dashed_name: process-parent-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.parent.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
+  type: keyword
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
   description: The field set containing process info in case of any pid spoofing.

--- a/generated/alerts/ecs/subset/memory_protection_event/ecs_flat.yml
+++ b/generated/alerts/ecs/subset/memory_protection_event/ecs_flat.yml
@@ -633,6 +633,19 @@ Target.process.Ext.dll.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+Target.process.Ext.protection:
+  dashed_name: Target-process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: Target.process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
+  type: keyword
 Target.process.Ext.services:
   dashed_name: Target-process-Ext-services
   description: Services running in this process.
@@ -1377,6 +1390,19 @@ Target.process.parent.Ext.dll.pe.product:
   normalize: []
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
+  type: keyword
+Target.process.parent.Ext.protection:
+  dashed_name: Target-process-parent-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: Target.process.parent.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
   type: keyword
 Target.process.parent.Ext.real:
   dashed_name: Target-process-parent-Ext-real
@@ -4998,6 +5024,18 @@ process.Ext.dll.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+process.Ext.protection:
+  dashed_name: process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  short: OS-level protections granted to this process
+  type: keyword
 process.Ext.services:
   dashed_name: process-Ext-services
   description: Services running in this process.
@@ -5732,6 +5770,19 @@ process.parent.Ext.dll.pe.product:
   normalize: []
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
+  type: keyword
+process.parent.Ext.protection:
+  dashed_name: process-parent-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.parent.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
   type: keyword
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real

--- a/generated/alerts/ecs/subset/ransomware_event/ecs_flat.yml
+++ b/generated/alerts/ecs/subset/ransomware_event/ecs_flat.yml
@@ -2137,6 +2137,18 @@ process.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.Ext.protection:
+  dashed_name: process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  short: OS-level protections granted to this process
+  type: keyword
 process.Ext.services:
   dashed_name: process-Ext-services
   description: Services running in this process.
@@ -2596,6 +2608,19 @@ process.parent.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.parent.Ext.protection:
+  dashed_name: process-parent-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.parent.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
+  type: keyword
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
   description: The field set containing process info in case of any pid spoofing.

--- a/generated/alerts/elasticsearch/7/template.json
+++ b/generated/alerts/elasticsearch/7/template.json
@@ -502,6 +502,10 @@
                       }
                     }
                   },
+                  "protection": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
                   "services": {
                     "ignore_above": 1024,
                     "type": "keyword"
@@ -778,6 +782,10 @@
                             }
                           }
                         }
+                      },
+                      "protection": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
                       },
                       "real": {
                         "properties": {
@@ -2499,6 +2507,10 @@
                   }
                 }
               },
+              "protection": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "services": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -2775,6 +2787,10 @@
                         }
                       }
                     }
+                  },
+                  "protection": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   },
                   "real": {
                     "properties": {

--- a/generated/process/ecs/ecs_flat.yml
+++ b/generated/process/ecs/ecs_flat.yml
@@ -1284,6 +1284,18 @@ process.Ext.dll.path:
   original_fieldset: dll
   short: Full file path of the library.
   type: keyword
+process.Ext.protection:
+  dashed_name: process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  short: OS-level protections granted to this process
+  type: keyword
 process.Ext.session:
   dashed_name: process-Ext-session
   description: Session information for the current process
@@ -1685,6 +1697,19 @@ process.parent.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.parent.Ext.protection:
+  dashed_name: process-parent-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.parent.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
+  type: keyword
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
   description: The field set containing process info in case of any pid spoofing.

--- a/generated/process/ecs/subset/process/ecs_flat.yml
+++ b/generated/process/ecs/subset/process/ecs_flat.yml
@@ -1284,6 +1284,18 @@ process.Ext.dll.path:
   original_fieldset: dll
   short: Full file path of the library.
   type: keyword
+process.Ext.protection:
+  dashed_name: process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  short: OS-level protections granted to this process
+  type: keyword
 process.Ext.session:
   dashed_name: process-Ext-session
   description: Session information for the current process
@@ -1685,6 +1697,19 @@ process.parent.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.parent.Ext.protection:
+  dashed_name: process-parent-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.parent.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
+  type: keyword
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
   description: The field set containing process info in case of any pid spoofing.

--- a/generated/process/elasticsearch/7/template.json
+++ b/generated/process/elasticsearch/7/template.json
@@ -366,6 +366,10 @@
                   }
                 }
               },
+              "protection": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
               "session": {
                 "ignore_above": 1024,
                 "type": "keyword"
@@ -521,6 +525,10 @@
                       }
                     },
                     "type": "nested"
+                  },
+                  "protection": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   },
                   "real": {
                     "properties": {

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -713,6 +713,12 @@
       ignore_above: 1024
       description: The version of the model used.
       default_field: false
+    - name: process.Ext.protection
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light.
+      default_field: false
     - name: process.Ext.services
       level: custom
       type: keyword
@@ -1126,6 +1132,12 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft® Windows® Operating System"
+      default_field: false
+    - name: process.parent.Ext.protection
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light.
       default_field: false
     - name: process.parent.Ext.real
       level: custom
@@ -3675,6 +3687,12 @@
       ignore_above: 1024
       description: The version of the model used.
       default_field: false
+    - name: Ext.protection
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light.
+      default_field: false
     - name: Ext.services
       level: custom
       type: keyword
@@ -4085,6 +4103,12 @@
       ignore_above: 1024
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft® Windows® Operating System"
+      default_field: false
+    - name: parent.Ext.protection
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light.
       default_field: false
     - name: parent.Ext.real
       level: custom

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -592,6 +592,12 @@
       description: Full file path of the library.
       example: C:\Windows\System32\kernel32.dll
       default_field: false
+    - name: Ext.protection
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light.
+      default_field: false
     - name: Ext.session
       level: custom
       type: keyword
@@ -826,6 +832,12 @@
 
         Leave unpopulated if a certificate was unchecked.'
       example: 'true'
+      default_field: false
+    - name: parent.Ext.protection
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light.
       default_field: false
     - name: parent.Ext.real
       level: custom

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -108,6 +108,7 @@ sent by the endpoint.
 | Target.process.Ext.malware_classification.threshold | The score threshold for the model.  Files that score above this threshold are considered malicious. | double |
 | Target.process.Ext.malware_classification.upx_packed | Whether UPX packing was detected. | boolean |
 | Target.process.Ext.malware_classification.version | The version of the model used. | keyword |
+| Target.process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | Target.process.Ext.services | Services running in this process. | keyword |
 | Target.process.Ext.session | Session information for the current process | keyword |
 | Target.process.Ext.token.domain | Domain of token user. | keyword |
@@ -166,6 +167,7 @@ sent by the endpoint.
 | Target.process.parent.Ext.dll.pe.imphash | A hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values. Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html. | keyword |
 | Target.process.parent.Ext.dll.pe.original_file_name | Internal name of the file, provided at compile-time. | keyword |
 | Target.process.parent.Ext.dll.pe.product | Internal product name of the file, provided at compile-time. | keyword |
+| Target.process.parent.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | Target.process.parent.Ext.real | The field set containing process info in case of any pid spoofing. This is mainly useful for process.parent. | object |
 | Target.process.parent.Ext.real.pid | For process.parent this will be the ppid of the process that actually spawned the current process. | long |
 | Target.process.parent.Ext.token.domain | Domain of token user. | keyword |
@@ -513,6 +515,7 @@ sent by the endpoint.
 | process.Ext.malware_classification.threshold | The score threshold for the model.  Files that score above this threshold are considered malicious. | double |
 | process.Ext.malware_classification.upx_packed | Whether UPX packing was detected. | boolean |
 | process.Ext.malware_classification.version | The version of the model used. | keyword |
+| process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | process.Ext.services | Services running in this process. | keyword |
 | process.Ext.session | Session information for the current process | keyword |
 | process.Ext.token.domain | Domain of token user. | keyword |
@@ -571,6 +574,7 @@ sent by the endpoint.
 | process.parent.Ext.dll.pe.imphash | A hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values. Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html. | keyword |
 | process.parent.Ext.dll.pe.original_file_name | Internal name of the file, provided at compile-time. | keyword |
 | process.parent.Ext.dll.pe.product | Internal product name of the file, provided at compile-time. | keyword |
+| process.parent.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | process.parent.Ext.real | The field set containing process info in case of any pid spoofing. This is mainly useful for process.parent. | object |
 | process.parent.Ext.real.pid | For process.parent this will be the ppid of the process that actually spawned the current process. | long |
 | process.parent.Ext.token.domain | Domain of token user. | keyword |
@@ -1232,6 +1236,7 @@ sent by the endpoint.
 | process.Ext.dll.Ext.mapped_size | The size of this module's memory mapping, in bytes. | unsigned_long |
 | process.Ext.dll.name | Name of the library. This generally maps to the name of the file on disk. | keyword |
 | process.Ext.dll.path | Full file path of the library. | keyword |
+| process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | process.Ext.session | Session information for the current process | keyword |
 | process.Ext.token.elevation | Whether the token is elevated or not | boolean |
 | process.Ext.token.elevation_level | What level of elevation the token has | keyword |
@@ -1261,6 +1266,7 @@ sent by the endpoint.
 | process.parent.Ext.code_signature.subject_name | Subject name of the code signer | keyword |
 | process.parent.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | process.parent.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
+| process.parent.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | process.parent.Ext.real | The field set containing process info in case of any pid spoofing. This is mainly useful for process.parent. | object |
 | process.parent.Ext.real.pid | For process.parent this will be the ppid of the process that actually spawned the current process. | long |
 | process.parent.Ext.user | User associated with the running process. | keyword |

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -5069,6 +5069,18 @@ process.Ext.malware_classification.version:
   original_fieldset: malware_classification
   short: The version of the model used.
   type: keyword
+process.Ext.protection:
+  dashed_name: process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  short: OS-level protections granted to this process
+  type: keyword
 process.Ext.services:
   dashed_name: process-Ext-services
   description: Services running in this process.
@@ -5515,6 +5527,19 @@ process.parent.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.parent.Ext.protection:
+  dashed_name: process-parent-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.parent.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
+  type: keyword
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
   description: The field set containing process info in case of any pid spoofing.

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -628,6 +628,19 @@ Target.process.Ext.dll.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+Target.process.Ext.protection:
+  dashed_name: Target-process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: Target.process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
+  type: keyword
 Target.process.Ext.services:
   dashed_name: Target-process-Ext-services
   description: Services running in this process.
@@ -1359,6 +1372,19 @@ Target.process.parent.Ext.dll.pe.product:
   normalize: []
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
+  type: keyword
+Target.process.parent.Ext.protection:
+  dashed_name: Target-process-parent-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: Target.process.parent.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
   type: keyword
 Target.process.parent.Ext.real:
   dashed_name: Target-process-parent-Ext-real
@@ -4925,6 +4951,18 @@ process.Ext.dll.pe.product:
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
   type: keyword
+process.Ext.protection:
+  dashed_name: process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  short: OS-level protections granted to this process
+  type: keyword
 process.Ext.services:
   dashed_name: process-Ext-services
   description: Services running in this process.
@@ -5646,6 +5684,19 @@ process.parent.Ext.dll.pe.product:
   normalize: []
   original_fieldset: pe
   short: Internal product name of the file, provided at compile-time.
+  type: keyword
+process.parent.Ext.protection:
+  dashed_name: process-parent-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.parent.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
   type: keyword
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real

--- a/schemas/v1/alerts/ransomware_event.yaml
+++ b/schemas/v1/alerts/ransomware_event.yaml
@@ -2105,6 +2105,18 @@ process.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.Ext.protection:
+  dashed_name: process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  short: OS-level protections granted to this process
+  type: keyword
 process.Ext.services:
   dashed_name: process-Ext-services
   description: Services running in this process.
@@ -2551,6 +2563,19 @@ process.parent.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.parent.Ext.protection:
+  dashed_name: process-parent-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.parent.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
+  type: keyword
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
   description: The field set containing process info in case of any pid spoofing.

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1284,6 +1284,18 @@ process.Ext.dll.path:
   original_fieldset: dll
   short: Full file path of the library.
   type: keyword
+process.Ext.protection:
+  dashed_name: process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  short: OS-level protections granted to this process
+  type: keyword
 process.Ext.session:
   dashed_name: process-Ext-session
   description: Session information for the current process
@@ -1685,6 +1697,19 @@ process.parent.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.parent.Ext.protection:
+  dashed_name: process-parent-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.parent.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  original_fieldset: process
+  short: OS-level protections granted to this process
+  type: keyword
 process.parent.Ext.real:
   dashed_name: process-parent-Ext-real
   description: The field set containing process info in case of any pid spoofing.


### PR DESCRIPTION
Issue: https://github.com/elastic/endpoint-dev/issues/8759

Windows has a concept of a Protected Process, which has strict code signing requirements and other limitations in order to keep malware out.

By adding process protection level to events and alerts, we can harden allowlist and trustedapp actions for known-problematic processes by adding a PPL requirement.   This rules out a variety of trivial backdoors that would otherwise be a concern.

This may help us avoid performance issues like: https://discuss.elastic.co/t/issues-with-elastic-agent-and-defender/269818

Note: Protection is a property of the process, not its access token.