### PR TITLE
7.16 version should now be 1.2.x

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.22.0-dev.0
+current_version = 1.2.0-dev.0
 commit = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)\.(?P<build>\d+))?
 serialize = 

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: endpoint
 title: Endpoint Security
 description: Protect your hosts with threat prevention, detection, and deep security data visibility.
-version: 0.22.0-dev.0
+version: 1.2.0-dev.0
 categories: ["security"]
 # Options are experimental, beta, ga
 release: ga


### PR DESCRIPTION

Corrected versioning schema:


| branch | stack version | prev pkg ver | new pkg ver | PR |
|-----------|-------------------|------------------|------------------|-----: |
| `7.14`   | 7.14               | 0.20.2          |  1.0.0            |  https://github.com/elastic/package-storage/pull/1956 |
| `7.15`   |  7.15              | 0.21.0          |   1.1.0           | https://github.com/elastic/package-storage/pull/1957 |
| `master` | 7.16             | 0.22.0          | 1.2.0             | this one | 