### PR TITLE
process.user mapping re-added

### DIFF
--- a/custom_subsets/elastic_endpoint/alerts/linux_event_model_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/linux_event_model_event.yaml
@@ -47,6 +47,10 @@ fields:
             fields:
               major: {}
               minor: {}
+      user:
+        fields:
+          id: {}
+          name: {}
       working_directory: {}
       real_user:
         fields:

--- a/custom_subsets/elastic_endpoint/process/linux_event_model_event.yaml
+++ b/custom_subsets/elastic_endpoint/process/linux_event_model_event.yaml
@@ -47,6 +47,10 @@ fields:
             fields:
               major: {}
               minor: {}
+      user:
+        fields:
+          id: {}
+          name: {}
       working_directory: {}
       real_user:
         fields:

--- a/generated/alerts/ecs/ecs_flat.yml
+++ b/generated/alerts/ecs/ecs_flat.yml
@@ -12222,6 +12222,34 @@ process.uptime:
   normalize: []
   short: Seconds the process has been up.
   type: long
+process.user.id:
+  dashed_name: process-user-id
+  description: Unique identifier of the user.
+  flat_name: process.user.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: user
+  short: Unique identifier of the user.
+  type: keyword
+process.user.name:
+  dashed_name: process-user-name
+  description: Short name or login of the user.
+  example: albert
+  flat_name: process.user.name
+  ignore_above: 1024
+  level: core
+  multi_fields:
+  - flat_name: process.user.name.text
+    name: text
+    norms: false
+    type: text
+  name: name
+  normalize: []
+  original_fieldset: user
+  short: Short name or login of the user.
+  type: keyword
 process.working_directory:
   dashed_name: process-working-directory
   description: The working directory of the process.

--- a/generated/alerts/elasticsearch/7/template.json
+++ b/generated/alerts/elasticsearch/7/template.json
@@ -4726,6 +4726,24 @@
           "uptime": {
             "type": "long"
           },
