### PR TITLE
new fields for improved call_stack details

### DIFF
--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -160,7 +160,7 @@
 
     - name: thread.Ext.call_stack_final_user_module.hash
       level: custom
-      type: nested
+      type: object
       description: Hashes of the call_stack_final_user_module.
 
     - name: thread.Ext.call_stack_final_user_module.hash.sha256

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -89,44 +89,44 @@
       description: >
         Concatentation of the non-repeated modules in the call stack.
 
-    - name: thread.Ext.final_user_module
+    - name: thread.Ext.call_stack_final_user_module
       level: custom
       type: nested
       description: >
         The final non-win32 module in the call stack.
 
-    - name: thread.Ext.final_user_module.name
+    - name: thread.Ext.call_stack_final_user_module.name
       level: custom
       type: keyword
       example: "example.dll"
       description: >
-        The file name of the final_user_module.
+        The file name of the call_stack_final_user_module.
 
-    - name: thread.Ext.final_user_module.path
+    - name: thread.Ext.call_stack_final_user_module.path
       level: custom
       type: keyword
       example: "C:\\Program Files\\Example\\example.dll"
       description: >
-        The file path of the final_user_module.
+        The file path of the call_stack_final_user_module.
 
-    - name: thread.Ext.final_user_module.code_signature
+    - name: thread.Ext.call_stack_final_user_module.code_signature
       level: custom
       type: nested
-      description: Code signature of the final_user_module.
+      description: Code signature of the call_stack_final_user_module.
 
-    - name: thread.Ext.final_user_module.code_signature.exists
+    - name: thread.Ext.call_stack_final_user_module.code_signature.exists
       level: custom
       type: boolean
       description: Boolean to capture if a signature is present.
       example: "true"
 
-    - name: thread.Ext.final_user_module.code_signature.subject_name
+    - name: thread.Ext.call_stack_final_user_module.code_signature.subject_name
       level: custom
       type: keyword
       description: Subject name of the code signer
       example: Microsoft Corporation
 
-    - name: thread.Ext.final_user_module.code_signature.valid
+    - name: thread.Ext.call_stack_final_user_module.code_signature.valid
       level: custom
       type: boolean
       short: Boolean to capture if the digital signature is verified against the binary content.
@@ -136,7 +136,7 @@
 
         Leave unpopulated if a certificate was unchecked.
 
-    - name: thread.Ext.final_user_module.code_signature.trusted
+    - name: thread.Ext.call_stack_final_user_module.code_signature.trusted
       level: custom
       type: boolean
       short: Stores the trust status of the certificate chain.
@@ -147,7 +147,7 @@
         Validating the trust of the certificate chain may be complicated, and this field should only be populated
         by tools that actively check the status.
 
-    - name: thread.Ext.final_user_module.code_signature.status
+    - name: thread.Ext.call_stack_final_user_module.code_signature.status
       level: custom
       type: keyword
       short: Additional information about the certificate status.
@@ -158,15 +158,15 @@
         Leave unpopulated if the validity or trust of the certificate was unchecked.
       example: ERROR_UNTRUSTED_ROOT
 
-    - name: thread.Ext.final_user_module.hash
+    - name: thread.Ext.call_stack_final_user_module.hash
       level: custom
       type: nested
-      description: Hashes of the final_user_module.
+      description: Hashes of the call_stack_final_user_module.
 
-    - name: thread.Ext.final_user_module.hash.sha256
+    - name: thread.Ext.call_stack_final_user_module.hash.sha256
       level: custom
       type: keyword
-      description: The sha256 of the final_user_module.
+      description: The sha256 of the call_stack_final_user_module.
       example: "d25ff1e6c6460a7f9de39198d182058c1712726008d187e1953b83abe977e4a0"
 
     - name: thread.Ext.start

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -82,6 +82,93 @@
       type: object
       description: Object for all custom defined fields to live in.
 
