### PR TITLE
Hide .metrics-metadata-united

### DIFF
--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
@@ -527,7 +527,8 @@
                 "codec": "best_compression",
                 "refresh_interval": "5s",
                 "number_of_shards": "1",
-                "number_of_routing_shards": "30"
+                "number_of_routing_shards": "30",
+                "hidden": true
             }
         },
         "aliases": {}


### PR DESCRIPTION
## Change Summary

Starting in ES 8.0, hidden indices do not just mean start-with-leading-dot. The `index.hidden` setting was added.

This sets our dot-prefixed united metadata index to have `hidden: true`


## Release Target

8.0

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed any generated files (in `schema/`, `generated/`)
- [x] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [x] The new transform successfully starts in Kibana
- [x] The corresponding transform destination schema was updated if necessary
