### PR TITLE
[United Meta] Add updated_at alias to metadata-latest, matching fleet

### DIFF
--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
@@ -23,6 +23,10 @@
                 "@timestamp": {
                     "type": "date"
                 },
+                "updated_at": {
+                    "type": "alias",
+                    "path": "@timestamp"
+                },
                 "Endpoint": {
                     "properties": {
                         "configuration": {


### PR DESCRIPTION
This adds `updated_at` as an alias field to `@timestamp` in the mapping for the metadata-latest transform destination index (`metrics-endpoint.metadata_current_default`).

The reasoning here is to match a field name that exists in `.fleet-agents`, the same `updated_at` field which is a timestamp. This will allow a (PR to come) new transform to unite these two with a time-sync field by the same name.


The `updated_at` field *will not* appear in result documents for this transform destination. the `_source` document is unchanged. This just allows _queries_ to also use `updated_at` as a field name to query by. This is otherwise a transparent change.


## Before

<details>

<summary>Query</summary>

```sh
echo '{
  "query": {
    "range": {
      "updated_at": {
        "gte": "2021-08-01T12:00:00",
        "lte": "2021-10-01T12:00:00"
      }
    }
  }
}' | http -a elastic:changeme estc:9201/metrics-endpoint.metadata_current_default/_search
HTTP/1.1 200 OK
X-elastic-product: Elasticsearch
content-encoding: gzip
content-length: 139
content-type: application/json

{
    "_shards": {
        "failed": 0,
        "skipped": 0,
        "successful": 1,
        "total": 1
    },
    "hits": {
        "hits": [],
        "max_score": null,
        "total": {
            "relation": "eq",
            "value": 0
        }
    },
    "timed_out": false,
    "took": 1
}
```
</details>

## After

<details>

<summary>Query</summary>

```sh

echo '{
  "query": {
    "range": {
      "updated_at": {
        "gte": "2021-08-01T12:00:00",
        "lte": "2021-10-01T12:00:00"
      }
    }
  }
}' | http -a elastic:changeme estc:9201/metrics-endpoint.metadata_current_default/_search
HTTP/1.1 200 OK
X-elastic-product: Elasticsearch
content-encoding: gzip
content-length: 942
content-type: application/json

{
    "_shards": {
        "failed": 0,
        "skipped": 0,
        "successful": 1,
        "total": 1
    },
    "hits": {
        "hits": [
            {
                "_id": "MjsctkIzbzJz9rNHjTzJlboAAAAAAAAA",
                "_index": "metrics-endpoint.metadata_current_default",
                "_score": 1.0,
                "_source": {
                    "@timestamp": "2021-09-03T14:08:45.904667604Z",
                    "Endpoint": {
                        "configuration": {
                            "isolation": false
                        },
                        "policy": {
                            "applied": {
                                "endpoint_policy_version": "1",
                                "id": "c660e994-27fd-4823-9ac0-3c3ace02103e",
                                "name": "X",
                                "status": "success",
                                "version": "3"
                            }
                        },
                        "state": {
                            "isolation": false
                        },
                        "status": "enrolled"
                    },
                    "agent": {
                        "build": {
                            "original": "version: 7.14.0, compiled: Tue Jul 13 22:09:42 2021, branch: 7.14, commit: 63faac2063c70c61120cd10a57e666e339f13d38"
                        },
                        "id": "2fd1338d-7ba9-4f24-964e-d4193fdafd01",
                        "type": "endpoint",
                        "version": "7.14.0"
                    },
                    "data_stream": {
                        "dataset": "endpoint.metadata",
                        "namespace": "default",
                        "type": "metrics"
                    },
                    "ecs": {
                        "version": "1.6.0"
                    },
                    "elastic": {
                        "agent": {
                            "id": "2fd1338d-7ba9-4f24-964e-d4193fdafd01"
                        }
                    },
                    "event": {
                        "action": "endpoint_metadata",
                        "agent_id_status": "verified",
                        "category": [
                            "host"
                        ],
                        "created": "2021-09-03T14:08:45.904667604Z",
                        "dataset": "endpoint.metadata",
                        "id": "MH6fDytugmmTxi+R+++++++i",
                        "ingested": "2021-09-03T14:08:45Z",
                        "kind": "metric",
                        "module": "endpoint",
                        "sequence": 10,
                        "type": [
                            "info"
                        ]
                    },
                    "host": {
                        "architecture": "x86_64",
                        "hostname": "f7162ebf9b0d",
                        "id": "2aefee5b-93e1-4bc9-8a50-b015d789eb26",
                        "ip": [
                            "127.0.0.1",
                            "::1",
                            "10.0.2.100",
                            "fe80::7c9c:d9ff:fe63:c3a8"
                        ],
                        "mac": [
                            "7e:9c:d9:63:c3:a8"
                        ],
                        "name": "f7162ebf9b0d",
                        "os": {
                            "Ext": {
                                "variant": "CentOS"
                            },
                            "family": "centos",
                            "full": "CentOS 8.3.2011",
                            "kernel": "5.13.13-arch1-1 #1 SMP PREEMPT Thu, 26 Aug 2021 19:14:36 +0000",
                            "name": "Linux",
                            "platform": "centos",
                            "version": "8.3.2011"
                        }
                    },
                    "message": "Endpoint metadata"
                }
            }
        ],
        "max_score": 1.0,
        "total": {
            "relation": "eq",
            "value": 1
        }
    },
    "timed_out": false,
    "took": 1
}

```

</details>


## Upgrade

Upgrading the existing mapping with existing data was fine. It is just adding a field, and aliasing to something that always existed, so upgrade was expected to be trivial:

```
INFO [TransformIndexer] [endpoint.metadata_current-default-1.1.1] transform has stopped.
INFO [MetadataDeleteIndexService] [metrics-endpoint.metadata_current_default/aFJMj4CXTai6AnRY5i0Y3w] deleting index
INFO [MetadataCreateIndexService] [metrics-endpoint.metadata_current_default] creating index, cause [api], templates [metrics-metadata-current], shards [1]/[1]
INFO [AllocationService] updating number_of_replicas to [0] for indices [metrics-endpoint.metadata_current_default]
INFO [TransformTask] [endpoint.metadata_current-default-1.2.0-dev.0] updating state for transform to [{"task_state":"started","indexer_state":"stopped","checkpoint":0,"progress":{"docs_indexed":0,"docs_processed":0},"should_stop_at_checkpoint":false}].
INFO [TransformPersistentTasksExecutor] [endpoint.metadata_current-default-1.2.0-dev.0] successfully completed and scheduled task in node operation
INFO [MetadataMappingService] [metrics-endpoint.metadata_current_default/dc6r47h5RxCgd_Ab1L2FhA] update_mapping [_doc]
```