+    - name: thread.Ext.call_stack_summary
+      level: custom
+      type: keyword
+      example: "ntdll.dll, example.exe, kernel32.dll, ntdll.dll"
+      description: >
+        Concatentation of the non-repeated modules in the call stack.
+
+    - name: thread.Ext.final_user_module
+      level: custom
+      type: nested
+      description: >
+        The final non-win32 module in the call stack.
+
+    - name: thread.Ext.final_user_module.name
+      level: custom
+      type: keyword
+      example: "example.dll"
+      description: >
+        The file name of the final_user_module.
+
+    - name: thread.Ext.final_user_module.path
+      level: custom
+      type: keyword
+      example: "C:\\Program Files\\Example\\example.dll"
+      description: >
+        The file path of the final_user_module.
+
+    - name: thread.Ext.final_user_module.code_signature
+      level: custom
+      type: nested
+      description: Code signature of the final_user_module.
+
+    - name: thread.Ext.final_user_module.code_signature.exists
+      level: custom
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: "true"
+
+    - name: thread.Ext.final_user_module.code_signature.subject_name
+      level: custom
+      type: keyword
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+
+    - name: thread.Ext.final_user_module.code_signature.valid
+      level: custom
+      type: boolean
+      short: Boolean to capture if the digital signature is verified against the binary content.
+      example: "true"
+      description: >
+        Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.
+
+    - name: thread.Ext.final_user_module.code_signature.trusted
+      level: custom
+      type: boolean
+      short: Stores the trust status of the certificate chain.
+      example: "true"
+      description: >
+        Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated
+        by tools that actively check the status.
+
+    - name: thread.Ext.final_user_module.code_signature.status
+      level: custom
+      type: keyword
+      short: Additional information about the certificate status.
+      description: >
+        Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status.
+        Leave unpopulated if the validity or trust of the certificate was unchecked.
+      example: ERROR_UNTRUSTED_ROOT
+
+    - name: thread.Ext.final_user_module.hash
+      level: custom
+      type: nested
+      description: Hashes of the final_user_module.
+
+    - name: thread.Ext.final_user_module.hash.sha256
+      level: custom
+      type: keyword
+      description: The sha256 of the final_user_module.
+      example: "d25ff1e6c6460a7f9de39198d182058c1712726008d187e1953b83abe977e4a0"
+
     - name: thread.Ext.start
       level: custom
       type: date

--- a/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
@@ -205,7 +205,7 @@ fields:
                   symbol_info: {}
                   rva: {}
               call_stack_summary: {}
-              final_user_module:
+              call_stack_final_user_module:
                 fields:
                   name: {}
                   path: {}

--- a/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
@@ -218,8 +218,7 @@ fields:
                       valid: {}
                   hash:
                     fields:
-                      sha256:
-                        exceptionable: true
+                      sha256: {}
               parameter: {}
               parameter_bytes_compressed: {}
               parameter_bytes_compressed_present: {}

--- a/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
@@ -204,6 +204,22 @@ fields:
                       protection: {}
                   symbol_info: {}
                   rva: {}
+              call_stack_summary: {}
+              final_user_module:
+                fields:
+                  name: {}
+                  path: {}
+                  code_signature:
+                    fields:
+                      exists: {}
+                      status: {}
+                      subject_name: {}
+                      trusted: {}
+                      valid: {}
+                  hash:
+                    fields:
+                      sha256:
+                        exceptionable: true
               parameter: {}
               parameter_bytes_compressed: {}
               parameter_bytes_compressed_present: {}

--- a/generated/alerts/ecs/ecs_flat.yml
+++ b/generated/alerts/ecs/ecs_flat.yml
@@ -3452,6 +3452,152 @@ Target.process.thread.Ext.call_stack.symbol_info:
   original_fieldset: call_stack
   short: The nearest symbol for `instruction_pointer`.
   type: keyword
