### PR TITLE
Add new documents_volume fields

### DIFF
--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -504,6 +504,86 @@
       type: long
       description: Total size of suppressed documents
 
+    - name: metrics.documents_volume.security_events.sent_count
+      level: custom
+      type: long
+      description: Number of sent documents
+
+    - name: metrics.documents_volume.security_events.sent_bytes
+      level: custom
+      type: long
+      description: Total size of sent documents
+
+    - name: metrics.documents_volume.security_events.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed documents
+
+    - name: metrics.documents_volume.security_events.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed documents
+
+    - name: metrics.documents_volume.dns_events.sent_count
+      level: custom
+      type: long
+      description: Number of sent documents
+
+    - name: metrics.documents_volume.dns_events.sent_bytes
+      level: custom
+      type: long
+      description: Total size of sent documents
+
+    - name: metrics.documents_volume.dns_events.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed documents
+
+    - name: metrics.documents_volume.dns_events.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed documents
+
+    - name: metrics.documents_volume.alerts.sent_count
+      level: custom
+      type: long
+      description: Number of sent documents
+
+    - name: metrics.documents_volume.alerts.sent_bytes
+      level: custom
+      type: long
+      description: Total size of sent documents
+
+    - name: metrics.documents_volume.alerts.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed documents
+
+    - name: metrics.documents_volume.alerts.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed documents
+
+    - name: metrics.documents_volume.diagnostic_alerts.sent_count
+      level: custom
+      type: long
+      description: Number of sent documents
+
+    - name: metrics.documents_volume.diagnostic_alerts.sent_bytes
+      level: custom
+      type: long
+      description: Total size of sent documents
+
+    - name: metrics.documents_volume.diagnostic_alerts.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed documents
+
+    - name: metrics.documents_volume.diagnostic_alerts.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed documents
+
     - name: metrics.uptime
       level: custom
       type: object

--- a/generated/metrics/ecs/ecs_flat.yml
+++ b/generated/metrics/ecs/ecs_flat.yml
@@ -152,6 +152,114 @@ Endpoint.metrics.documents_volume:
   normalize: []
   short: Statistics about sent documents
   type: object
+Endpoint.metrics.documents_volume.alerts.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-alerts-sent-bytes
+  description: Total size of sent documents
+  flat_name: Endpoint.metrics.documents_volume.alerts.sent_bytes
+  level: custom
+  name: metrics.documents_volume.alerts.sent_bytes
+  normalize: []
+  short: Total size of sent documents
+  type: long
+Endpoint.metrics.documents_volume.alerts.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-alerts-sent-count
+  description: Number of sent documents
+  flat_name: Endpoint.metrics.documents_volume.alerts.sent_count
+  level: custom
+  name: metrics.documents_volume.alerts.sent_count
+  normalize: []
+  short: Number of sent documents
+  type: long
+Endpoint.metrics.documents_volume.alerts.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-alerts-suppressed-bytes
+  description: Total size of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.alerts.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.alerts.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.alerts.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-alerts-suppressed-count
+  description: Number of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.alerts.suppressed_count
+  level: custom
+  name: metrics.documents_volume.alerts.suppressed_count
+  normalize: []
+  short: Number of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.diagnostic_alerts.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-diagnostic-alerts-sent-bytes
+  description: Total size of sent documents
+  flat_name: Endpoint.metrics.documents_volume.diagnostic_alerts.sent_bytes
+  level: custom
+  name: metrics.documents_volume.diagnostic_alerts.sent_bytes
+  normalize: []
+  short: Total size of sent documents
+  type: long
+Endpoint.metrics.documents_volume.diagnostic_alerts.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-diagnostic-alerts-sent-count
+  description: Number of sent documents
+  flat_name: Endpoint.metrics.documents_volume.diagnostic_alerts.sent_count
+  level: custom
+  name: metrics.documents_volume.diagnostic_alerts.sent_count
+  normalize: []
+  short: Number of sent documents
+  type: long
+Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-diagnostic-alerts-suppressed-bytes
+  description: Total size of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.diagnostic_alerts.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-diagnostic-alerts-suppressed-count
+  description: Number of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_count
+  level: custom
+  name: metrics.documents_volume.diagnostic_alerts.suppressed_count
+  normalize: []
+  short: Number of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.dns_events.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-dns-events-sent-bytes
+  description: Total size of sent documents
+  flat_name: Endpoint.metrics.documents_volume.dns_events.sent_bytes
+  level: custom
+  name: metrics.documents_volume.dns_events.sent_bytes
+  normalize: []
+  short: Total size of sent documents
+  type: long
+Endpoint.metrics.documents_volume.dns_events.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-dns-events-sent-count
+  description: Number of sent documents
+  flat_name: Endpoint.metrics.documents_volume.dns_events.sent_count
+  level: custom
+  name: metrics.documents_volume.dns_events.sent_count
+  normalize: []
+  short: Number of sent documents
+  type: long
+Endpoint.metrics.documents_volume.dns_events.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-dns-events-suppressed-bytes
+  description: Total size of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.dns_events.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.dns_events.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.dns_events.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-dns-events-suppressed-count
+  description: Number of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.dns_events.suppressed_count
+  level: custom
+  name: metrics.documents_volume.dns_events.suppressed_count
+  normalize: []
+  short: Number of suppressed documents
+  type: long
 Endpoint.metrics.documents_volume.file_events.sent_bytes:
   dashed_name: Endpoint-metrics-documents-volume-file-events-sent-bytes
   description: Total size of sent documents
