### PR TITLE
Set transform pivot to elastic.agent.id

### DIFF
--- a/package/endpoint/elasticsearch/transform/metadata_current/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_current/default.json
@@ -14,7 +14,7 @@
     },
     "latest": {
         "unique_key": [
-            "agent.id"
+            "elastic.agent.id"
         ],
         "sort": "@timestamp"
     },


### PR DESCRIPTION
Endpoint (the binary) v7.14 will start sending a new value for its `agent.id`. So upgrading agent+endpoint will result in duplicate hosts from this transform. The `elastic.agent.id` will be the same value across upgrades, and resolves the change as a consistent, single host

This is to handle https://github.com/elastic/kibana/issues/105035