### PR TITLE
set malware_signature.primary.matches as unindexed keyword

### DIFF
--- a/custom_schemas/custom_malware_signature.yml
+++ b/custom_schemas/custom_malware_signature.yml
@@ -38,6 +38,7 @@
       level: custom
       type: keyword
       description: The first matching details.
+      enabled: false
 
     - name: primary.signature.id
       level: custom

--- a/custom_schemas/custom_malware_signature.yml
+++ b/custom_schemas/custom_malware_signature.yml
@@ -36,7 +36,7 @@
 
     - name: primary.matches
       level: custom
-      type: nested
+      type: keyword
       description: The first matching details.
 
     - name: primary.signature.id

--- a/custom_schemas/custom_malware_signature.yml
+++ b/custom_schemas/custom_malware_signature.yml
@@ -38,7 +38,7 @@
       level: custom
       type: keyword
       description: The first matching details.
-      enabled: false
+      index: no
 
     - name: primary.signature.id
       level: custom

--- a/generated/alerts/ecs/ecs_flat.yml
+++ b/generated/alerts/ecs/ecs_flat.yml
@@ -1666,6 +1666,7 @@ Target.process.Ext.memory_region.malware_signature.primary:
 Target.process.Ext.memory_region.malware_signature.primary.matches:
   dashed_name: Target-process-Ext-memory-region-malware-signature-primary-matches
   description: The first matching details.
+  enabled: false
   flat_name: Target.process.Ext.memory_region.malware_signature.primary.matches
   ignore_above: 1024
   level: custom
@@ -7758,6 +7759,7 @@ process.Ext.memory_region.malware_signature.primary:
 process.Ext.memory_region.malware_signature.primary.matches:
   dashed_name: process-Ext-memory-region-malware-signature-primary-matches
   description: The first matching details.
+  enabled: false
   flat_name: process.Ext.memory_region.malware_signature.primary.matches
   ignore_above: 1024
   level: custom

--- a/generated/alerts/ecs/ecs_flat.yml
+++ b/generated/alerts/ecs/ecs_flat.yml
@@ -1666,9 +1666,9 @@ Target.process.Ext.memory_region.malware_signature.primary:
 Target.process.Ext.memory_region.malware_signature.primary.matches:
   dashed_name: Target-process-Ext-memory-region-malware-signature-primary-matches
   description: The first matching details.
-  enabled: false
+  doc_values: false
   flat_name: Target.process.Ext.memory_region.malware_signature.primary.matches
-  ignore_above: 1024
+  index: false
   level: custom
   name: primary.matches
   normalize: []
@@ -7759,9 +7759,9 @@ process.Ext.memory_region.malware_signature.primary:
 process.Ext.memory_region.malware_signature.primary.matches:
   dashed_name: process-Ext-memory-region-malware-signature-primary-matches
   description: The first matching details.
-  enabled: false
+  doc_values: false
   flat_name: process.Ext.memory_region.malware_signature.primary.matches
-  ignore_above: 1024
+  index: false
   level: custom
   name: primary.matches
   normalize: []

--- a/generated/alerts/ecs/ecs_flat.yml
+++ b/generated/alerts/ecs/ecs_flat.yml
@@ -1667,12 +1667,13 @@ Target.process.Ext.memory_region.malware_signature.primary.matches:
   dashed_name: Target-process-Ext-memory-region-malware-signature-primary-matches
   description: The first matching details.
   flat_name: Target.process.Ext.memory_region.malware_signature.primary.matches
+  ignore_above: 1024
   level: custom
   name: primary.matches
   normalize: []
   original_fieldset: malware_signature
   short: The first matching details.
-  type: nested
+  type: keyword
 Target.process.Ext.memory_region.malware_signature.primary.signature.hash:
   dashed_name: Target-process-Ext-memory-region-malware-signature-primary-signature-hash
   description: hash of file matching signature.
@@ -7758,12 +7759,13 @@ process.Ext.memory_region.malware_signature.primary.matches:
   dashed_name: process-Ext-memory-region-malware-signature-primary-matches
   description: The first matching details.
   flat_name: process.Ext.memory_region.malware_signature.primary.matches
