### PR TITLE
Revert "bump kibana compat to ^8.1.0 (#213)"

### DIFF
--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -16,7 +16,7 @@ policy_templates:
     description: Interact with the endpoint.
     multiple: false
 conditions:
-  kibana.version: "^8.1.0"
+  kibana.version: "^8.0.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
   # >= <the version> && < 8.0.0
 icons:


### PR DESCRIPTION
This reverts commit 62b3dc42de4b2e9c8558035ea62dfe9e410cb583.

## Change Summary

bump to `^8.1.0` was incorrect as it made `8.1.0` to minimum supported version. reverting back to `^8.0.0`.