### PR TITLE
[memory_protection_event] memory_region.mapped_path

### DIFF
--- a/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
@@ -306,6 +306,7 @@ fields:
                               sha256: {}
                       matches: {}
                   version: {}
+              mapped_path: {}
               mapped_pe:
                 fields: *pe-fields
               mapped_pe_detected: {}

--- a/generated/alerts/ecs/ecs_flat.yml
+++ b/generated/alerts/ecs/ecs_flat.yml
@@ -1729,6 +1729,18 @@ Target.process.Ext.memory_region.malware_signature.version:
   original_fieldset: malware_signature
   short: malware signature version
   type: keyword
+Target.process.Ext.memory_region.mapped_path:
+  dashed_name: Target-process-Ext-memory-region-mapped-path
+  description: If the memory corresponds to a file mapping, this is the file's path.
+  example: C:\Windows\System32\mshtml.dll
+  flat_name: Target.process.Ext.memory_region.mapped_path
+  ignore_above: 1024
+  level: custom
+  name: mapped_path
+  normalize: []
+  original_fieldset: memory_region
+  short: If the memory corresponds to a file mapping, this is the file's path.
+  type: keyword
 Target.process.Ext.memory_region.mapped_pe.company:
   dashed_name: Target-process-Ext-memory-region-mapped-pe-company
   description: Internal company name of the file, provided at compile-time.
@@ -7821,6 +7833,18 @@ process.Ext.memory_region.malware_signature.version:
   normalize: []
   original_fieldset: malware_signature
   short: malware signature version
+  type: keyword
+process.Ext.memory_region.mapped_path:
+  dashed_name: process-Ext-memory-region-mapped-path
+  description: If the memory corresponds to a file mapping, this is the file's path.
+  example: C:\Windows\System32\mshtml.dll
+  flat_name: process.Ext.memory_region.mapped_path
+  ignore_above: 1024
+  level: custom
+  name: mapped_path
+  normalize: []
+  original_fieldset: memory_region
+  short: If the memory corresponds to a file mapping, this is the file's path.
   type: keyword
 process.Ext.memory_region.mapped_pe.company:
   dashed_name: process-Ext-memory-region-mapped-pe-company

--- a/generated/alerts/elasticsearch/7/template.json
+++ b/generated/alerts/elasticsearch/7/template.json
@@ -708,6 +708,10 @@
                           }
                         }
                       },
+                      "mapped_path": {
+                        "ignore_above": 1024,
+                        "type": "keyword"
+                      },
                       "mapped_pe": {
                         "properties": {
                           "company": {
@@ -2886,6 +2890,10 @@
                         "type": "keyword"
                       }
                     }
+                  },
+                  "mapped_path": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
                   },
                   "mapped_pe": {
                     "properties": {

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -992,6 +992,13 @@
       ignore_above: 1024
       description: malware signature version
       default_field: false
+    - name: process.Ext.memory_region.mapped_path
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: If the memory corresponds to a file mapping, this is the file's path.
+      example: C:\Windows\System32\kernel32.dll
+      default_field: false
     - name: process.Ext.memory_region.mapped_pe.company
       level: extended
       type: keyword
@@ -4247,6 +4254,13 @@
       type: keyword
       ignore_above: 1024
       description: malware signature version
+      default_field: false
+    - name: Ext.memory_region.mapped_path
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: If the memory corresponds to a file mapping, this is the file's path.
+      example: C:\Windows\System32\kernel32.dll
       default_field: false
     - name: Ext.memory_region.mapped_pe.company
       level: extended

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -153,6 +153,7 @@ sent by the endpoint.
 | Target.process.Ext.memory_region.malware_signature.primary.signature.id | The id of the first yara rule matched. | keyword |
 | Target.process.Ext.memory_region.malware_signature.primary.signature.name | The name of the first yara rule matched. | keyword |
 | Target.process.Ext.memory_region.malware_signature.version | malware signature version | keyword |
+| Target.process.Ext.memory_region.mapped_path | If the memory corresponds to a file mapping, this is the file's path. | keyword |
 | Target.process.Ext.memory_region.mapped_pe.company | Internal company name of the file, provided at compile-time. | keyword |
 | Target.process.Ext.memory_region.mapped_pe.description | Internal description of the file, provided at compile-time. | keyword |
 | Target.process.Ext.memory_region.mapped_pe.file_version | Internal version of the file, provided at compile-time. | keyword |
@@ -587,6 +588,7 @@ sent by the endpoint.
 | process.Ext.memory_region.malware_signature.primary.signature.id | The id of the first yara rule matched. | keyword |
 | process.Ext.memory_region.malware_signature.primary.signature.name | The name of the first yara rule matched. | keyword |
 | process.Ext.memory_region.malware_signature.version | malware signature version | keyword |
+| process.Ext.memory_region.mapped_path | If the memory corresponds to a file mapping, this is the file's path. | keyword |
 | process.Ext.memory_region.mapped_pe.company | Internal company name of the file, provided at compile-time. | keyword |
 | process.Ext.memory_region.mapped_pe.description | Internal description of the file, provided at compile-time. | keyword |
 | process.Ext.memory_region.mapped_pe.file_version | Internal version of the file, provided at compile-time. | keyword |

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -826,6 +826,18 @@ Target.process.Ext.memory_region.malware_signature.version:
   original_fieldset: malware_signature
   short: malware signature version
   type: keyword
+Target.process.Ext.memory_region.mapped_path:
+  dashed_name: Target-process-Ext-memory-region-mapped-path
+  description: If the memory corresponds to a file mapping, this is the file's path.
+  example: C:\Windows\System32\kernel32.dll
+  flat_name: Target.process.Ext.memory_region.mapped_path
+  ignore_above: 1024
+  level: extended
+  name: mapped_path
+  normalize: []
+  original_fieldset: memory_region
+  short: If the memory corresponds to a file mapping, this is the file's path.
+  type: keyword
 Target.process.Ext.memory_region.mapped_pe.company:
   dashed_name: Target-process-Ext-memory-region-mapped-pe-company
   description: Internal company name of the file, provided at compile-time.
@@ -5511,6 +5523,18 @@ process.Ext.memory_region.malware_signature.version:
   normalize: []
   original_fieldset: malware_signature
   short: malware signature version
+  type: keyword
+process.Ext.memory_region.mapped_path:
+  dashed_name: process-Ext-memory-region-mapped-path
+  description: If the memory corresponds to a file mapping, this is the file's path.
+  example: C:\Windows\System32\kernel32.dll
+  flat_name: process.Ext.memory_region.mapped_path
+  ignore_above: 1024
+  level: extended
+  name: mapped_path
+  normalize: []
+  original_fieldset: memory_region
+  short: If the memory corresponds to a file mapping, this is the file's path.
   type: keyword
 process.Ext.memory_region.mapped_pe.company:
   dashed_name: process-Ext-memory-region-mapped-pe-company


### PR DESCRIPTION
## Change Summary

`mapped_path` was not initially included in the memory_protection_event subset for `memory_region`. However, this field is required in some scenarios. 

It is currently referenced in the descriptions of other included fields such as `mapped_pe_detected` which is defined as "Whether the file at mapped_path is an executable".

## Release Target
 * 8.1

### For mapping changes:
- [X] I ran `make` after making the schema changes, and committed any generated files (in `schema/`, `generated/`)
- [x] Does this field need to be "exceptionable"? (no longer specified in this package, this is now tracked in Kibana)
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:
- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
