### PR TITLE
[8.0][backport] hide .metrics-metadata-united (#223)

### DIFF
--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
@@ -527,7 +527,8 @@
                 "codec": "best_compression",
                 "refresh_interval": "5s",
                 "number_of_shards": "1",
-                "number_of_routing_shards": "30"
+                "number_of_routing_shards": "30",
+                "hidden": true
             }
         },
         "aliases": {}


### PR DESCRIPTION
backport of #223 to 8.0 (1.4 package series)