### PR TITLE
[Maintenance] Add some pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/Other.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Other.md
@@ -1,0 +1,12 @@
+---
+name: Other
+about: Any other change that doesn't fit into the above
+labels: 'Team:Onboarding and Lifecycle Mgt'
+---
+
+## Change Summary
+
+
+## Release Target
+
+<!-- What is intended Kibana release this is expected to ship with -->

--- a/.github/PULL_REQUEST_TEMPLATE/Schema_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Schema_change.md
@@ -8,7 +8,7 @@ labels: 'schema, Team:Onboarding and Lifecycle Mgt'
 
 <!-- please describe the intended use for the field changes -->
 
-#### Sample values
+### Sample values
 
 <!--  Please provide sample values that will go into these field changes. 
     

--- a/.github/PULL_REQUEST_TEMPLATE/Schema_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Schema_change.md
@@ -1,0 +1,35 @@
+---
+name: Schema Change
+about: Adds/Removes/changes any schema fields
+labels: 'schema, Team:Onboarding and Lifecycle Mgt'
+---
+
+## Change Summary
+
+<!-- please describe the intended use for the field changes -->
+
+#### Sample values
+
+<!--  Please provide sample values that will go into these field changes. 
+    
+    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533
+-->
+
+Sample document:
+
+```json
+
+
+```
+
+
+## Release Target
+
+<!-- What is intended Kibana release this is expected to ship with -->
+
+
+## Q/A
+
+- [ ] I ran `make` after making the schema changes, and committed any generated files (in `schema/`, `generated/`)
+- [ ] Does this field need to be "exceptionable"? (no longer specified in this package, this is now tracked in Kibana)
+- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

--- a/.github/PULL_REQUEST_TEMPLATE/Transform.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Transform.md
@@ -1,0 +1,18 @@
+---
+name: Transform
+about: Any changes to transform definitions or destination schemas
+labels: 'transform, Team:Onboarding and Lifecycle Mgt'
+---
+
+## Change Summary
+
+
+## Release Target
+
+<!-- What is intended Kibana release this is expected to ship with -->
+
+
+## Q/A
+
+- [ ] The new transform successfully starts in Kibana
+- [ ] The corresponding transform destination schema was updated if necessary


### PR DESCRIPTION
Now, when people create PRs to the package, we have some reminders and requests for info, so we can match up the intent (e.g. use of the new schema field, and sample values) with the change and field type