### PR TITLE
Added security attributes

### DIFF
--- a/custom_schemas/custom_token.yml
+++ b/custom_schemas/custom_token.yml
@@ -109,3 +109,11 @@
       type: keyword
       description: >
         Description of the privilege.
+        
+    - name: security_attributes
+      level: custom
+      type: keyword
+      description: >
+        Array of security attributes of the token, retrieved via the 
+        TokenSecurityAttributes class.
+      example: TSA://ProcUnique, LUA://DecHdAutoAp

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -158,6 +158,7 @@ fields:
               elevation_level: {}
               elevation_type: {}
               integrity_level_name: {}
+              security_attributes: {}
       parent:
         fields:
           args: {}

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1444,6 +1444,20 @@ process.Ext.token.integrity_level_name:
   original_fieldset: token
   short: Human readable integrity level.
   type: keyword
+process.Ext.token.security_attributes:
+  dashed_name: process-Ext-token-security-attributes
+  description: Array of security attributes of the token, retrieved via the  TokenSecurityAttributes
+    class.
+  example: TSA://ProcUnique, LUA://DecHdAutoAp
+  flat_name: process.Ext.token.security_attributes
+  ignore_above: 1024
+  level: custom
+  name: security_attributes
+  normalize: []
+  original_fieldset: token
+  short: Array of security attributes of the token, retrieved via the  TokenSecurityAttributes
+    class.
+  type: keyword
 process.args:
   dashed_name: process-args
   description: 'Array of process arguments, starting with the absolute path to the


### PR DESCRIPTION
## Change Summary

Add `process.Ext.token.security_attributes`, which contains the names of all the values in the [TokenSecurityAttributes](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-token_information_class) information class.  [Here's](https://github.com/processhacker/processhacker/blob/ac8578d86bbca9924e9cec2c09ec495d44a6f3fd/ProcessHacker/tokprp.c#L3118-L3171) code demonstrating how to collect it.

### Sample values
```json
"process": {
    "Ext": {
        "token": {
            "security_attributes": [
                "TSA://ProcUnique",
                "LUA://DecHdAutoAp"
            ]
        }
    }
}
```

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed any generated files (in `schema/`, `generated/`)
- [ ] Does this field need to be "exceptionable"? (no longer specified in this package, this is now tracked in Kibana)