### PR TITLE
Added missing mapping for process.env_vars

### DIFF
--- a/custom_subsets/elastic_endpoint/alerts/linux_event_model_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/linux_event_model_event.yaml
@@ -30,6 +30,7 @@ fields:
       args_count: {}
       command_line: {}
       entity_id: {}
+      env_vars: {}
       executable: {}
       interactive: {}
       name: {}

--- a/custom_subsets/elastic_endpoint/process/linux_event_model_event.yaml
+++ b/custom_subsets/elastic_endpoint/process/linux_event_model_event.yaml
@@ -30,6 +30,7 @@ fields:
       args_count: {}
       command_line: {}
       entity_id: {}
+      env_vars: {}
       executable: {}
       interactive: {}
       name: {}

--- a/generated/alerts/ecs/ecs_flat.yml
+++ b/generated/alerts/ecs/ecs_flat.yml
@@ -9015,6 +9015,19 @@ process.entry_leader.working_directory:
   original_fieldset: process
   short: The working directory of the process.
   type: keyword
+process.env_vars:
+  dashed_name: process-env-vars
+  description: 'Environment variables set at the time of the event.
+
+    May be filtered to protect sensitive information.'
+  example: "{\n  \"USER\": \"elastic\",\n  \"LANG\": \"en_US.UTF-8\",\n  \"HOME\"\
+    : \"/home/elastic\"\n}"
+  flat_name: process.env_vars
+  level: extended
+  name: env_vars
+  normalize: []
+  short: Environment variables set at the time of the event.
+  type: object
 process.executable:
   dashed_name: process-executable
   description: Absolute path to the process executable.

--- a/generated/alerts/elasticsearch/7/template.json
+++ b/generated/alerts/elasticsearch/7/template.json
@@ -3368,6 +3368,9 @@
               }
             }
           },
+          "env_vars": {
+            "type": "object"
+          },
           "executable": {
             "fields": {
               "caseless": {

--- a/generated/process/ecs/ecs_flat.yml
+++ b/generated/process/ecs/ecs_flat.yml
@@ -2228,6 +2228,19 @@ process.entry_leader.working_directory:
   original_fieldset: process
   short: The working directory of the process.
   type: keyword
+process.env_vars:
+  dashed_name: process-env-vars
+  description: 'Environment variables set at the time of the event.
+
+    May be filtered to protect sensitive information.'
+  example: "{\n  \"USER\": \"elastic\",\n  \"LANG\": \"en_US.UTF-8\",\n  \"HOME\"\
+    : \"/home/elastic\"\n}"
+  flat_name: process.env_vars
+  level: extended
+  name: env_vars
+  normalize: []
+  short: Environment variables set at the time of the event.
+  type: object
 process.executable:
   dashed_name: process-executable
   description: Absolute path to the process executable.

--- a/generated/process/elasticsearch/7/template.json
+++ b/generated/process/elasticsearch/7/template.json
@@ -734,6 +734,9 @@
               }
             }
           },
+          "env_vars": {
+            "type": "object"
+          },
           "executable": {
             "fields": {
               "caseless": {

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -4928,6 +4928,14 @@
       description: The working directory of the process.
       example: /home/alice
       default_field: false
+    - name: env_vars
+      level: extended
+      type: object
+      description: 'Environment variables set at the time of the event.
+
+        May be filtered to protect sensitive information.'
+      example: "{\n  \"USER\": \"elastic\",\n  \"LANG\": \"en_US.UTF-8\",\n  \"HOME\": \"/home/elastic\"\n}"
+      default_field: false
     - name: executable
       level: extended
       type: keyword

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -1112,6 +1112,14 @@
       description: The working directory of the process.
       example: /home/alice
       default_field: false
+    - name: env_vars
+      level: extended
+      type: object
+      description: 'Environment variables set at the time of the event.
+
+        May be filtered to protect sensitive information.'
+      example: "{\n  \"USER\": \"elastic\",\n  \"LANG\": \"en_US.UTF-8\",\n  \"HOME\": \"/home/elastic\"\n}"
+      default_field: false
     - name: executable
       level: extended
       type: keyword

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -675,6 +675,7 @@ sent by the endpoint.
 | process.entry_leader.user.id | Unique identifier of the user. | keyword |
 | process.entry_leader.user.name | Short name or login of the user. | keyword |
 | process.entry_leader.working_directory | The working directory of the process. | keyword |
+| process.env_vars | Environment variables set at the time of the event. May be filtered to protect sensitive information. | object |
 | process.executable | Absolute path to the process executable. | keyword |
 | process.exit_code | The exit code of the process, if this is a termination event. The field should be absent if there is no exit code for the event (e.g. process start). | long |
 | process.group_leader.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
@@ -1968,6 +1969,7 @@ sent by the endpoint.
 | process.entry_leader.user.id | Unique identifier of the user. | keyword |
 | process.entry_leader.user.name | Short name or login of the user. | keyword |
 | process.entry_leader.working_directory | The working directory of the process. | keyword |
+| process.env_vars | Environment variables set at the time of the event. May be filtered to protect sensitive information. | object |
 | process.executable | Absolute path to the process executable. | keyword |
 | process.exit_code | The exit code of the process, if this is a termination event. The field should be absent if there is no exit code for the event (e.g. process start). | long |
 | process.group_leader.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |

--- a/schemas/v1/alerts/linux_event_model_event.yaml
+++ b/schemas/v1/alerts/linux_event_model_event.yaml
@@ -796,6 +796,19 @@ process.entry_leader.working_directory:
   original_fieldset: process
   short: The working directory of the process.
   type: keyword
+process.env_vars:
+  dashed_name: process-env-vars
+  description: 'Environment variables set at the time of the event.
+
+    May be filtered to protect sensitive information.'
+  example: "{\n  \"USER\": \"elastic\",\n  \"LANG\": \"en_US.UTF-8\",\n  \"HOME\"\
+    : \"/home/elastic\"\n}"
+  flat_name: process.env_vars
+  level: extended
+  name: env_vars
+  normalize: []
+  short: Environment variables set at the time of the event.
+  type: object
 process.executable:
   dashed_name: process-executable
   description: Absolute path to the process executable.

--- a/schemas/v1/process/linux_event_model_event.yaml
+++ b/schemas/v1/process/linux_event_model_event.yaml
@@ -796,6 +796,19 @@ process.entry_leader.working_directory:
   original_fieldset: process
   short: The working directory of the process.
   type: keyword
+process.env_vars:
+  dashed_name: process-env-vars
+  description: 'Environment variables set at the time of the event.
+
+    May be filtered to protect sensitive information.'
+  example: "{\n  \"USER\": \"elastic\",\n  \"LANG\": \"en_US.UTF-8\",\n  \"HOME\"\
+    : \"/home/elastic\"\n}"
+  flat_name: process.env_vars
+  level: extended
+  name: env_vars
+  normalize: []
+  short: Environment variables set at the time of the event.
+  type: object
 process.executable:
   dashed_name: process-executable
   description: Absolute path to the process executable.


### PR DESCRIPTION
## Change Summary

Small amendment to the previous linux-process-model PR.

## Release Target

8.2

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed any generated files (in `schema/`, `generated/`)
- [ ] Does this field need to be "exceptionable"? (no longer specified in this package, this is now tracked in Kibana)
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match
