### PR TITLE
add endpoint metadata mapping keyword_constant values

### DIFF
--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
@@ -99,13 +99,15 @@
                 "data_stream": {
                     "properties": {
                         "dataset": {
-                            "type": "constant_keyword"
+                            "type": "constant_keyword",
+                            "value": "endpoint.metadata"
                         },
                         "namespace": {
                             "type": "keyword"
                         },
                         "type": {
-                            "type": "constant_keyword"
+                            "type": "constant_keyword",
+                            "value": "metrics"
                         }
                     }
                 },

--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
@@ -107,13 +107,15 @@
                                 "data_stream": {
                                     "properties": {
                                         "dataset": {
-                                            "type": "constant_keyword"
+                                            "type": "constant_keyword",
+                                            "value": "endpoint.metadata"
                                         },
                                         "namespace": {
                                             "type": "keyword"
                                         },
                                         "type": {
-                                            "type": "constant_keyword"
+                                            "type": "constant_keyword",
+                                            "value": "metrics"
                                         }
                                     }
                                 },


### PR DESCRIPTION
## Change Summary

Adding explicit value for keyword_constant types in the latest + united metadata transform destination indices to fix [es deprecation warning for no put mapping permissions](https://github.com/elastic/security-team/issues/2476). Since the value wasn't previously provided, the mapping was being updated when the first document gets indexed causing us to require mapping put permissions for kibana_system.


### For Transform changes:

- [x] The new transform successfully starts in Kibana
- [x] The corresponding transform destination schema was updated if necessary