+Target.process.thread.Ext.call_stack_final_user_module:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module
+  description: The final non-win32 module in the call stack.
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module
+  level: custom
+  name: thread.Ext.call_stack_final_user_module
+  normalize: []
+  original_fieldset: process
+  short: The final non-win32 module in the call stack.
+  type: nested
+Target.process.thread.Ext.call_stack_final_user_module.code_signature:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-code-signature
+  description: Code signature of the call_stack_final_user_module.
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.code_signature
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature
+  normalize: []
+  original_fieldset: process
+  short: Code signature of the call_stack_final_user_module.
+  type: nested
+Target.process.thread.Ext.call_stack_final_user_module.code_signature.exists:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.code_signature.exists
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.exists
+  normalize: []
+  original_fieldset: process
+  short: Boolean to capture if a signature is present.
+  type: boolean
+Target.process.thread.Ext.call_stack_final_user_module.code_signature.status:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.code_signature.status
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.status
+  normalize: []
+  original_fieldset: process
+  short: Additional information about the certificate status.
+  type: keyword
+Target.process.thread.Ext.call_stack_final_user_module.code_signature.subject_name:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.code_signature.subject_name
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.subject_name
+  normalize: []
+  original_fieldset: process
+  short: Subject name of the code signer
+  type: keyword
+Target.process.thread.Ext.call_stack_final_user_module.code_signature.trusted:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.code_signature.trusted
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.trusted
+  normalize: []
+  original_fieldset: process
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+Target.process.thread.Ext.call_stack_final_user_module.code_signature.valid:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.code_signature.valid
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.valid
+  normalize: []
+  original_fieldset: process
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
+Target.process.thread.Ext.call_stack_final_user_module.hash:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-hash
+  description: Hashes of the call_stack_final_user_module.
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.hash
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.hash
+  normalize: []
+  original_fieldset: process
+  short: Hashes of the call_stack_final_user_module.
+  type: object
+Target.process.thread.Ext.call_stack_final_user_module.hash.sha256:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-hash-sha256
+  description: The sha256 of the call_stack_final_user_module.
+  example: d25ff1e6c6460a7f9de39198d182058c1712726008d187e1953b83abe977e4a0
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.hash.sha256
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.hash.sha256
+  normalize: []
+  original_fieldset: process
+  short: The sha256 of the call_stack_final_user_module.
+  type: keyword
+Target.process.thread.Ext.call_stack_final_user_module.name:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-name
+  description: The file name of the call_stack_final_user_module.
+  example: example.dll
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.name
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.name
+  normalize: []
+  original_fieldset: process
+  short: The file name of the call_stack_final_user_module.
+  type: keyword
+Target.process.thread.Ext.call_stack_final_user_module.path:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-path
+  description: The file path of the call_stack_final_user_module.
+  example: C:\Program Files\Example\example.dll
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.path
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.path
+  normalize: []
+  original_fieldset: process
+  short: The file path of the call_stack_final_user_module.
+  type: keyword
+Target.process.thread.Ext.call_stack_summary:
+  dashed_name: Target-process-thread-Ext-call-stack-summary
+  description: Concatentation of the non-repeated modules in the call stack.
+  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  flat_name: Target.process.thread.Ext.call_stack_summary
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_summary
+  normalize: []
+  original_fieldset: process
+  short: Concatentation of the non-repeated modules in the call stack.
+  type: keyword
 Target.process.thread.Ext.parameter:
   dashed_name: Target-process-thread-Ext-parameter
   description: When a thread is created, this is the raw numerical value of its parameter.
@@ -9425,6 +9571,140 @@ process.thread.Ext.call_stack.symbol_info:
   normalize: []
   original_fieldset: call_stack
   short: The nearest symbol for `instruction_pointer`.
