### PR TITLE
Set both transforms to be "managed" mode

### DIFF
--- a/package/endpoint/elasticsearch/transform/metadata_current/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_current/default.json
@@ -19,6 +19,9 @@
         "sort": "@timestamp"
     },
     "description": "Latest Endpoint metadata document per host",
+    "_meta": {
+        "managed": true
+    },
     "frequency": "10s",
     "sync": {
         "time": {

--- a/package/endpoint/elasticsearch/transform/metadata_united/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_united/default.json
@@ -34,5 +34,8 @@
             }
         }
     },
-    "description": "Merges latest Endpoint and Agent metadata documents"
+    "description": "Merges latest Endpoint and Agent metadata documents",
+    "_meta": {
+        "managed": true
+    }
 }


### PR DESCRIPTION
## Change Summary

Adds `Managed` flag to both transforms, marking them as "system" transforms


![2021-11-18-141032_scrot](https://user-images.githubusercontent.com/315796/142481296-82c46909-144f-4f4d-ba8a-17790d3b3d45.png)


## Release Target

8.0.0 (package `1.3` series)

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [X] I ran `make` after making the schema changes, and committed any generated files (in `schema/`, `generated/`)
- [ ] ~~Does this field need to be "exceptionable"? (no longer specified in this package, this is now tracked in Kibana)~~
- [ ] ~~If this is a `metadata` change, I also updated both transform destination schemas to match~~

### For Transform changes:

- [x] The new transform successfully starts in Kibana
- [ ] ~~The corresponding transform destination schema was updated if necessary~~