+          "user": {
+            "properties": {
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "working_directory": {
             "fields": {
               "caseless": {

--- a/generated/process/ecs/ecs_flat.yml
+++ b/generated/process/ecs/ecs_flat.yml
@@ -4595,6 +4595,34 @@ process.uptime:
   normalize: []
   short: Seconds the process has been up.
   type: long
+process.user.id:
+  dashed_name: process-user-id
+  description: Unique identifier of the user.
+  flat_name: process.user.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: user
+  short: Unique identifier of the user.
+  type: keyword
+process.user.name:
+  dashed_name: process-user-name
+  description: Short name or login of the user.
+  example: albert
+  flat_name: process.user.name
+  ignore_above: 1024
+  level: core
+  multi_fields:
+  - flat_name: process.user.name.text
+    name: text
+    norms: false
+    type: text
+  name: name
+  normalize: []
+  original_fieldset: user
+  short: Short name or login of the user.
+  type: keyword
 process.working_directory:
   dashed_name: process-working-directory
   description: The working directory of the process.

--- a/generated/process/elasticsearch/7/template.json
+++ b/generated/process/elasticsearch/7/template.json
@@ -1778,6 +1778,24 @@
           "uptime": {
             "type": "long"
           },
+          "user": {
+            "properties": {
+              "id": {
+                "ignore_above": 1024,
+                "type": "keyword"
+              },
+              "name": {
+                "fields": {
+                  "text": {
+                    "norms": false,
+                    "type": "text"
+                  }
+                },
+                "ignore_above": 1024,
+                "type": "keyword"
+              }
+            }
+          },
           "working_directory": {
             "fields": {
               "caseless": {

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -6749,6 +6749,23 @@
       type: long
       description: Seconds the process has been up.
       example: 1325
+    - name: user.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier of the user.
+      default_field: false
+    - name: user.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+      description: Short name or login of the user.
+      example: albert
+      default_field: false
     - name: working_directory
       level: extended
       type: keyword

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -2471,6 +2471,23 @@
       type: long
       description: Seconds the process has been up.
       example: 1325
+    - name: user.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier of the user.
+      default_field: false
+    - name: user.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: text
+          norms: false
+      description: Short name or login of the user.
+      example: albert
+      default_field: false
     - name: working_directory
       level: extended
       type: keyword

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -898,6 +898,8 @@ sent by the endpoint.
 | process.tty.char_device.major | The major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as "ttyS0" and "pts/0. For more details see https://www.kernel.org/doc/html/v4.11/admin-guide/devices.html | long |
 | process.tty.char_device.minor | The minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them. | long |
 | process.uptime | Seconds the process has been up. | long |
+| process.user.id | Unique identifier of the user. | keyword |
+| process.user.name | Short name or login of the user. | keyword |
 | process.working_directory | The working directory of the process. | keyword |
 | registry.data.strings | Content when writing string types. Populated as an array when writing string data to the registry. For single string registry types (REG_SZ, REG_EXPAND_SZ), this should be an array with one string. For sequences of string with REG_MULTI_SZ, this array will be variable length. For numeric data, such as REG_DWORD and REG_QWORD, this should be populated with the decimal representation (e.g `"1"`). | keyword |
 | registry.path | Full path, including hive, key and value | keyword |
@@ -2136,6 +2138,8 @@ sent by the endpoint.
 | process.tty.char_device.major | The major number identifies the driver associated with the device. The character device's major and minor numbers can be algorithmically combined to produce the more familiar terminal identifiers such as "ttyS0" and "pts/0. For more details see https://www.kernel.org/doc/html/v4.11/admin-guide/devices.html | long |
 | process.tty.char_device.minor | The minor number is used only by the driver specified by the major number; other parts of the kernel don’t use it, and merely pass it along to the driver. It is common for a driver to control several devices; the minor number provides a way for the driver to differentiate among them. | long |
 | process.uptime | Seconds the process has been up. | long |
+| process.user.id | Unique identifier of the user. | keyword |
+| process.user.name | Short name or login of the user. | keyword |
 | process.working_directory | The working directory of the process. | keyword |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_code | Two-letter code representing continent's name. | keyword |

--- a/schemas/v1/alerts/linux_event_model_event.yaml
+++ b/schemas/v1/alerts/linux_event_model_event.yaml
@@ -2503,6 +2503,34 @@ process.tty.char_device.minor:
   normalize: []
   short: The TTY character device's minor number.
   type: long
+process.user.id:
+  dashed_name: process-user-id
+  description: Unique identifier of the user.
+  flat_name: process.user.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: user
+  short: Unique identifier of the user.
+  type: keyword
+process.user.name:
+  dashed_name: process-user-name
+  description: Short name or login of the user.
+  example: albert
+  flat_name: process.user.name
+  ignore_above: 1024
+  level: core
+  multi_fields:
+  - flat_name: process.user.name.text
+    name: text
+    norms: false
+    type: text
+  name: name
+  normalize: []
+  original_fieldset: user
+  short: Short name or login of the user.
+  type: keyword
 process.working_directory:
   dashed_name: process-working-directory
   description: The working directory of the process.

--- a/schemas/v1/process/linux_event_model_event.yaml
+++ b/schemas/v1/process/linux_event_model_event.yaml
@@ -2503,6 +2503,34 @@ process.tty.char_device.minor:
   normalize: []
   short: The TTY character device's minor number.
   type: long
+process.user.id:
+  dashed_name: process-user-id
+  description: Unique identifier of the user.
+  flat_name: process.user.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: user
+  short: Unique identifier of the user.
+  type: keyword
+process.user.name:
+  dashed_name: process-user-name
+  description: Short name or login of the user.
+  example: albert
+  flat_name: process.user.name
+  ignore_above: 1024
+  level: core
+  multi_fields:
+  - flat_name: process.user.name.text
+    name: text
+    norms: false
+    type: text
+  name: name
+  normalize: []
+  original_fieldset: user
+  short: Short name or login of the user.
+  type: keyword
 process.working_directory:
   dashed_name: process-working-directory
   description: The working directory of the process.


### PR DESCRIPTION
## Change Summary

Due to some consistency issues with the ECS 8.2 release we need to include process.user mapping.


## Release Target

8.2

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed any generated files (in `schema/`, `generated/`)
- [ ] Does this field need to be "exceptionable"? (no longer specified in this package, this is now tracked in Kibana)
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match