+  type: keyword
+process.thread.Ext.call_stack_final_user_module:
+  dashed_name: process-thread-Ext-call-stack-final-user-module
+  description: The final non-win32 module in the call stack.
+  flat_name: process.thread.Ext.call_stack_final_user_module
+  level: custom
+  name: thread.Ext.call_stack_final_user_module
+  normalize: []
+  short: The final non-win32 module in the call stack.
+  type: nested
+process.thread.Ext.call_stack_final_user_module.code_signature:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-code-signature
+  description: Code signature of the call_stack_final_user_module.
+  flat_name: process.thread.Ext.call_stack_final_user_module.code_signature
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature
+  normalize: []
+  short: Code signature of the call_stack_final_user_module.
+  type: nested
+process.thread.Ext.call_stack_final_user_module.code_signature.exists:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.thread.Ext.call_stack_final_user_module.code_signature.exists
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.thread.Ext.call_stack_final_user_module.code_signature.status:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.thread.Ext.call_stack_final_user_module.code_signature.status
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.status
+  normalize: []
+  short: Additional information about the certificate status.
+  type: keyword
+process.thread.Ext.call_stack_final_user_module.code_signature.subject_name:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.thread.Ext.call_stack_final_user_module.code_signature.subject_name
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.subject_name
+  normalize: []
+  short: Subject name of the code signer
+  type: keyword
+process.thread.Ext.call_stack_final_user_module.code_signature.trusted:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.thread.Ext.call_stack_final_user_module.code_signature.trusted
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.thread.Ext.call_stack_final_user_module.code_signature.valid:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.thread.Ext.call_stack_final_user_module.code_signature.valid
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.valid
+  normalize: []
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
+process.thread.Ext.call_stack_final_user_module.hash:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-hash
+  description: Hashes of the call_stack_final_user_module.
+  flat_name: process.thread.Ext.call_stack_final_user_module.hash
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.hash
+  normalize: []
+  short: Hashes of the call_stack_final_user_module.
+  type: object
+process.thread.Ext.call_stack_final_user_module.hash.sha256:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-hash-sha256
+  description: The sha256 of the call_stack_final_user_module.
+  example: d25ff1e6c6460a7f9de39198d182058c1712726008d187e1953b83abe977e4a0
+  flat_name: process.thread.Ext.call_stack_final_user_module.hash.sha256
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.hash.sha256
+  normalize: []
+  short: The sha256 of the call_stack_final_user_module.
+  type: keyword
+process.thread.Ext.call_stack_final_user_module.name:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-name
+  description: The file name of the call_stack_final_user_module.
+  example: example.dll
+  flat_name: process.thread.Ext.call_stack_final_user_module.name
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.name
+  normalize: []
+  short: The file name of the call_stack_final_user_module.
+  type: keyword
+process.thread.Ext.call_stack_final_user_module.path:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-path
+  description: The file path of the call_stack_final_user_module.
+  example: C:\Program Files\Example\example.dll
+  flat_name: process.thread.Ext.call_stack_final_user_module.path
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.path
+  normalize: []
+  short: The file path of the call_stack_final_user_module.
+  type: keyword
+process.thread.Ext.call_stack_summary:
+  dashed_name: process-thread-Ext-call-stack-summary
+  description: Concatentation of the non-repeated modules in the call stack.
+  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  flat_name: process.thread.Ext.call_stack_summary
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_summary
+  normalize: []
+  short: Concatentation of the non-repeated modules in the call stack.
   type: keyword
 process.thread.Ext.parameter:
   dashed_name: process-thread-Ext-parameter

--- a/generated/alerts/elasticsearch/7/template.json
+++ b/generated/alerts/elasticsearch/7/template.json
@@ -1367,6 +1367,54 @@
                         },
                         "type": "group"
                       },
+                      "call_stack_final_user_module": {
+                        "properties": {
+                          "code_signature": {
+                            "properties": {
+                              "exists": {
+                                "type": "boolean"
+                              },
+                              "status": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                              },
+                              "subject_name": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                              },
+                              "trusted": {
+                                "type": "boolean"
+                              },
+                              "valid": {
+                                "type": "boolean"
+                              }
+                            },
+                            "type": "nested"
+                          },
+                          "hash": {
+                            "properties": {
+                              "sha256": {
+                                "ignore_above": 1024,
+                                "type": "keyword"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "path": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "nested"
+                      },
+                      "call_stack_summary": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
                       "parameter": {
                         "type": "unsigned_long"
                       },
@@ -3504,6 +3552,54 @@
                       }
                     },
                     "type": "group"
