### PR TITLE
[Security Solution] Update the alias in this mapping to point to event.ingested

### DIFF
--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-current.json
@@ -25,7 +25,7 @@
                 },
                 "updated_at": {
                     "type": "alias",
-                    "path": "@timestamp"
+                    "path": "event.ingested"
                 },
                 "Endpoint": {
                     "properties": {


### PR DESCRIPTION
## Change Summary

I found this bug while doing some local testing: https://github.com/elastic/kibana/issues/127404

The root cause is that my host VM had a time drift into the future.  I discovered that our `united` transform looks to sync on an `updated_at` field which is contained in the `fleet_agents*` index and in an alias in the `metadata_current` index.

I updated the alias of `updated_at` in the mapping of the `metadata_current` index to point to `event.ingested`.  Previously it was pointing at `@timestamp` which refers to the time on the Host itself.  `event.ingested` should be used because it refers to server time.

It's important to point this at server time because the `updated_at` field is used in this transform: https://github.com/elastic/endpoint-package/blob/master/package/endpoint/elasticsearch/transform/metadata_united/default.json#L15

The `updated_at` field which is used in `fleet-agents*` also refers to server time, which I verified manually.

### Sample values

The alias is set up to use `event.ingested` below which is the same `date` type as `@timestamp`, it's just better to use because it refers to server time.

```json
          "event" : {
            "agent_id_status" : "verified",
            "sequence" : 418240,
            "ingested" : "2022-03-06T08:01:48Z",
            "created" : "2022-03-06T08:00:53.283059679Z",
            "kind" : "metric",
            "module" : "endpoint",
            "action" : "endpoint_metadata",
            "id" : "MVglf8DK3xNN/U03+++2LIDT",
            "category" : [
              "host"
            ],
            "type" : [
              "info"
            ],
            "dataset" : "endpoint.metadata"
          }
```

Sample document:

```json
{
        "_index" : "metrics-endpoint.metadata_current_default",
        "_id" : "YaAnYyqupGzwW8fg7TewHjkAAAAAAAAA",
        "_score" : 1.0,
        "_source" : {
          "agent" : {
            "build" : {
              "original" : "version: 8.0.0-SNAPSHOT, compiled: Sun Feb 6 00:00:00 2022, branch: 8.0, commit: 0e9e501ad696c6399a2769a5ab54148db3cd9443"
            },
            "id" : "aae2817d-d16b-4088-b7c1-caff07e66b17",
            "type" : "endpoint",
            "version" : "8.0.0-SNAPSHOT"
          },
          "@timestamp" : "2022-03-06T08:00:53.283059679Z",
          "Endpoint" : {
            "capabilities" : [
              "isolation"
            ],
            "configuration" : {
              "isolation" : false
            },
            "state" : {
              "isolation" : false
            },
            "policy" : {
              "applied" : {
                "name" : "endpoint-1",
                "id" : "e86c237f-9cea-4569-84f3-d92bdc2b297e",
                "endpoint_policy_version" : "15",
                "version" : "20",
                "status" : "success"
              }
            },
            "status" : "enrolled"
          },
          "ecs" : {
            "version" : "1.11.0"
          },
          "data_stream" : {
            "namespace" : "default",
            "type" : "metrics",
            "dataset" : "endpoint.metadata"
          },
          "elastic" : {
            "agent" : {
              "id" : "aae2817d-d16b-4088-b7c1-caff07e66b17"
            }
          },
          "host" : {
            "hostname" : "security-linux-1",
            "os" : {
              "Ext" : {
                "variant" : "Debian"
              },
              "kernel" : "4.19.0-18-cloud-amd64 #1 SMP Debian 4.19.208-1 (2021-09-29)",
              "name" : "Linux",
              "family" : "debian",
              "type" : "linux",
              "version" : "10.11",
              "platform" : "debian",
              "full" : "Debian 10.11"
            },
            "ip" : [
              "127.0.0.1",
              "::1",
              "10.200.0.194",
              "fe80::4001:aff:fec8:c2"
            ],
            "name" : "security-linux-1",
            "id" : "76ea303129f249aa7382338e4263eac1",
            "mac" : [
              "42:01:0a:c8:00:c2"
            ],
            "architecture" : "x86_64"
          },
          "message" : "Endpoint metadata",
          "event" : {
            "agent_id_status" : "verified",
            "sequence" : 418240,
            "ingested" : "2022-03-06T08:01:48Z",
            "created" : "2022-03-06T08:00:53.283059679Z",
            "kind" : "metric",
            "module" : "endpoint",
            "action" : "endpoint_metadata",
            "id" : "MVglf8DK3xNN/U03+++2LIDT",
            "category" : [
              "host"
            ],
            "type" : [
              "info"
            ],
            "dataset" : "endpoint.metadata"
          }
        }
      }
```


## Release Target

`8.2`, but I think we should release a package for `8.1`, `8.0`, and `7.17` since this bug could be encountered on those as well.

## Q/A

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed any generated files (in `schema/`, `generated/`)
- [ ] Does this field need to be "exceptionable"? (no longer specified in this package, this is now tracked in Kibana)
- [x] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [x] The new transform successfully starts in Kibana
- [x] The corresponding transform destination schema was updated if necessary
