### PR TITLE
bump kibana compat to ^8.1.0

### DIFF
--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -16,7 +16,7 @@ policy_templates:
     description: Interact with the endpoint.
     multiple: false
 conditions:
-  kibana.version: "^8.0.0"
+  kibana.version: "^8.1.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
   # >= <the version> && < 8.0.0
 icons:


### PR DESCRIPTION
## Change Summary

kibana compat `^8.0.0` -> `^8.1.0` to support kibana main branch which is on 8.1.x now.