### PR TITLE
lower current + united transform frequencies to 1s

### DIFF
--- a/package/endpoint/elasticsearch/transform/metadata_current/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_current/default.json
@@ -22,11 +22,11 @@
     "_meta": {
         "managed": true
     },
-    "frequency": "10s",
+    "frequency": "1s",
     "sync": {
         "time": {
             "field": "event.ingested",
-            "delay": "10s"
+            "delay": "1s"
         }
     }
 }

--- a/package/endpoint/elasticsearch/transform/metadata_united/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_united/default.json
@@ -8,10 +8,10 @@
     "dest": {
         "index": ".metrics-endpoint.metadata_united_default"
     },
-    "frequency": "4s",
+    "frequency": "1s",
     "sync": {
         "time": {
-            "delay": "4s",
+            "delay": "1s",
             "field": "updated_at"
         }
     },


### PR DESCRIPTION
## Change Summary

Reducing `metadata_current` and `metadata_united` transform frequencies down to 1s per outcome from https://github.com/elastic/security-team/issues/2261.