+                  },
+                  "call_stack_final_user_module": {
+                    "properties": {
+                      "code_signature": {
+                        "properties": {
+                          "exists": {
+                            "type": "boolean"
+                          },
+                          "status": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "subject_name": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          },
+                          "trusted": {
+                            "type": "boolean"
+                          },
+                          "valid": {
+                            "type": "boolean"
+                          }
+                        },
+                        "type": "nested"
+                      },
+                      "hash": {
+                        "properties": {
+                          "sha256": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                          }
+                        },
+                        "type": "object"
+                      },
+                      "name": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
+                      "path": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      }
+                    },
+                    "type": "nested"
+                  },
+                  "call_stack_summary": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   },
                   "parameter": {
                     "type": "unsigned_long"

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -1963,6 +1963,87 @@
       ignore_above: 1024
       description: The nearest symbol for `instruction_pointer`.
       default_field: false
+    - name: process.thread.Ext.call_stack_final_user_module
+      level: custom
+      type: nested
+      description: The final non-win32 module in the call stack.
+      default_field: false
+    - name: process.thread.Ext.call_stack_final_user_module.code_signature
+      level: custom
+      type: nested
+      description: Code signature of the call_stack_final_user_module.
+      default_field: false
+    - name: process.thread.Ext.call_stack_final_user_module.code_signature.exists
+      level: custom
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: process.thread.Ext.call_stack_final_user_module.code_signature.status
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: process.thread.Ext.call_stack_final_user_module.code_signature.subject_name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: process.thread.Ext.call_stack_final_user_module.code_signature.trusted
+      level: custom
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: process.thread.Ext.call_stack_final_user_module.code_signature.valid
+      level: custom
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      default_field: false
+    - name: process.thread.Ext.call_stack_final_user_module.hash
+      level: custom
+      type: object
+      description: Hashes of the call_stack_final_user_module.
+      default_field: false
+    - name: process.thread.Ext.call_stack_final_user_module.hash.sha256
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The sha256 of the call_stack_final_user_module.
+      example: d25ff1e6c6460a7f9de39198d182058c1712726008d187e1953b83abe977e4a0
+      default_field: false
+    - name: process.thread.Ext.call_stack_final_user_module.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The file name of the call_stack_final_user_module.
+      example: example.dll
+      default_field: false
+    - name: process.thread.Ext.call_stack_final_user_module.path
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The file path of the call_stack_final_user_module.
+      example: C:\Program Files\Example\example.dll
+      default_field: false
+    - name: process.thread.Ext.call_stack_summary
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Concatentation of the non-repeated modules in the call stack.
+      example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+      default_field: false
     - name: process.thread.Ext.parameter
       level: custom
       type: unsigned_long
@@ -5156,6 +5237,87 @@
       type: keyword
       ignore_above: 1024
       description: The nearest symbol for `instruction_pointer`.
+      default_field: false
+    - name: thread.Ext.call_stack_final_user_module
+      level: custom
+      type: nested
+      description: The final non-win32 module in the call stack.
+      default_field: false
+    - name: thread.Ext.call_stack_final_user_module.code_signature
+      level: custom
+      type: nested
+      description: Code signature of the call_stack_final_user_module.
+      default_field: false
+    - name: thread.Ext.call_stack_final_user_module.code_signature.exists
+      level: custom
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: thread.Ext.call_stack_final_user_module.code_signature.status
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: thread.Ext.call_stack_final_user_module.code_signature.subject_name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: thread.Ext.call_stack_final_user_module.code_signature.trusted
+      level: custom
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: thread.Ext.call_stack_final_user_module.code_signature.valid
+      level: custom
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      default_field: false
+    - name: thread.Ext.call_stack_final_user_module.hash
+      level: custom
+      type: object
+      description: Hashes of the call_stack_final_user_module.
+      default_field: false
+    - name: thread.Ext.call_stack_final_user_module.hash.sha256
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The sha256 of the call_stack_final_user_module.
+      example: d25ff1e6c6460a7f9de39198d182058c1712726008d187e1953b83abe977e4a0
+      default_field: false
+    - name: thread.Ext.call_stack_final_user_module.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The file name of the call_stack_final_user_module.
+      example: example.dll
+      default_field: false
+    - name: thread.Ext.call_stack_final_user_module.path
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The file path of the call_stack_final_user_module.
+      example: C:\Program Files\Example\example.dll
+      default_field: false
+    - name: thread.Ext.call_stack_summary
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Concatentation of the non-repeated modules in the call stack.
+      example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
       default_field: false
     - name: thread.Ext.parameter
       level: custom

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -2549,6 +2549,152 @@ Target.process.thread.Ext.call_stack.symbol_info:
   original_fieldset: call_stack
   short: The nearest symbol for `instruction_pointer`.
   type: keyword
+Target.process.thread.Ext.call_stack_final_user_module:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module
+  description: The final non-win32 module in the call stack.
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module
+  level: custom
+  name: thread.Ext.call_stack_final_user_module
+  normalize: []
+  original_fieldset: process
+  short: The final non-win32 module in the call stack.
+  type: nested
+Target.process.thread.Ext.call_stack_final_user_module.code_signature:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-code-signature
+  description: Code signature of the call_stack_final_user_module.
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.code_signature
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature
+  normalize: []
+  original_fieldset: process
+  short: Code signature of the call_stack_final_user_module.
+  type: nested
+Target.process.thread.Ext.call_stack_final_user_module.code_signature.exists:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.code_signature.exists
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.exists
+  normalize: []
+  original_fieldset: process
+  short: Boolean to capture if a signature is present.
+  type: boolean
+Target.process.thread.Ext.call_stack_final_user_module.code_signature.status:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.code_signature.status
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.status
+  normalize: []
+  original_fieldset: process
+  short: Additional information about the certificate status.
+  type: keyword
+Target.process.thread.Ext.call_stack_final_user_module.code_signature.subject_name:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.code_signature.subject_name
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.subject_name
+  normalize: []
+  original_fieldset: process
+  short: Subject name of the code signer
+  type: keyword
+Target.process.thread.Ext.call_stack_final_user_module.code_signature.trusted:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.code_signature.trusted
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.trusted
+  normalize: []
+  original_fieldset: process
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+Target.process.thread.Ext.call_stack_final_user_module.code_signature.valid:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.code_signature.valid
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.valid
+  normalize: []
+  original_fieldset: process
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
+Target.process.thread.Ext.call_stack_final_user_module.hash:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-hash
+  description: Hashes of the call_stack_final_user_module.
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.hash
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.hash
+  normalize: []
+  original_fieldset: process
+  short: Hashes of the call_stack_final_user_module.
+  type: object
+Target.process.thread.Ext.call_stack_final_user_module.hash.sha256:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-hash-sha256
+  description: The sha256 of the call_stack_final_user_module.
+  example: d25ff1e6c6460a7f9de39198d182058c1712726008d187e1953b83abe977e4a0
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.hash.sha256
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.hash.sha256
+  normalize: []
+  original_fieldset: process
+  short: The sha256 of the call_stack_final_user_module.
+  type: keyword
+Target.process.thread.Ext.call_stack_final_user_module.name:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-name
+  description: The file name of the call_stack_final_user_module.
+  example: example.dll
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.name
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.name
+  normalize: []
+  original_fieldset: process
+  short: The file name of the call_stack_final_user_module.
+  type: keyword
+Target.process.thread.Ext.call_stack_final_user_module.path:
+  dashed_name: Target-process-thread-Ext-call-stack-final-user-module-path
+  description: The file path of the call_stack_final_user_module.
+  example: C:\Program Files\Example\example.dll
+  flat_name: Target.process.thread.Ext.call_stack_final_user_module.path
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.path
+  normalize: []
+  original_fieldset: process
+  short: The file path of the call_stack_final_user_module.
+  type: keyword
+Target.process.thread.Ext.call_stack_summary:
+  dashed_name: Target-process-thread-Ext-call-stack-summary
+  description: Concatentation of the non-repeated modules in the call stack.
+  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  flat_name: Target.process.thread.Ext.call_stack_summary
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_summary
+  normalize: []
+  original_fieldset: process
+  short: Concatentation of the non-repeated modules in the call stack.
+  type: keyword
 Target.process.thread.Ext.parameter:
   dashed_name: Target-process-thread-Ext-parameter
   description: When a thread is created, this is the raw numerical value of its parameter.
@@ -7017,6 +7163,140 @@ process.thread.Ext.call_stack.symbol_info:
   normalize: []
   original_fieldset: call_stack
   short: The nearest symbol for `instruction_pointer`.
+  type: keyword
+process.thread.Ext.call_stack_final_user_module:
+  dashed_name: process-thread-Ext-call-stack-final-user-module
+  description: The final non-win32 module in the call stack.
+  flat_name: process.thread.Ext.call_stack_final_user_module
+  level: custom
+  name: thread.Ext.call_stack_final_user_module
+  normalize: []
+  short: The final non-win32 module in the call stack.
+  type: nested
+process.thread.Ext.call_stack_final_user_module.code_signature:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-code-signature
+  description: Code signature of the call_stack_final_user_module.
+  flat_name: process.thread.Ext.call_stack_final_user_module.code_signature
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature
+  normalize: []
+  short: Code signature of the call_stack_final_user_module.
+  type: nested
+process.thread.Ext.call_stack_final_user_module.code_signature.exists:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.thread.Ext.call_stack_final_user_module.code_signature.exists
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.thread.Ext.call_stack_final_user_module.code_signature.status:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.thread.Ext.call_stack_final_user_module.code_signature.status
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.status
+  normalize: []
+  short: Additional information about the certificate status.
+  type: keyword
+process.thread.Ext.call_stack_final_user_module.code_signature.subject_name:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.thread.Ext.call_stack_final_user_module.code_signature.subject_name
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.subject_name
+  normalize: []
+  short: Subject name of the code signer
+  type: keyword
+process.thread.Ext.call_stack_final_user_module.code_signature.trusted:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.thread.Ext.call_stack_final_user_module.code_signature.trusted
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.thread.Ext.call_stack_final_user_module.code_signature.valid:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.thread.Ext.call_stack_final_user_module.code_signature.valid
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.code_signature.valid
+  normalize: []
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
+process.thread.Ext.call_stack_final_user_module.hash:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-hash
+  description: Hashes of the call_stack_final_user_module.
+  flat_name: process.thread.Ext.call_stack_final_user_module.hash
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.hash
+  normalize: []
+  short: Hashes of the call_stack_final_user_module.
+  type: object
+process.thread.Ext.call_stack_final_user_module.hash.sha256:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-hash-sha256
+  description: The sha256 of the call_stack_final_user_module.
+  example: d25ff1e6c6460a7f9de39198d182058c1712726008d187e1953b83abe977e4a0
+  flat_name: process.thread.Ext.call_stack_final_user_module.hash.sha256
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.hash.sha256
+  normalize: []
+  short: The sha256 of the call_stack_final_user_module.
+  type: keyword
+process.thread.Ext.call_stack_final_user_module.name:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-name
+  description: The file name of the call_stack_final_user_module.
+  example: example.dll
+  flat_name: process.thread.Ext.call_stack_final_user_module.name
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.name
+  normalize: []
+  short: The file name of the call_stack_final_user_module.
+  type: keyword
+process.thread.Ext.call_stack_final_user_module.path:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-path
+  description: The file path of the call_stack_final_user_module.
+  example: C:\Program Files\Example\example.dll
+  flat_name: process.thread.Ext.call_stack_final_user_module.path
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.path
+  normalize: []
+  short: The file path of the call_stack_final_user_module.
+  type: keyword
+process.thread.Ext.call_stack_summary:
+  dashed_name: process-thread-Ext-call-stack-summary
+  description: Concatentation of the non-repeated modules in the call stack.
+  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  flat_name: process.thread.Ext.call_stack_summary
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_summary
+  normalize: []
+  short: Concatentation of the non-repeated modules in the call stack.
   type: keyword
 process.thread.Ext.parameter:
   dashed_name: process-thread-Ext-parameter


### PR DESCRIPTION
Adds additional thread information fields related to call stacks.
This improves our ability to write strong exceptionlist rules.

The additional fields are -
```
process.thread.Ext.call_stack_summary
process.thread.Ext.call_stack_final_user_module.name
process.thread.Ext.call_stack_final_user_module.path
process.thread.Ext.call_stack_final_user_module.hash.sha256
process.thread.Ext.call_stack_final_user_module.code_signature
```