@@ -365,6 +473,42 @@ Endpoint.metrics.documents_volume.registry_events.suppressed_count:
   flat_name: Endpoint.metrics.documents_volume.registry_events.suppressed_count
   level: custom
   name: metrics.documents_volume.registry_events.suppressed_count
+  normalize: []
+  short: Number of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.security_events.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sent-bytes
+  description: Total size of sent documents
+  flat_name: Endpoint.metrics.documents_volume.security_events.sent_bytes
+  level: custom
+  name: metrics.documents_volume.security_events.sent_bytes
+  normalize: []
+  short: Total size of sent documents
+  type: long
+Endpoint.metrics.documents_volume.security_events.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sent-count
+  description: Number of sent documents
+  flat_name: Endpoint.metrics.documents_volume.security_events.sent_count
+  level: custom
+  name: metrics.documents_volume.security_events.sent_count
+  normalize: []
+  short: Number of sent documents
+  type: long
+Endpoint.metrics.documents_volume.security_events.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-suppressed-bytes
+  description: Total size of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.security_events.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.security_events.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.security_events.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-suppressed-count
+  description: Number of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.security_events.suppressed_count
+  level: custom
+  name: metrics.documents_volume.security_events.suppressed_count
   normalize: []
   short: Number of suppressed documents
   type: long

