### PR TITLE
[Security Solution] Increase delay of united transform

### DIFF
--- a/package/endpoint/elasticsearch/transform/metadata_united/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_united/default.json
@@ -11,7 +11,7 @@
     "frequency": "1s",
     "sync": {
         "time": {
-            "delay": "1s",
+            "delay": "5s",
             "field": "updated_at"
         }
     },

--- a/package/endpoint/elasticsearch/transform/metadata_united/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_united/default.json
@@ -11,7 +11,7 @@
     "frequency": "1s",
     "sync": {
         "time": {
-            "delay": "5s",
+            "delay": "4s",
             "field": "updated_at"
         }
     },


### PR DESCRIPTION
## Change Summary

In Endpoint management dev testing, we noticed that the shorter delays in the united transform were periodically dropping documents when using our endpoint generator dev tool.

When I was running tests which added ~30 Agent and Endpoint docs resulted in the `united` transform, I noticed that documents from our generator dev tool would periodically be dropped.  I believe this has to do with look back in the transform when combining the Agent and Endpoint documents.

After increasing the delay in the `united` transform, all transforms kept up without problems when I left the generator running, adding a total of 2000 Agent and Endpoint docs.

See the Agent/Endpoint counts match below.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/56395104/161053539-7b10c0ff-c900-4391-b618-876efdc4d1b1.png">

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/56395104/161053464-00b682eb-e769-436d-aaad-5871136fe1df.png">


## Release Target

`8.2`

## Q/A

### For Transform changes:

- [x] The new transform successfully starts in Kibana
- [x] The corresponding transform destination schema was updated if necessary
