### PR TITLE
Make 1.3 series target 7.17 release

### DIFF
--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -16,7 +16,7 @@ policy_templates:
     description: Interact with the endpoint.
     multiple: false
 conditions:
-  kibana.version: "^8.0.0"
+  kibana.version: "^7.17.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
   # >= <the version> && < 8.0.0
 icons:


### PR DESCRIPTION
## Change Summary

With the addition of a 7.17 stack, let's increment the package to follow.

package `1.2.x` series will continue to serve stack `7.16`.

package `1.3.x` series will target 7.17 stack

which will bump `1.4.x` package series to track kibana `8.0`
