### PR TITLE
increase alerts nested fields limit

### DIFF
--- a/package/endpoint/data_stream/alerts/manifest.yml
+++ b/package/endpoint/data_stream/alerts/manifest.yml
@@ -2,5 +2,10 @@ title: Endpoint Alerts
 type: logs
 elasticsearch:
   index_template:
+    settings:
+      index:
+        mapping:
+          nested_fields:
+            limit: 80
     mappings:
       dynamic: false


### PR DESCRIPTION
## Change Summary

Increase the [nested fields limit](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html#_limits_on_nested_mappings_and_objects) for alerts, as we have gone over 50


## Release Target

7.16