--- a/generated/metrics/elasticsearch/7/template.json
+++ b/generated/metrics/elasticsearch/7/template.json
@@ -74,6 +74,54 @@
               },
               "documents_volume": {
                 "properties": {
+                  "alerts": {
+                    "properties": {
+                      "sent_bytes": {
+                        "type": "long"
+                      },
+                      "sent_count": {
+                        "type": "long"
+                      },
+                      "suppressed_bytes": {
+                        "type": "long"
+                      },
+                      "suppressed_count": {
+                        "type": "long"
+                      }
+                    }
+                  },
+                  "diagnostic_alerts": {
+                    "properties": {
+                      "sent_bytes": {
+                        "type": "long"
+                      },
+                      "sent_count": {
+                        "type": "long"
+                      },
+                      "suppressed_bytes": {
+                        "type": "long"
+                      },
+                      "suppressed_count": {
+                        "type": "long"
+                      }
+                    }
+                  },
+                  "dns_events": {
+                    "properties": {
+                      "sent_bytes": {
+                        "type": "long"
+                      },
+                      "sent_count": {
+                        "type": "long"
+                      },
+                      "suppressed_bytes": {
+                        "type": "long"
+                      },
+                      "suppressed_count": {
+                        "type": "long"
+                      }
+                    }
+                  },
                   "file_events": {
                     "properties": {
                       "sent_bytes": {
@@ -155,6 +203,22 @@
                     }
                   },
                   "registry_events": {
+                    "properties": {
+                      "sent_bytes": {
+                        "type": "long"
+                      },
+                      "sent_count": {
+                        "type": "long"
+                      },
+                      "suppressed_bytes": {
+                        "type": "long"
+                      },
+                      "suppressed_count": {
+                        "type": "long"
+                      }
+                    }
+                  },
+                  "security_events": {
                     "properties": {
                       "sent_bytes": {
                         "type": "long"

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -99,6 +99,66 @@
       type: object
       description: Statistics about sent documents
       default_field: false
+    - name: metrics.documents_volume.alerts.sent_bytes
+      level: custom
+      type: long
+      description: Total size of sent documents
+      default_field: false
+    - name: metrics.documents_volume.alerts.sent_count
+      level: custom
+      type: long
+      description: Number of sent documents
+      default_field: false
+    - name: metrics.documents_volume.alerts.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed documents
+      default_field: false
+    - name: metrics.documents_volume.alerts.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed documents
+      default_field: false
+    - name: metrics.documents_volume.diagnostic_alerts.sent_bytes
+      level: custom
+      type: long
+      description: Total size of sent documents
+      default_field: false
+    - name: metrics.documents_volume.diagnostic_alerts.sent_count
+      level: custom
+      type: long
+      description: Number of sent documents
+      default_field: false
+    - name: metrics.documents_volume.diagnostic_alerts.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed documents
+      default_field: false
+    - name: metrics.documents_volume.diagnostic_alerts.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed documents
+      default_field: false
+    - name: metrics.documents_volume.dns_events.sent_bytes
+      level: custom
+      type: long
+      description: Total size of sent documents
+      default_field: false
+    - name: metrics.documents_volume.dns_events.sent_count
+      level: custom
+      type: long
+      description: Number of sent documents
+      default_field: false
+    - name: metrics.documents_volume.dns_events.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed documents
+      default_field: false
+    - name: metrics.documents_volume.dns_events.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed documents
+      default_field: false
     - name: metrics.documents_volume.file_events.sent_bytes
       level: custom
       type: long
@@ -215,6 +275,26 @@
       description: Total size of suppressed documents
       default_field: false
     - name: metrics.documents_volume.registry_events.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed documents
+      default_field: false
+    - name: metrics.documents_volume.security_events.sent_bytes
+      level: custom
+      type: long
+      description: Total size of sent documents
+      default_field: false
+    - name: metrics.documents_volume.security_events.sent_count
+      level: custom
+      type: long
+      description: Number of sent documents
+      default_field: false
+    - name: metrics.documents_volume.security_events.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed documents
+      default_field: false
+    - name: metrics.documents_volume.security_events.suppressed_count
       level: custom
       type: long
       description: Number of suppressed documents

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2461,6 +2461,18 @@ Metrics documents contain performance information about the endpoint executable 
 | Endpoint.metrics.cpu.endpoint.latest | Average CPU over the last sample interval | half_float |
 | Endpoint.metrics.cpu.endpoint.mean | Average CPU load used by the endpoint | half_float |
 | Endpoint.metrics.documents_volume | Statistics about sent documents | object |
+| Endpoint.metrics.documents_volume.alerts.sent_bytes | Total size of sent documents | long |
+| Endpoint.metrics.documents_volume.alerts.sent_count | Number of sent documents | long |
+| Endpoint.metrics.documents_volume.alerts.suppressed_bytes | Total size of suppressed documents | long |
+| Endpoint.metrics.documents_volume.alerts.suppressed_count | Number of suppressed documents | long |
+| Endpoint.metrics.documents_volume.diagnostic_alerts.sent_bytes | Total size of sent documents | long |
+| Endpoint.metrics.documents_volume.diagnostic_alerts.sent_count | Number of sent documents | long |
+| Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_bytes | Total size of suppressed documents | long |
+| Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_count | Number of suppressed documents | long |
+| Endpoint.metrics.documents_volume.dns_events.sent_bytes | Total size of sent documents | long |
+| Endpoint.metrics.documents_volume.dns_events.sent_count | Number of sent documents | long |
+| Endpoint.metrics.documents_volume.dns_events.suppressed_bytes | Total size of suppressed documents | long |
+| Endpoint.metrics.documents_volume.dns_events.suppressed_count | Number of suppressed documents | long |
 | Endpoint.metrics.documents_volume.file_events.sent_bytes | Total size of sent documents | long |
 | Endpoint.metrics.documents_volume.file_events.sent_count | Number of sent documents | long |
 | Endpoint.metrics.documents_volume.file_events.suppressed_bytes | Total size of suppressed documents | long |
@@ -2485,6 +2497,10 @@ Metrics documents contain performance information about the endpoint executable 
 | Endpoint.metrics.documents_volume.registry_events.sent_count | Number of sent documents | long |
 | Endpoint.metrics.documents_volume.registry_events.suppressed_bytes | Total size of suppressed documents | long |
 | Endpoint.metrics.documents_volume.registry_events.suppressed_count | Number of suppressed documents | long |
+| Endpoint.metrics.documents_volume.security_events.sent_bytes | Total size of sent documents | long |
+| Endpoint.metrics.documents_volume.security_events.sent_count | Number of sent documents | long |
+| Endpoint.metrics.documents_volume.security_events.suppressed_bytes | Total size of suppressed documents | long |
+| Endpoint.metrics.documents_volume.security_events.suppressed_count | Number of suppressed documents | long |
 | Endpoint.metrics.memory | Memory statistics | object |
 | Endpoint.metrics.memory.endpoint | Endpoint memory utilization | object |
 | Endpoint.metrics.memory.endpoint.private | The memory private to the endpoint | object |

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -152,6 +152,114 @@ Endpoint.metrics.documents_volume:
   normalize: []
   short: Statistics about sent documents
   type: object
+Endpoint.metrics.documents_volume.alerts.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-alerts-sent-bytes
+  description: Total size of sent documents
+  flat_name: Endpoint.metrics.documents_volume.alerts.sent_bytes
+  level: custom
+  name: metrics.documents_volume.alerts.sent_bytes
+  normalize: []
+  short: Total size of sent documents
+  type: long
+Endpoint.metrics.documents_volume.alerts.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-alerts-sent-count
+  description: Number of sent documents
+  flat_name: Endpoint.metrics.documents_volume.alerts.sent_count
+  level: custom
+  name: metrics.documents_volume.alerts.sent_count
+  normalize: []
+  short: Number of sent documents
+  type: long
+Endpoint.metrics.documents_volume.alerts.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-alerts-suppressed-bytes
+  description: Total size of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.alerts.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.alerts.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.alerts.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-alerts-suppressed-count
+  description: Number of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.alerts.suppressed_count
+  level: custom
+  name: metrics.documents_volume.alerts.suppressed_count
+  normalize: []
+  short: Number of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.diagnostic_alerts.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-diagnostic-alerts-sent-bytes
+  description: Total size of sent documents
+  flat_name: Endpoint.metrics.documents_volume.diagnostic_alerts.sent_bytes
+  level: custom
+  name: metrics.documents_volume.diagnostic_alerts.sent_bytes
+  normalize: []
+  short: Total size of sent documents
+  type: long
+Endpoint.metrics.documents_volume.diagnostic_alerts.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-diagnostic-alerts-sent-count
+  description: Number of sent documents
+  flat_name: Endpoint.metrics.documents_volume.diagnostic_alerts.sent_count
+  level: custom
+  name: metrics.documents_volume.diagnostic_alerts.sent_count
+  normalize: []
+  short: Number of sent documents
+  type: long
+Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-diagnostic-alerts-suppressed-bytes
+  description: Total size of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.diagnostic_alerts.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-diagnostic-alerts-suppressed-count
+  description: Number of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_count
+  level: custom
+  name: metrics.documents_volume.diagnostic_alerts.suppressed_count
+  normalize: []
+  short: Number of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.dns_events.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-dns-events-sent-bytes
+  description: Total size of sent documents
+  flat_name: Endpoint.metrics.documents_volume.dns_events.sent_bytes
+  level: custom
+  name: metrics.documents_volume.dns_events.sent_bytes
+  normalize: []
+  short: Total size of sent documents
+  type: long
+Endpoint.metrics.documents_volume.dns_events.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-dns-events-sent-count
+  description: Number of sent documents
+  flat_name: Endpoint.metrics.documents_volume.dns_events.sent_count
+  level: custom
+  name: metrics.documents_volume.dns_events.sent_count
+  normalize: []
+  short: Number of sent documents
+  type: long
+Endpoint.metrics.documents_volume.dns_events.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-dns-events-suppressed-bytes
+  description: Total size of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.dns_events.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.dns_events.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.dns_events.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-dns-events-suppressed-count
+  description: Number of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.dns_events.suppressed_count
+  level: custom
+  name: metrics.documents_volume.dns_events.suppressed_count
+  normalize: []
+  short: Number of suppressed documents
+  type: long
 Endpoint.metrics.documents_volume.file_events.sent_bytes:
   dashed_name: Endpoint-metrics-documents-volume-file-events-sent-bytes
   description: Total size of sent documents
@@ -365,6 +473,42 @@ Endpoint.metrics.documents_volume.registry_events.suppressed_count:
   flat_name: Endpoint.metrics.documents_volume.registry_events.suppressed_count
   level: custom
   name: metrics.documents_volume.registry_events.suppressed_count
+  normalize: []
+  short: Number of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.security_events.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sent-bytes
+  description: Total size of sent documents
+  flat_name: Endpoint.metrics.documents_volume.security_events.sent_bytes
+  level: custom
+  name: metrics.documents_volume.security_events.sent_bytes
+  normalize: []
+  short: Total size of sent documents
+  type: long
+Endpoint.metrics.documents_volume.security_events.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sent-count
+  description: Number of sent documents
+  flat_name: Endpoint.metrics.documents_volume.security_events.sent_count
+  level: custom
+  name: metrics.documents_volume.security_events.sent_count
+  normalize: []
+  short: Number of sent documents
+  type: long
+Endpoint.metrics.documents_volume.security_events.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-suppressed-bytes
+  description: Total size of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.security_events.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.security_events.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.security_events.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-suppressed-count
+  description: Number of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.security_events.suppressed_count
+  level: custom
+  name: metrics.documents_volume.security_events.suppressed_count
   normalize: []
   short: Number of suppressed documents
   type: long


### PR DESCRIPTION
## Change Summary

This adds the fields listed below to the Endpoint metrics document

```
Endpoint.metrics.documents_volume.alerts.sent_bytes
Endpoint.metrics.documents_volume.alerts.sent_count
Endpoint.metrics.documents_volume.alerts.suppressed_bytes
Endpoint.metrics.documents_volume.alerts.suppressed_count
Endpoint.metrics.documents_volume.diagnostic_alerts.sent_bytes
Endpoint.metrics.documents_volume.diagnostic_alerts.sent_count
Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_bytes
Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_count
Endpoint.metrics.documents_volume.dns_events.sent_bytes
Endpoint.metrics.documents_volume.dns_events.sent_count
Endpoint.metrics.documents_volume.dns_events.suppressed_bytes
Endpoint.metrics.documents_volume.dns_events.suppressed_count
Endpoint.metrics.documents_volume.security_events.sent_bytes
Endpoint.metrics.documents_volume.security_events.sent_count
Endpoint.metrics.documents_volume.security_events.suppressed_bytes
Endpoint.metrics.documents_volume.security_events.suppressed_count
```

### Sample values

Here's a document snippet

```json
{                                                                                                       
    "Endpoint": {                                                                                       
        "metrics": {                                                                                    
            "documents_volume": {                                                                       
                "alerts": {                                                                             
                    "sent_bytes": 9102,                                                                 
                    "sent_count": 1,                                                                    
                    "suppressed_bytes": 0,                                                              
                    "suppressed_count": 0                                                               
                },                                                                                      
                "diagnostic_alerts": {                                                                  
                    "sent_bytes": 9165,                                                                 
                    "sent_count": 1,                                                                    
                    "suppressed_bytes": 0,                                                              
                    "suppressed_count": 0                                                               
                },                                                                                      
                "dns_events": {                                                                         
                    "sent_bytes": 13209,                                                                
                    "sent_count": 6,                                                                    
                    "suppressed_bytes": 49289,                                                          
                    "suppressed_count": 22                                                              
                },                                                                                      
                "file_events": {                                                                        
                    "sent_bytes": 2937483,                                                              
                    "sent_count": 966,                                                                  
                    "suppressed_bytes": 2888069,                                                        
                    "suppressed_count": 964                                                             
                },                                                                                      
                "library_events": {                                                                     
                    "sent_bytes": 7011,                                                                 
                    "sent_count": 4,                                                                    
                    "suppressed_bytes": 12618,                                                          
                    "suppressed_count": 4                                                               
                },                                                                                      
                "network_events": {                                                                     
                    "sent_bytes": 63882,                                                                
                    "sent_count": 25,                                                                   
                    "suppressed_bytes": 358314,                                                         
                    "suppressed_count": 138                                                             
                },                                                                                      
                "overall": {                                                                            
                    "sent_bytes": 3041944,                                                              
                    "sent_count": 1004,                                                                 
                    "suppressed_bytes": 4429563,                                                        
                    "suppressed_count": 1664                                                            
                },                                                                                      
                "process_events": {                                                                     
                    "sent_bytes": 0,                                                                    
                    "sent_count": 0,                                                                    
                    "suppressed_bytes": 340217,                                                         
                    "suppressed_count": 117                                                             
                },                                                                                      
                "registry_events": {                                                                    
                    "sent_bytes": 2092,                                                                 
                    "sent_count": 1,                                                                    
                    "suppressed_bytes": 423791,                                                         
                    "suppressed_count": 198                                                             
                },                                                                                      
                "security_events": {                                                                    
                    "sent_bytes": 0,                                                                    
                    "sent_count": 0,                                                                    
                    "suppressed_bytes": 357265,                                                         
                    "suppressed_count": 221                                                             
                }                                                                                       
            }                                                                                           
        }                                                                                               
    }                                                                                                   
}    
```

## Release Target

8.2.0

## Q/A

I don't know how to QA this.

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed any generated files (in `schema/`, `generated/`)
- [x] Does this field need to be "exceptionable"? (no longer specified in this package, this is now tracked in Kibana)
  - No
- [x] If this is a `metadata` change, I also updated both transform destination schemas to match
  - No, it's a metrics change.

### For Transform changes:

I'm pretty sure this isn't a transform change.