### PR TITLE
increase alerts total_fields limit

### DIFF
--- a/package/endpoint/data_stream/alerts/manifest.yml
+++ b/package/endpoint/data_stream/alerts/manifest.yml
@@ -7,5 +7,7 @@ elasticsearch:
         mapping:
           nested_fields:
             limit: 80
+          total_fields:
+            limit: 5000
     mappings:
       dynamic: false


### PR DESCRIPTION
## Change Summary

Raise the alerts `total_fields` setting, so that Fleet may remove their explicit setting (at 10k, letting it default to 1k).

Original Fleet field removal:

- https://github.com/elastic/kibana/issues/104620
- https://github.com/elastic/kibana/pull/114101

And subsequent reversal when our alerts index was over 1k:

- https://github.com/elastic/kibana/pull/114299


## Release Target

8.0

## Q/A


### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed any generated files (in `schema/`, `generated/`)

