### PR TITLE
add new united metadata transform

### DIFF
--- a/package/endpoint/data_stream/metadata/manifest.yml
+++ b/package/endpoint/data_stream/metadata/manifest.yml
@@ -4,3 +4,11 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+    settings:
+      index:
+        sort.field:
+          - "@timestamp"
+          - agent.id
+        sort.order:
+          - desc
+          - asc

--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
@@ -23,6 +23,10 @@
                 "@timestamp": {
                     "type": "date"
                 },
+                "updated_at": {
+                    "type": "alias",
+                    "path": "@timestamp"
+                },
                 "Endpoint": {
                     "properties": {
                         "configuration": {

--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
@@ -292,7 +292,15 @@
                 "codec": "best_compression",
                 "refresh_interval": "5s",
                 "number_of_shards": "1",
-                "number_of_routing_shards": "30"
+                "number_of_routing_shards": "30",
+                "sort.field": [
+                    "@timestamp",
+                    "agent.id"
+                ],
+                "sort.order": [
+                    "desc",
+                    "asc"
+                ]
             }
         },
         "aliases": {}

--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
@@ -1,0 +1,533 @@
+{
+    "index_patterns": [
+        ".metrics-endpoint.metadata_united_*"
+    ],
+    "priority": 200,
+    "template": {
+        "mappings": {
+            "dynamic": "false",
+            "_meta": {},
+            "dynamic_templates": [{
+                "strings_as_keyword": {
+                    "match_mapping_type": "string",
+                    "mapping": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                    }
+                }
+            }],
+            "date_detection": false,
+            "properties": {
+                "agent": {
+                    "properties": {
+                        "id": {
+                            "type": "keyword",
+                            "ignore_above": 1024
+                        }
+                    }
+                },
+                "united": {
+                    "properties": {
+                        "endpoint": {
+                            "properties": {
+                                "@timestamp": {
+                                    "type": "date"
+                                },
+                                "Endpoint": {
+                                    "properties": {
+                                        "configuration": {
+                                            "properties": {
+                                                "isolation": {
+                                                    "type": "boolean",
+                                                    "null_value": false
+                                                }
+                                            }
+                                        },
+                                        "policy": {
+                                            "properties": {
+                                                "applied": {
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "keyword",
+                                                            "ignore_above": 1024
+                                                        },
+                                                        "name": {
+                                                            "type": "keyword",
+                                                            "ignore_above": 1024
+                                                        },
+                                                        "status": {
+                                                            "type": "keyword",
+                                                            "ignore_above": 1024
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "state": {
+                                            "properties": {
+                                                "isolation": {
+                                                    "type": "boolean",
+                                                    "null_value": false
+                                                }
+                                            }
+                                        },
+                                        "status": {
+                                            "type": "keyword",
+                                            "ignore_above": 1024
+                                        },
+                                        "capabilities": {
+                                            "type": "keyword",
+                                            "ignore_above": 128,
+                                            "doc_values": false
+                                        }
+                                    }
+                                },
+                                "agent": {
+                                    "properties": {
+                                        "id": {
+                                            "type": "keyword",
+                                            "ignore_above": 1024
+                                        },
+                                        "name": {
+                                            "type": "keyword",
+                                            "ignore_above": 1024
+                                        },
+                                        "type": {
+                                            "type": "keyword",
+                                            "ignore_above": 1024
+                                        },
+                                        "version": {
+                                            "type": "keyword",
+                                            "ignore_above": 1024
+                                        }
+                                    }
+                                },
+                                "data_stream": {
+                                    "properties": {
+                                        "dataset": {
+                                            "type": "constant_keyword"
+                                        },
+                                        "namespace": {
+                                            "type": "keyword"
+                                        },
+                                        "type": {
+                                            "type": "constant_keyword"
+                                        }
+                                    }
+                                },
+                                "ecs": {
+                                    "properties": {
+                                        "version": {
+                                            "type": "keyword",
+                                            "ignore_above": 1024
+                                        }
+                                    }
+                                },
+                                "elastic": {
+                                    "properties": {
+                                        "agent": {
+                                            "properties": {
+                                                "id": {
+                                                    "type": "keyword",
+                                                    "ignore_above": 1024
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "event": {
+                                    "properties": {
+                                        "action": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "category": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "code": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "created": {
+                                            "type": "date"
+                                        },
+                                        "dataset": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "hash": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "id": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "ingested": {
+                                            "type": "date"
+                                        },
+                                        "kind": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "module": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "outcome": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "provider": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "sequence": {
+                                            "type": "long"
+                                        },
+                                        "severity": {
+                                            "type": "long"
+                                        },
+                                        "type": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        }
+                                    }
+                                },
+                                "host": {
+                                    "properties": {
+                                        "architecture": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "domain": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "hostname": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "id": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "ip": {
+                                            "type": "ip"
+                                        },
+                                        "mac": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "name": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "os": {
+                                            "properties": {
+                                                "Ext": {
+                                                    "properties": {
+                                                        "variant": {
+                                                            "ignore_above": 1024,
+                                                            "type": "keyword"
+                                                        }
+                                                    }
+                                                },
+                                                "family": {
+                                                    "ignore_above": 1024,
+                                                    "type": "keyword"
+                                                },
+                                                "full": {
+                                                    "fields": {
+                                                        "caseless": {
+                                                            "ignore_above": 1024,
+                                                            "normalizer": "lowercase",
+                                                            "type": "keyword"
+                                                        },
+                                                        "text": {
+                                                            "norms": false,
+                                                            "type": "text"
+                                                        }
+                                                    },
+                                                    "ignore_above": 1024,
+                                                    "type": "keyword"
+                                                },
+                                                "kernel": {
+                                                    "ignore_above": 1024,
+                                                    "type": "keyword"
+                                                },
+                                                "name": {
+                                                    "fields": {
+                                                        "caseless": {
+                                                            "ignore_above": 1024,
+                                                            "normalizer": "lowercase",
+                                                            "type": "keyword"
+                                                        },
+                                                        "text": {
+                                                            "norms": false,
+                                                            "type": "text"
+                                                        }
+                                                    },
+                                                    "ignore_above": 1024,
+                                                    "type": "keyword"
+                                                },
+                                                "platform": {
+                                                    "ignore_above": 1024,
+                                                    "type": "keyword"
+                                                },
+                                                "version": {
+                                                    "ignore_above": 1024,
+                                                    "type": "keyword"
+                                                }
+                                            }
+                                        },
+                                        "type": {
+                                            "ignore_above": 1024,
+                                            "type": "keyword"
+                                        },
+                                        "uptime": {
+                                            "type": "long"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "agent": {
+                            "properties": {
+                                "access_api_key_id": {
+                                    "type": "keyword"
+                                },
+                                "action_seq_no": {
+                                    "type": "integer",
+                                    "index": false
+                                },
+                                "active": {
+                                    "type": "boolean"
+                                },
+                                "agent": {
+                                    "properties": {
+                                        "id": {
+                                            "type": "keyword"
+                                        },
+                                        "version": {
+                                            "type": "keyword"
+                                        }
+                                    }
+                                },
+                                "default_api_key": {
+                                    "type": "keyword"
+                                },
+                                "default_api_key_id": {
+                                    "type": "keyword"
+                                },
+                                "enrolled_at": {
+                                    "type": "date"
+                                },
+                                "last_checkin": {
+                                    "type": "date"
+                                },
+                                "last_checkin_status": {
+                                    "type": "keyword"
+                                },
+                                "last_updated": {
+                                    "type": "date"
+                                },
+                                "local_metadata": {
+                                    "properties": {
+                                        "elastic": {
+                                            "properties": {
+                                                "agent": {
+                                                    "properties": {
+                                                        "build": {
+                                                            "properties": {
+                                                                "original": {
+                                                                    "type": "text",
+                                                                    "fields": {
+                                                                        "keyword": {
+                                                                            "type": "keyword",
+                                                                            "ignore_above": 256
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        },
+                                                        "id": {
+                                                            "type": "keyword"
+                                                        },
+                                                        "log_level": {
+                                                            "type": "keyword"
+                                                        },
+                                                        "snapshot": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "upgradeable": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "version": {
+                                                            "type": "text",
+                                                            "fields": {
+                                                                "keyword": {
+                                                                    "type": "keyword",
+                                                                    "ignore_above": 16
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "host": {
+                                            "properties": {
+                                                "architecture": {
+                                                    "type": "keyword"
+                                                },
+                                                "hostname": {
+                                                    "type": "text",
+                                                    "fields": {
+                                                        "keyword": {
+                                                            "type": "keyword",
+                                                            "ignore_above": 256
+                                                        }
+                                                    }
+                                                },
+                                                "id": {
+                                                    "type": "keyword"
+                                                },
+                                                "ip": {
+                                                    "type": "text",
+                                                    "fields": {
+                                                        "keyword": {
+                                                            "type": "keyword",
+                                                            "ignore_above": 64
+                                                        }
+                                                    }
+                                                },
+                                                "mac": {
+                                                    "type": "text",
+                                                    "fields": {
+                                                        "keyword": {
+                                                            "type": "keyword",
+                                                            "ignore_above": 17
+                                                        }
+                                                    }
+                                                },
+                                                "name": {
+                                                    "type": "text",
+                                                    "fields": {
+                                                        "keyword": {
+                                                            "type": "keyword",
+                                                            "ignore_above": 256
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "os": {
+                                            "properties": {
+                                                "family": {
+                                                    "type": "keyword"
+                                                },
+                                                "full": {
+                                                    "type": "text",
+                                                    "fields": {
+                                                        "keyword": {
+                                                            "type": "keyword",
+                                                            "ignore_above": 128
+                                                        }
+                                                    }
+                                                },
+                                                "kernel": {
+                                                    "type": "text",
+                                                    "fields": {
+                                                        "keyword": {
+                                                            "type": "keyword",
+                                                            "ignore_above": 128
+                                                        }
+                                                    }
+                                                },
+                                                "name": {
+                                                    "type": "text",
+                                                    "fields": {
+                                                        "keyword": {
+                                                            "type": "keyword",
+                                                            "ignore_above": 256
+                                                        }
+                                                    }
+                                                },
+                                                "platform": {
+                                                    "type": "keyword"
+                                                },
+                                                "version": {
+                                                    "type": "text",
+                                                    "fields": {
+                                                        "keyword": {
+                                                            "type": "keyword",
+                                                            "ignore_above": 32
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "packages": {
+                                    "type": "keyword"
+                                },
+                                "policy_coordinator_idx": {
+                                    "type": "integer"
+                                },
+                                "policy_id": {
+                                    "type": "keyword"
+                                },
+                                "policy_output_permissions_hash": {
+                                    "type": "keyword"
+                                },
+                                "policy_revision_idx": {
+                                    "type": "integer"
+                                },
+                                "shared_id": {
+                                    "type": "keyword"
+                                },
+                                "type": {
+                                    "type": "keyword"
+                                },
+                                "unenrolled_at": {
+                                    "type": "date"
+                                },
+                                "unenrolled_reason": {
+                                    "type": "keyword"
+                                },
+                                "unenrollment_started_at": {
+                                    "type": "date"
+                                },
+                                "updated_at": {
+                                    "type": "date"
+                                },
+                                "upgrade_started_at": {
+                                    "type": "date"
+                                },
+                                "upgraded_at": {
+                                    "type": "date"
+                                },
+                                "user_provided_metadata": {
+                                    "type": "object",
+                                    "enabled": false
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "settings": {
+            "index": {
+                "codec": "best_compression",
+                "refresh_interval": "5s",
+                "number_of_shards": "1",
+                "number_of_routing_shards": "30"
+            }
+        },
+        "aliases": {}
+    }
+}

--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
@@ -7,15 +7,17 @@
         "mappings": {
             "dynamic": "false",
             "_meta": {},
-            "dynamic_templates": [{
-                "strings_as_keyword": {
-                    "match_mapping_type": "string",
-                    "mapping": {
-                        "ignore_above": 1024,
-                        "type": "keyword"
+            "dynamic_templates": [
+                {
+                    "strings_as_keyword": {
+                        "match_mapping_type": "string",
+                        "mapping": {
+                            "ignore_above": 1024,
+                            "type": "keyword"
+                        }
                     }
                 }
-            }],
+            ],
             "date_detection": false,
             "properties": {
                 "agent": {

--- a/package/endpoint/elasticsearch/transform/metadata_united/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_united/default.json
@@ -1,0 +1,35 @@
+{
+    "source": {
+        "index": ["metrics-endpoint.metadata_current_default*",".fleet-agents*"]
+    },
+    "dest": {
+        "index": ".metrics-endpoint.metadata_united_default"
+    },
+    "frequency": "4s",
+    "sync": {
+        "time": {
+            "delay": "4s",
+            "field": "updated_at"
+        }
+    },
+    "pivot": {
+        "aggs": {
+            "united": {
+                "scripted_metric": {
+                    "init_script": "state.docs = []",
+                    "map_script": "state.docs.add(new HashMap(params['_source']))",
+                    "combine_script": "return state.docs",
+                    "reduce_script": "def ret = new HashMap(); for (s in states) { for (d in s) { if (d.containsKey('Endpoint')) { ret.endpoint = d } else { ret.agent = d } }} return ret"
+                }
+            }
+        },
+        "group_by": {
+            "agent.id": {
+                "terms": {
+                    "field": "agent.id"
+                }
+            }
+        }
+    },
+    "description": "Merges latest Endpoint and Agent metadata documents"
+}

--- a/package/endpoint/elasticsearch/transform/metadata_united/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_united/default.json
@@ -1,6 +1,9 @@
 {
     "source": {
-        "index": ["metrics-endpoint.metadata_current_default*",".fleet-agents*"]
+        "index": [
+            "metrics-endpoint.metadata_current_default*",
+            ".fleet-agents*"
+        ]
     },
     "dest": {
         "index": ".metrics-endpoint.metadata_united_default"


### PR DESCRIPTION
* adds new united metadata transform which joins the .fleet-agents and metrics-endpoint.metadata_current_default indices
* enables index sorting [timestamp, agent.id] on metrics-endpoint.metadata_current_default and metadata ds