+  ignore_above: 1024
   level: custom
   name: primary.matches
   normalize: []
   original_fieldset: malware_signature
   short: The first matching details.
-  type: nested
+  type: keyword
 process.Ext.memory_region.malware_signature.primary.signature.hash:
   dashed_name: process-Ext-memory-region-malware-signature-primary-signature-hash
   description: hash of file matching signature.

--- a/generated/alerts/elasticsearch/7/template.json
+++ b/generated/alerts/elasticsearch/7/template.json
@@ -674,7 +674,8 @@
                           "primary": {
                             "properties": {
                               "matches": {
-                                "type": "nested"
+                                "ignore_above": 1024,
+                                "type": "keyword"
                               },
                               "signature": {
                                 "properties": {
@@ -2851,7 +2852,8 @@
                       "primary": {
                         "properties": {
                           "matches": {
-                            "type": "nested"
+                            "ignore_above": 1024,
+                            "type": "keyword"
                           },
                           "signature": {
                             "properties": {

--- a/generated/alerts/elasticsearch/7/template.json
+++ b/generated/alerts/elasticsearch/7/template.json
@@ -674,7 +674,8 @@
                           "primary": {
                             "properties": {
                               "matches": {
-                                "ignore_above": 1024,
+                                "doc_values": false,
+                                "index": false,
                                 "type": "keyword"
                               },
                               "signature": {
@@ -2852,7 +2853,8 @@
                       "primary": {
                         "properties": {
                           "matches": {
-                            "ignore_above": 1024,
+                            "doc_values": false,
+                            "index": false,
                             "type": "keyword"
                           },
                           "signature": {

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -958,7 +958,8 @@
       default_field: false
     - name: process.Ext.memory_region.malware_signature.primary.matches
       level: custom
-      type: nested
+      type: keyword
+      ignore_above: 1024
       description: The first matching details.
       default_field: false
     - name: process.Ext.memory_region.malware_signature.primary.signature.hash
@@ -4212,7 +4213,8 @@
       default_field: false
     - name: Ext.memory_region.malware_signature.primary.matches
       level: custom
-      type: nested
+      type: keyword
+      ignore_above: 1024
       description: The first matching details.
       default_field: false
     - name: Ext.memory_region.malware_signature.primary.signature.hash

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -959,9 +959,9 @@
     - name: process.Ext.memory_region.malware_signature.primary.matches
       level: custom
       type: keyword
-      ignore_above: 1024
       description: The first matching details.
-      enabled: false
+      index: false
+      doc_values: false
       default_field: false
     - name: process.Ext.memory_region.malware_signature.primary.signature.hash
       level: custom
@@ -4215,9 +4215,9 @@
     - name: Ext.memory_region.malware_signature.primary.matches
       level: custom
       type: keyword
-      ignore_above: 1024
       description: The first matching details.
-      enabled: false
+      index: false
+      doc_values: false
       default_field: false
     - name: Ext.memory_region.malware_signature.primary.signature.hash
       level: custom

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -961,6 +961,7 @@
       type: keyword
       ignore_above: 1024
       description: The first matching details.
+      enabled: false
       default_field: false
     - name: process.Ext.memory_region.malware_signature.primary.signature.hash
       level: custom
@@ -4216,6 +4217,7 @@
       type: keyword
       ignore_above: 1024
       description: The first matching details.
+      enabled: false
       default_field: false
     - name: Ext.memory_region.malware_signature.primary.signature.hash
       level: custom

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -147,7 +147,6 @@ sent by the endpoint.
 | Target.process.Ext.memory_region.malware_signature.all_names | A sequence of signature names matched. | keyword |
 | Target.process.Ext.memory_region.malware_signature.identifier | malware signature identifier | keyword |
 | Target.process.Ext.memory_region.malware_signature.primary | The first matching details. | object |
-| Target.process.Ext.memory_region.malware_signature.primary.matches | The first matching details. | keyword |
 | Target.process.Ext.memory_region.malware_signature.primary.signature.hash | hash of file matching signature. | nested |
 | Target.process.Ext.memory_region.malware_signature.primary.signature.hash.sha256 | sha256 hash of file matching signature. | keyword |
 | Target.process.Ext.memory_region.malware_signature.primary.signature.id | The id of the first yara rule matched. | keyword |
@@ -581,7 +580,6 @@ sent by the endpoint.
 | process.Ext.memory_region.malware_signature.all_names | A sequence of signature names matched. | keyword |
 | process.Ext.memory_region.malware_signature.identifier | malware signature identifier | keyword |
 | process.Ext.memory_region.malware_signature.primary | The first matching details. | object |
-| process.Ext.memory_region.malware_signature.primary.matches | The first matching details. | keyword |
 | process.Ext.memory_region.malware_signature.primary.signature.hash | hash of file matching signature. | nested |
 | process.Ext.memory_region.malware_signature.primary.signature.hash.sha256 | sha256 hash of file matching signature. | keyword |
 | process.Ext.memory_region.malware_signature.primary.signature.id | The id of the first yara rule matched. | keyword |

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -147,6 +147,7 @@ sent by the endpoint.
 | Target.process.Ext.memory_region.malware_signature.all_names | A sequence of signature names matched. | keyword |
 | Target.process.Ext.memory_region.malware_signature.identifier | malware signature identifier | keyword |
 | Target.process.Ext.memory_region.malware_signature.primary | The first matching details. | object |
+| Target.process.Ext.memory_region.malware_signature.primary.matches | The first matching details. | keyword |
 | Target.process.Ext.memory_region.malware_signature.primary.signature.hash | hash of file matching signature. | nested |
 | Target.process.Ext.memory_region.malware_signature.primary.signature.hash.sha256 | sha256 hash of file matching signature. | keyword |
 | Target.process.Ext.memory_region.malware_signature.primary.signature.id | The id of the first yara rule matched. | keyword |
@@ -580,6 +581,7 @@ sent by the endpoint.
 | process.Ext.memory_region.malware_signature.all_names | A sequence of signature names matched. | keyword |
 | process.Ext.memory_region.malware_signature.identifier | malware signature identifier | keyword |
 | process.Ext.memory_region.malware_signature.primary | The first matching details. | object |
+| process.Ext.memory_region.malware_signature.primary.matches | The first matching details. | keyword |
 | process.Ext.memory_region.malware_signature.primary.signature.hash | hash of file matching signature. | nested |
 | process.Ext.memory_region.malware_signature.primary.signature.hash.sha256 | sha256 hash of file matching signature. | keyword |
 | process.Ext.memory_region.malware_signature.primary.signature.id | The id of the first yara rule matched. | keyword |

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -147,7 +147,7 @@ sent by the endpoint.
 | Target.process.Ext.memory_region.malware_signature.all_names | A sequence of signature names matched. | keyword |
 | Target.process.Ext.memory_region.malware_signature.identifier | malware signature identifier | keyword |
 | Target.process.Ext.memory_region.malware_signature.primary | The first matching details. | object |
-| Target.process.Ext.memory_region.malware_signature.primary.matches | The first matching details. | nested |
+| Target.process.Ext.memory_region.malware_signature.primary.matches | The first matching details. | keyword |
 | Target.process.Ext.memory_region.malware_signature.primary.signature.hash | hash of file matching signature. | nested |
 | Target.process.Ext.memory_region.malware_signature.primary.signature.hash.sha256 | sha256 hash of file matching signature. | keyword |
 | Target.process.Ext.memory_region.malware_signature.primary.signature.id | The id of the first yara rule matched. | keyword |
@@ -581,7 +581,7 @@ sent by the endpoint.
 | process.Ext.memory_region.malware_signature.all_names | A sequence of signature names matched. | keyword |
 | process.Ext.memory_region.malware_signature.identifier | malware signature identifier | keyword |
 | process.Ext.memory_region.malware_signature.primary | The first matching details. | object |
-| process.Ext.memory_region.malware_signature.primary.matches | The first matching details. | nested |
+| process.Ext.memory_region.malware_signature.primary.matches | The first matching details. | keyword |
 | process.Ext.memory_region.malware_signature.primary.signature.hash | hash of file matching signature. | nested |
 | process.Ext.memory_region.malware_signature.primary.signature.hash.sha256 | sha256 hash of file matching signature. | keyword |
 | process.Ext.memory_region.malware_signature.primary.signature.id | The id of the first yara rule matched. | keyword |

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -763,6 +763,7 @@ Target.process.Ext.memory_region.malware_signature.primary:
 Target.process.Ext.memory_region.malware_signature.primary.matches:
   dashed_name: Target-process-Ext-memory-region-malware-signature-primary-matches
   description: The first matching details.
+  enabled: false
   flat_name: Target.process.Ext.memory_region.malware_signature.primary.matches
   ignore_above: 1024
   level: custom
@@ -5448,6 +5449,7 @@ process.Ext.memory_region.malware_signature.primary:
 process.Ext.memory_region.malware_signature.primary.matches:
   dashed_name: process-Ext-memory-region-malware-signature-primary-matches
   description: The first matching details.
+  enabled: false
   flat_name: process.Ext.memory_region.malware_signature.primary.matches
   ignore_above: 1024
   level: custom

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -763,9 +763,9 @@ Target.process.Ext.memory_region.malware_signature.primary:
 Target.process.Ext.memory_region.malware_signature.primary.matches:
   dashed_name: Target-process-Ext-memory-region-malware-signature-primary-matches
   description: The first matching details.
-  enabled: false
+  doc_values: false
   flat_name: Target.process.Ext.memory_region.malware_signature.primary.matches
-  ignore_above: 1024
+  index: false
   level: custom
   name: primary.matches
   normalize: []
@@ -5449,9 +5449,9 @@ process.Ext.memory_region.malware_signature.primary:
 process.Ext.memory_region.malware_signature.primary.matches:
   dashed_name: process-Ext-memory-region-malware-signature-primary-matches
   description: The first matching details.
-  enabled: false
+  doc_values: false
   flat_name: process.Ext.memory_region.malware_signature.primary.matches
-  ignore_above: 1024
+  index: false
   level: custom
   name: primary.matches
   normalize: []

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -764,12 +764,13 @@ Target.process.Ext.memory_region.malware_signature.primary.matches:
   dashed_name: Target-process-Ext-memory-region-malware-signature-primary-matches
   description: The first matching details.
   flat_name: Target.process.Ext.memory_region.malware_signature.primary.matches
+  ignore_above: 1024
   level: custom
   name: primary.matches
   normalize: []
   original_fieldset: malware_signature
   short: The first matching details.
-  type: nested
+  type: keyword
 Target.process.Ext.memory_region.malware_signature.primary.signature.hash:
   dashed_name: Target-process-Ext-memory-region-malware-signature-primary-signature-hash
   description: hash of file matching signature.
@@ -5448,12 +5449,13 @@ process.Ext.memory_region.malware_signature.primary.matches:
   dashed_name: process-Ext-memory-region-malware-signature-primary-matches
   description: The first matching details.
   flat_name: process.Ext.memory_region.malware_signature.primary.matches
+  ignore_above: 1024
   level: custom
   name: primary.matches
   normalize: []
   original_fieldset: malware_signature
   short: The first matching details.
-  type: nested
+  type: keyword
 process.Ext.memory_region.malware_signature.primary.signature.hash:
   dashed_name: process-Ext-memory-region-malware-signature-primary-signature-hash
   description: hash of file matching signature.


### PR DESCRIPTION
## Change Summary

Changes from `nested` to `keyword`. Looks like the expected values are an array of concrete values (strings, it looks like)

this stems from https://github.com/elastic/endpoint-package/issues/211

### Sample values


Sample document:

```json
        "malware_signature": {
          "all_names": "Linux.EICAR.Not-a-virus",
          "identifier": "production-malware-signature-v1-linux",
          "primary": {
            "matches": [
              "WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5EQVJELUFOVElWSVJVUy1URVNULUZJTEUhJEgrSCo="
            ],
        },


```


## Release Target

7.16

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed any generated files (in `schema/`, `generated/`)
- [ ] ~~Does this field need to be "exceptionable"? (no longer specified in this package, this is now tracked in Kibana)~~
- [ ] ~~If this is a `metadata` change, I also updated both transform destination schemas to match~~


