### PR TITLE
Generate catchup

### DIFF
--- a/custom_subsets/elastic_endpoint/library/library.yaml
+++ b/custom_subsets/elastic_endpoint/library/library.yaml
@@ -113,8 +113,8 @@ fields:
       Ext:
         fields:
           ancestry: {}
-        code_signature:
-          fields: "*"
+          code_signature:
+            fields: "*"
   file:
     fields:
       pe:

--- a/generated/library/ecs/ecs_flat.yml
+++ b/generated/library/ecs/ecs_flat.yml
@@ -1882,6 +1882,78 @@ process.Ext.ancestry:
   normalize: []
   short: An array of entity_ids indicating the ancestors for this event
   type: keyword
+process.Ext.code_signature:
+  dashed_name: process-Ext-code-signature
+  description: Nested version of ECS code_signature fieldset.
+  flat_name: process.Ext.code_signature
+  level: custom
+  name: Ext.code_signature
+  normalize: []
+  short: Nested version of ECS code_signature fieldset.
+  type: nested
+process.Ext.code_signature.exists:
+  dashed_name: process-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.Ext.code_signature.status:
+  dashed_name: process-Ext-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.Ext.code_signature.status
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.status
+  normalize: []
+  short: Additional information about the certificate status.
+  type: keyword
+process.Ext.code_signature.subject_name:
+  dashed_name: process-Ext-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.Ext.code_signature.subject_name
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.subject_name
+  normalize: []
+  short: Subject name of the code signer
+  type: keyword
+process.Ext.code_signature.trusted:
+  dashed_name: process-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.Ext.code_signature.valid:
+  dashed_name: process-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 process.code_signature.exists:
   dashed_name: process-code-signature-exists
   description: Boolean to capture if a signature is present.

--- a/generated/library/elasticsearch/7/template.json
+++ b/generated/library/elasticsearch/7/template.json
@@ -562,6 +562,28 @@
               "ancestry": {
                 "ignore_above": 1024,
                 "type": "keyword"
+              },
+              "code_signature": {
+                "properties": {
+                  "exists": {
+                    "type": "boolean"
+                  },
+                  "status": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "subject_name": {
+                    "ignore_above": 1024,
+                    "type": "keyword"
+                  },
+                  "trusted": {
+                    "type": "boolean"
+                  },
+                  "valid": {
+                    "type": "boolean"
+                  }
+                },
+                "type": "nested"
               }
             },
             "type": "object"

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -196,6 +196,7 @@
     - name: child_processes.files.data
       level: custom
       type: keyword
+      ignore_above: 1024
       description: File header or MBR bytes.
       default_field: false
     - name: child_processes.files.entropy
@@ -287,6 +288,7 @@
     - name: files.data
       level: custom
       type: keyword
+      ignore_above: 1024
       description: File header or MBR bytes.
       default_field: false
     - name: files.entropy
@@ -425,73 +427,6 @@
     These fields provide more context about the target process and thread that are related to the data in the document. Useful in a security context where a target process or thread may be acted on by another process or thread.'
   type: group
   fields:
-    - name: dll.code_signature.exists
-      level: core
-      type: boolean
-      description: Boolean to capture if a signature is present.
-      example: "true"
-      default_field: false
-    - name: dll.code_signature.subject_name
-      level: extended
-      type: keyword
-      description: Subject name of the code signer
-      example: Microsoft Corporation
-      default_field: false
-    - name: dll.code_signature.valid
-      level: extended
-      type: boolean
-      short: Boolean to capture if the digital signature is verified against the binary content.
-      example: "true"
-      description: >
-        Boolean to capture if the digital signature is verified against the binary content.
-
-        Leave unpopulated if a certificate was unchecked.
-
-      default_field: false
-    - name: dll.code_signature.trusted
-      level: extended
-      type: boolean
-      short: Stores the trust status of the certificate chain.
-      example: "true"
-      description: >
-        Stores the trust status of the certificate chain.
-
-        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.
-
-      default_field: false
-    - name: dll.code_signature.status
-      level: extended
-      type: keyword
-      short: Additional information about the certificate status.
-      description: >
-        Additional information about the certificate status.
-
-        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.
-
-      example: ERROR_UNTRUSTED_ROOT
-      default_field: false
-    - name: dll.code_signature.signing_id
-      level: extended
-      type: keyword
-      short: The identifier used to sign the binary.
-      description: >
-        'The identifier used to sign the binary.
-
-        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
-
-      example: com.apple.xpc.proxy
-      default_field: false
-    - name: dll.code_signature.team_id
-      level: extended
-      type: keyword
-      short: The team identifier used to sign the binary.
-      description: >
-        'The team identifier used to sign the binary.
-
-        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
-
-      example: EQHXZ8M8AV
-      default_field: false
     - name: dll.Ext
       level: custom
       type: object
@@ -605,6 +540,62 @@
       type: unsigned_long
       description: The size of this module's memory mapping, in bytes.
       default_field: false
+    - name: dll.code_signature.exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: dll.code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
+    - name: dll.code_signature.status
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: dll.code_signature.subject_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: dll.code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      default_field: false
+    - name: dll.code_signature.trusted
+      level: extended
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: dll.code_signature.valid
+      level: extended
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      default_field: false
     - name: dll.hash.md5
       level: extended
       type: keyword
@@ -689,73 +680,6 @@
       description: Internal product name of the file, provided at compile-time.
       example: "Microsoft® Windows® Operating System"
       default_field: false
-    - name: process.code_signature.exists
-      level: core
-      type: boolean
-      description: Boolean to capture if a signature is present.
-      example: "true"
-      default_field: false
-    - name: process.code_signature.subject_name
-      level: extended
-      type: keyword
-      description: Subject name of the code signer
-      example: Microsoft Corporation
-      default_field: false
-    - name: process.code_signature.valid
-      level: extended
-      type: boolean
-      short: Boolean to capture if the digital signature is verified against the binary content.
-      example: "true"
-      description: >
-        Boolean to capture if the digital signature is verified against the binary content.
-
-        Leave unpopulated if a certificate was unchecked.
-
-      default_field: false
-    - name: process.code_signature.trusted
-      level: extended
-      type: boolean
-      short: Stores the trust status of the certificate chain.
-      example: "true"
-      description: >
-        Stores the trust status of the certificate chain.
-
-        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.
-
-      default_field: false
-    - name: process.code_signature.status
-      level: extended
-      type: keyword
-      short: Additional information about the certificate status.
-      description: >
-        Additional information about the certificate status.
-
-        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.
-
-      example: ERROR_UNTRUSTED_ROOT
-      default_field: false
-    - name: process.code_signature.signing_id
-      level: extended
-      type: keyword
-      short: The identifier used to sign the binary.
-      description: >
-        'The identifier used to sign the binary.
-
-        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
-
-      example: com.apple.xpc.proxy
-      default_field: false
-    - name: process.code_signature.team_id
-      level: extended
-      type: keyword
-      short: The team identifier used to sign the binary.
-      description: >
-        'The team identifier used to sign the binary.
-
-        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
-
-      example: EQHXZ8M8AV
-      default_field: false
     - name: process.Ext
       level: custom
       type: object
@@ -823,73 +747,6 @@
         Leave unpopulated if a certificate was unchecked.'
       example: 'true'
       default_field: false
-    - name: process.Ext.dll.code_signature.exists
-      level: core
-      type: boolean
-      description: Boolean to capture if a signature is present.
-      example: "true"
-      default_field: false
-    - name: process.Ext.dll.code_signature.subject_name
-      level: extended
-      type: keyword
-      description: Subject name of the code signer
-      example: Microsoft Corporation
-      default_field: false
-    - name: process.Ext.dll.code_signature.valid
-      level: extended
-      type: boolean
-      short: Boolean to capture if the digital signature is verified against the binary content.
-      example: "true"
-      description: >
-        Boolean to capture if the digital signature is verified against the binary content.
-
-        Leave unpopulated if a certificate was unchecked.
-
-      default_field: false
-    - name: process.Ext.dll.code_signature.trusted
-      level: extended
-      type: boolean
-      short: Stores the trust status of the certificate chain.
-      example: "true"
-      description: >
-        Stores the trust status of the certificate chain.
-
-        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.
-
-      default_field: false
-    - name: process.Ext.dll.code_signature.status
-      level: extended
-      type: keyword
-      short: Additional information about the certificate status.
-      description: >
-        Additional information about the certificate status.
-
-        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.
-
-      example: ERROR_UNTRUSTED_ROOT
-      default_field: false
-    - name: process.Ext.dll.code_signature.signing_id
-      level: extended
-      type: keyword
-      short: The identifier used to sign the binary.
-      description: >
-        'The identifier used to sign the binary.
-
-        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
-
-      example: com.apple.xpc.proxy
-      default_field: false
-    - name: process.Ext.dll.code_signature.team_id
-      level: extended
-      type: keyword
-      short: The team identifier used to sign the binary.
-      description: >
-        'The team identifier used to sign the binary.
-
-        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
-
-      example: EQHXZ8M8AV
-      default_field: false
     - name: process.Ext.dll.Ext
       level: custom
       type: object
@@ -952,6 +809,62 @@
       level: custom
       type: unsigned_long
       description: The size of this module's memory mapping, in bytes.
+      default_field: false
+    - name: process.Ext.dll.code_signature.exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: process.Ext.dll.code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
+    - name: process.Ext.dll.code_signature.status
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: process.Ext.dll.code_signature.subject_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: process.Ext.dll.code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      default_field: false
+    - name: process.Ext.dll.code_signature.trusted
+      level: extended
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: process.Ext.dll.code_signature.valid
+      level: extended
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
       default_field: false
     - name: process.Ext.dll.hash.md5
       level: extended
@@ -1455,6 +1368,62 @@
         This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: process.code_signature.exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: process.code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
+    - name: process.code_signature.status
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: process.code_signature.subject_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: process.code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      default_field: false
+    - name: process.code_signature.trusted
+      level: extended
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: process.code_signature.valid
+      level: extended
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      default_field: false
     - name: process.command_line
       level: extended
       type: keyword
@@ -1547,73 +1516,6 @@
         Sometimes called program name or similar.'
       example: ssh
       default_field: false
-    - name: process.parent.code_signature.exists
-      level: core
-      type: boolean
-      description: Boolean to capture if a signature is present.
-      example: "true"
-      default_field: false
-    - name: process.parent.code_signature.subject_name
-      level: extended
-      type: keyword
-      description: Subject name of the code signer
-      example: Microsoft Corporation
-      default_field: false
-    - name: process.parent.code_signature.valid
-      level: extended
-      type: boolean
-      short: Boolean to capture if the digital signature is verified against the binary content.
-      example: "true"
-      description: >
-        Boolean to capture if the digital signature is verified against the binary content.
-
-        Leave unpopulated if a certificate was unchecked.
-
-      default_field: false
-    - name: process.parent.code_signature.trusted
-      level: extended
-      type: boolean
-      short: Stores the trust status of the certificate chain.
-      example: "true"
-      description: >
-        Stores the trust status of the certificate chain.
-
-        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.
-
-      default_field: false
-    - name: process.parent.code_signature.status
-      level: extended
-      type: keyword
-      short: Additional information about the certificate status.
-      description: >
-        Additional information about the certificate status.
-
-        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.
-
-      example: ERROR_UNTRUSTED_ROOT
-      default_field: false
-    - name: process.parent.code_signature.signing_id
-      level: extended
-      type: keyword
-      short: The identifier used to sign the binary.
-      description: >
-        'The identifier used to sign the binary.
-
-        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
-
-      example: com.apple.xpc.proxy
-      default_field: false
-    - name: process.parent.code_signature.team_id
-      level: extended
-      type: keyword
-      short: The team identifier used to sign the binary.
-      description: >
-        'The team identifier used to sign the binary.
-
-        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
-
-      example: EQHXZ8M8AV
-      default_field: false
     - name: process.parent.Ext
       level: custom
       type: object
@@ -1668,73 +1570,6 @@
 
         Leave unpopulated if a certificate was unchecked.'
       example: 'true'
-      default_field: false
-    - name: process.parent.Ext.dll.code_signature.exists
-      level: core
-      type: boolean
-      description: Boolean to capture if a signature is present.
-      example: "true"
-      default_field: false
-    - name: process.parent.Ext.dll.code_signature.subject_name
-      level: extended
-      type: keyword
-      description: Subject name of the code signer
-      example: Microsoft Corporation
-      default_field: false
-    - name: process.parent.Ext.dll.code_signature.valid
-      level: extended
-      type: boolean
-      short: Boolean to capture if the digital signature is verified against the binary content.
-      example: "true"
-      description: >
-        Boolean to capture if the digital signature is verified against the binary content.
-
-        Leave unpopulated if a certificate was unchecked.
-
-      default_field: false
-    - name: process.parent.Ext.dll.code_signature.trusted
-      level: extended
-      type: boolean
-      short: Stores the trust status of the certificate chain.
-      example: "true"
-      description: >
-        Stores the trust status of the certificate chain.
-
-        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.
-
-      default_field: false
-    - name: process.parent.Ext.dll.code_signature.status
-      level: extended
-      type: keyword
-      short: Additional information about the certificate status.
-      description: >
-        Additional information about the certificate status.
-
-        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.
-
-      example: ERROR_UNTRUSTED_ROOT
-      default_field: false
-    - name: process.parent.Ext.dll.code_signature.signing_id
-      level: extended
-      type: keyword
-      short: The identifier used to sign the binary.
-      description: >
-        'The identifier used to sign the binary.
-
-        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
-
-      example: com.apple.xpc.proxy
-      default_field: false
-    - name: process.parent.Ext.dll.code_signature.team_id
-      level: extended
-      type: keyword
-      short: The team identifier used to sign the binary.
-      description: >
-        'The team identifier used to sign the binary.
-
-        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
-
-      example: EQHXZ8M8AV
       default_field: false
     - name: process.parent.Ext.dll.Ext
       level: custom
@@ -1798,6 +1633,62 @@
       level: custom
       type: unsigned_long
       description: The size of this module's memory mapping, in bytes.
+      default_field: false
+    - name: process.parent.Ext.dll.code_signature.exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: process.parent.Ext.dll.code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
+    - name: process.parent.Ext.dll.code_signature.status
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: process.parent.Ext.dll.code_signature.subject_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: process.parent.Ext.dll.code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      default_field: false
+    - name: process.parent.Ext.dll.code_signature.trusted
+      level: extended
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: process.parent.Ext.dll.code_signature.valid
+      level: extended
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
       default_field: false
     - name: process.parent.Ext.dll.hash.md5
       level: extended
@@ -2002,6 +1893,62 @@
 
         This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.'
       example: 4
+      default_field: false
+    - name: process.parent.code_signature.exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: process.parent.code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
+    - name: process.parent.code_signature.status
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: process.parent.code_signature.subject_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: process.parent.code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      default_field: false
+    - name: process.parent.code_signature.trusted
+      level: extended
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: process.parent.code_signature.valid
+      level: extended
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
       default_field: false
     - name: process.parent.command_line
       level: extended
@@ -4362,6 +4309,62 @@
       type: unsigned_long
       description: The size of this module's memory mapping, in bytes.
       default_field: false
+    - name: Ext.dll.code_signature.exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: Ext.dll.code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
+    - name: Ext.dll.code_signature.status
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: Ext.dll.code_signature.subject_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: Ext.dll.code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      default_field: false
+    - name: Ext.dll.code_signature.trusted
+      level: extended
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: Ext.dll.code_signature.valid
+      level: extended
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      default_field: false
     - name: Ext.dll.hash.md5
       level: extended
       type: keyword
@@ -5717,6 +5720,62 @@
       type: unsigned_long
       description: The size of this module's memory mapping, in bytes.
       default_field: false
+    - name: parent.Ext.dll.code_signature.exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: parent.Ext.dll.code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
+    - name: parent.Ext.dll.code_signature.status
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: parent.Ext.dll.code_signature.subject_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: parent.Ext.dll.code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      default_field: false
+    - name: parent.Ext.dll.code_signature.trusted
+      level: extended
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: parent.Ext.dll.code_signature.valid
+      level: extended
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
+      default_field: false
     - name: parent.Ext.dll.hash.md5
       level: extended
       type: keyword
@@ -5920,6 +5979,62 @@
 
         This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.'
       example: 4
+      default_field: false
+    - name: parent.code_signature.exists
+      level: core
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: parent.code_signature.signing_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The identifier used to sign the process.
+
+        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
+      example: com.apple.xpc.proxy
+      default_field: false
+    - name: parent.code_signature.status
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: parent.code_signature.subject_name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: parent.code_signature.team_id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'The team identifier used to sign the process.
+
+        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
+      example: EQHXZ8M8AV
+      default_field: false
+    - name: parent.code_signature.trusted
+      level: extended
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: parent.code_signature.valid
+      level: extended
+      type: boolean
+      description: 'Boolean to capture if the digital signature is verified against the binary content.
+
+        Leave unpopulated if a certificate was unchecked.'
+      example: 'true'
       default_field: false
     - name: parent.command_line
       level: extended

--- a/package/endpoint/data_stream/library/fields/fields.yml
+++ b/package/endpoint/data_stream/library/fields/fields.yml
@@ -596,7 +596,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The identifier used to sign the binary.
+      description: 'The identifier used to sign the process.
 
         This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
       example: com.apple.xpc.proxy
@@ -611,7 +611,7 @@
       example: ERROR_UNTRUSTED_ROOT
       default_field: false
     - name: code_signature.subject_name
-      level: extended
+      level: core
       type: keyword
       ignore_above: 1024
       description: Subject name of the code signer
@@ -621,7 +621,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The team identifier used to sign the binary.
+      description: 'The team identifier used to sign the process.
 
         This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
       example: EQHXZ8M8AV
@@ -983,7 +983,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The identifier used to sign the binary.
+      description: 'The identifier used to sign the process.
 
         This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
       example: com.apple.xpc.proxy
@@ -998,7 +998,7 @@
       example: ERROR_UNTRUSTED_ROOT
       default_field: false
     - name: code_signature.subject_name
-      level: extended
+      level: core
       type: keyword
       ignore_above: 1024
       description: Subject name of the code signer
@@ -1008,7 +1008,7 @@
       level: extended
       type: keyword
       ignore_above: 1024
-      description: 'The team identifier used to sign the binary.
+      description: 'The team identifier used to sign the process.
 
         This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
       example: EQHXZ8M8AV

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -635,49 +635,6 @@
       type: unsigned_long
       description: The size of this module's memory mapping, in bytes.
       default_field: false
-    - name: Ext.dll.Ext.code_signature
-      level: custom
-      type: nested
-      description: Nested version of ECS code_signature fieldset.
-      default_field: false
-    - name: Ext.dll.Ext.code_signature.exists
-      level: custom
-      type: boolean
-      description: Boolean to capture if a signature is present.
-      example: 'true'
-      default_field: false
-    - name: Ext.dll.Ext.code_signature.status
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: 'Additional information about the certificate status.
-
-        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
-      example: ERROR_UNTRUSTED_ROOT
-      default_field: false
-    - name: Ext.dll.Ext.code_signature.subject_name
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: Subject name of the code signer
-      example: Microsoft Corporation
-      default_field: false
-    - name: Ext.dll.Ext.code_signature.trusted
-      level: custom
-      type: boolean
-      description: 'Stores the trust status of the certificate chain.
-
-        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
-      example: 'true'
-      default_field: false
-    - name: Ext.dll.Ext.code_signature.valid
-      level: custom
-      type: boolean
-      description: 'Boolean to capture if the digital signature is verified against the binary content.
-
-        Leave unpopulated if a certificate was unchecked.'
-      example: 'true'
-      default_field: false
     - name: Ext.dll.name
       level: core
       type: keyword
@@ -693,62 +650,6 @@
       ignore_above: 1024
       description: Full file path of the library.
       example: C:\Windows\System32\kernel32.dll
-      default_field: false
-    - name: Ext.dll.code_signature.exists
-      level: core
-      type: boolean
-      description: Boolean to capture if a signature is present.
-      example: 'true'
-      default_field: false
-    - name: Ext.dll.code_signature.signing_id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The identifier used to sign the binary.
-
-        This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.'
-      example: com.apple.xpc.proxy
-      default_field: false
-    - name: Ext.dll.code_signature.status
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Additional information about the certificate status.
-
-        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
-      example: ERROR_UNTRUSTED_ROOT
-      default_field: false
-    - name: Ext.dll.code_signature.subject_name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Subject name of the code signer
-      example: Microsoft Corporation
-      default_field: false
-    - name: Ext.dll.code_signature.team_id
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'The team identifier used to sign the binary.
-
-        This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.'
-      example: EQHXZ8M8AV
-      default_field: false
-    - name: Ext.dll.code_signature.trusted
-      level: extended
-      type: boolean
-      description: 'Stores the trust status of the certificate chain.
-
-        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
-      example: 'true'
-      default_field: false
-    - name: Ext.dll.code_signature.valid
-      level: extended
-      type: boolean
-      description: 'Boolean to capture if the digital signature is verified against the binary content.
-
-        Leave unpopulated if a certificate was unchecked.'
-      example: 'true'
       default_field: false
     - name: Ext.protection
       level: custom

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -88,10 +88,10 @@ sent by the endpoint.
 | Target.dll.Ext.mapped_address | The base address where this module is loaded. | unsigned_long |
 | Target.dll.Ext.mapped_size | The size of this module's memory mapping, in bytes. | unsigned_long |
 | Target.dll.code_signature.exists | Boolean to capture if a signature is present. | boolean |
-| Target.dll.code_signature.signing_id | 'The identifier used to sign the binary. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.' | keyword |
+| Target.dll.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
 | Target.dll.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
 | Target.dll.code_signature.subject_name | Subject name of the code signer | keyword |
-| Target.dll.code_signature.team_id | 'The team identifier used to sign the binary. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.' | keyword |
+| Target.dll.code_signature.team_id | The team identifier used to sign the process. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only. | keyword |
 | Target.dll.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | Target.dll.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | Target.dll.hash.md5 | MD5 hash. | keyword |
@@ -127,10 +127,10 @@ sent by the endpoint.
 | Target.process.Ext.dll.Ext.mapped_address | The base address where this module is loaded. | unsigned_long |
 | Target.process.Ext.dll.Ext.mapped_size | The size of this module's memory mapping, in bytes. | unsigned_long |
 | Target.process.Ext.dll.code_signature.exists | Boolean to capture if a signature is present. | boolean |
-| Target.process.Ext.dll.code_signature.signing_id | 'The identifier used to sign the binary. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.' | keyword |
+| Target.process.Ext.dll.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
 | Target.process.Ext.dll.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
 | Target.process.Ext.dll.code_signature.subject_name | Subject name of the code signer | keyword |
-| Target.process.Ext.dll.code_signature.team_id | 'The team identifier used to sign the binary. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.' | keyword |
+| Target.process.Ext.dll.code_signature.team_id | The team identifier used to sign the process. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only. | keyword |
 | Target.process.Ext.dll.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | Target.process.Ext.dll.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | Target.process.Ext.dll.hash.md5 | MD5 hash. | keyword |
@@ -208,10 +208,10 @@ sent by the endpoint.
 | Target.process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | Target.process.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
 | Target.process.code_signature.exists | Boolean to capture if a signature is present. | boolean |
-| Target.process.code_signature.signing_id | 'The identifier used to sign the binary. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.' | keyword |
+| Target.process.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
 | Target.process.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
 | Target.process.code_signature.subject_name | Subject name of the code signer | keyword |
-| Target.process.code_signature.team_id | 'The team identifier used to sign the binary. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.' | keyword |
+| Target.process.code_signature.team_id | The team identifier used to sign the process. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only. | keyword |
 | Target.process.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | Target.process.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | Target.process.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | keyword |
@@ -242,10 +242,10 @@ sent by the endpoint.
 | Target.process.parent.Ext.dll.Ext.mapped_address | The base address where this module is loaded. | unsigned_long |
 | Target.process.parent.Ext.dll.Ext.mapped_size | The size of this module's memory mapping, in bytes. | unsigned_long |
 | Target.process.parent.Ext.dll.code_signature.exists | Boolean to capture if a signature is present. | boolean |
-| Target.process.parent.Ext.dll.code_signature.signing_id | 'The identifier used to sign the binary. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.' | keyword |
+| Target.process.parent.Ext.dll.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
 | Target.process.parent.Ext.dll.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
 | Target.process.parent.Ext.dll.code_signature.subject_name | Subject name of the code signer | keyword |
-| Target.process.parent.Ext.dll.code_signature.team_id | 'The team identifier used to sign the binary. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.' | keyword |
+| Target.process.parent.Ext.dll.code_signature.team_id | The team identifier used to sign the process. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only. | keyword |
 | Target.process.parent.Ext.dll.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | Target.process.parent.Ext.dll.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | Target.process.parent.Ext.dll.hash.md5 | MD5 hash. | keyword |
@@ -281,10 +281,10 @@ sent by the endpoint.
 | Target.process.parent.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | Target.process.parent.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
 | Target.process.parent.code_signature.exists | Boolean to capture if a signature is present. | boolean |
-| Target.process.parent.code_signature.signing_id | 'The identifier used to sign the binary. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only.' | keyword |
+| Target.process.parent.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
 | Target.process.parent.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
 | Target.process.parent.code_signature.subject_name | Subject name of the code signer | keyword |
-| Target.process.parent.code_signature.team_id | 'The team identifier used to sign the binary. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only.' | keyword |
+| Target.process.parent.code_signature.team_id | The team identifier used to sign the process. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only. | keyword |
 | Target.process.parent.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | Target.process.parent.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | Target.process.parent.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | keyword |
@@ -591,6 +591,13 @@ sent by the endpoint.
 | process.Ext.dll.Ext.compile_time | Timestamp from when the module was compiled. | date |
 | process.Ext.dll.Ext.mapped_address | The base address where this module is loaded. | unsigned_long |
 | process.Ext.dll.Ext.mapped_size | The size of this module's memory mapping, in bytes. | unsigned_long |
+| process.Ext.dll.code_signature.exists | Boolean to capture if a signature is present. | boolean |
+| process.Ext.dll.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
+| process.Ext.dll.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
+| process.Ext.dll.code_signature.subject_name | Subject name of the code signer | keyword |
+| process.Ext.dll.code_signature.team_id | The team identifier used to sign the process. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only. | keyword |
+| process.Ext.dll.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
+| process.Ext.dll.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.Ext.dll.hash.md5 | MD5 hash. | keyword |
 | process.Ext.dll.hash.sha1 | SHA1 hash. | keyword |
 | process.Ext.dll.hash.sha256 | SHA256 hash. | keyword |
@@ -765,6 +772,13 @@ sent by the endpoint.
 | process.parent.Ext.dll.Ext.compile_time | Timestamp from when the module was compiled. | date |
 | process.parent.Ext.dll.Ext.mapped_address | The base address where this module is loaded. | unsigned_long |
 | process.parent.Ext.dll.Ext.mapped_size | The size of this module's memory mapping, in bytes. | unsigned_long |
+| process.parent.Ext.dll.code_signature.exists | Boolean to capture if a signature is present. | boolean |
+| process.parent.Ext.dll.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
+| process.parent.Ext.dll.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
+| process.parent.Ext.dll.code_signature.subject_name | Subject name of the code signer | keyword |
+| process.parent.Ext.dll.code_signature.team_id | The team identifier used to sign the process. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only. | keyword |
+| process.parent.Ext.dll.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
+| process.parent.Ext.dll.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.parent.Ext.dll.hash.md5 | MD5 hash. | keyword |
 | process.parent.Ext.dll.hash.sha1 | SHA1 hash. | keyword |
 | process.parent.Ext.dll.hash.sha256 | SHA256 hash. | keyword |
@@ -797,6 +811,13 @@ sent by the endpoint.
 | process.parent.Ext.user | User associated with the running process. | keyword |
 | process.parent.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.parent.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
+| process.parent.code_signature.exists | Boolean to capture if a signature is present. | boolean |
+| process.parent.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
+| process.parent.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
+| process.parent.code_signature.subject_name | Subject name of the code signer | keyword |
+| process.parent.code_signature.team_id | The team identifier used to sign the process. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only. | keyword |
+| process.parent.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
+| process.parent.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.parent.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | keyword |
 | process.parent.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |
 | process.parent.executable | Absolute path to the process executable. | keyword |
@@ -1995,21 +2016,8 @@ sent by the endpoint.
 | process.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.Ext.defense_evasions | List of defense evasions found in this process. These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior. Examples tools that can cause defense evasions include Process Doppelganging and Process Herpaderping. | keyword |
 | process.Ext.dll.Ext | Object for all custom defined fields to live in. | object |
-| process.Ext.dll.Ext.code_signature | Nested version of ECS code_signature fieldset. | nested |
-| process.Ext.dll.Ext.code_signature.exists | Boolean to capture if a signature is present. | boolean |
-| process.Ext.dll.Ext.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
-| process.Ext.dll.Ext.code_signature.subject_name | Subject name of the code signer | keyword |
-| process.Ext.dll.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
-| process.Ext.dll.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.Ext.dll.Ext.mapped_address | The base address where this module is loaded. | unsigned_long |
 | process.Ext.dll.Ext.mapped_size | The size of this module's memory mapping, in bytes. | unsigned_long |
-| process.Ext.dll.code_signature.exists | Boolean to capture if a signature is present. | boolean |
-| process.Ext.dll.code_signature.signing_id | The identifier used to sign the binary. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
-| process.Ext.dll.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
-| process.Ext.dll.code_signature.subject_name | Subject name of the code signer | keyword |
-| process.Ext.dll.code_signature.team_id | The team identifier used to sign the binary. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only. | keyword |
-| process.Ext.dll.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
-| process.Ext.dll.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.Ext.dll.name | Name of the library. This generally maps to the name of the file on disk. | keyword |
 | process.Ext.dll.path | Full file path of the library. | keyword |
 | process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1659,10 +1659,10 @@ sent by the endpoint.
 | file.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | file.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | file.code_signature.exists | Boolean to capture if a signature is present. | boolean |
-| file.code_signature.signing_id | The identifier used to sign the binary. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
+| file.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
 | file.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
 | file.code_signature.subject_name | Subject name of the code signer | keyword |
-| file.code_signature.team_id | The team identifier used to sign the binary. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only. | keyword |
+| file.code_signature.team_id | The team identifier used to sign the process. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only. | keyword |
 | file.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | file.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | file.hash.md5 | MD5 hash. | keyword |
@@ -1711,10 +1711,10 @@ sent by the endpoint.
 | process.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | process.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.code_signature.exists | Boolean to capture if a signature is present. | boolean |
-| process.code_signature.signing_id | The identifier used to sign the binary. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
+| process.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
 | process.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |
 | process.code_signature.subject_name | Subject name of the code signer | keyword |
-| process.code_signature.team_id | The team identifier used to sign the binary. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only. | keyword |
+| process.code_signature.team_id | The team identifier used to sign the process. This is used to identify the team or vendor of a software product. The field is relevant to Apple *OS only. | keyword |
 | process.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | process.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -1882,6 +1882,78 @@ process.Ext.ancestry:
   normalize: []
   short: An array of entity_ids indicating the ancestors for this event
   type: keyword
+process.Ext.code_signature:
+  dashed_name: process-Ext-code-signature
+  description: Nested version of ECS code_signature fieldset.
+  flat_name: process.Ext.code_signature
+  level: custom
+  name: Ext.code_signature
+  normalize: []
+  short: Nested version of ECS code_signature fieldset.
+  type: nested
+process.Ext.code_signature.exists:
+  dashed_name: process-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: process.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
+process.Ext.code_signature.status:
+  dashed_name: process-Ext-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: process.Ext.code_signature.status
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.status
+  normalize: []
+  short: Additional information about the certificate status.
+  type: keyword
+process.Ext.code_signature.subject_name:
+  dashed_name: process-Ext-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: process.Ext.code_signature.subject_name
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.subject_name
+  normalize: []
+  short: Subject name of the code signer
+  type: keyword
+process.Ext.code_signature.trusted:
+  dashed_name: process-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: process.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+process.Ext.code_signature.valid:
+  dashed_name: process-Ext-code-signature-valid
+  description: 'Boolean to capture if the digital signature is verified against the
+    binary content.
+
+    Leave unpopulated if a certificate was unchecked.'
+  example: 'true'
+  flat_name: process.Ext.code_signature.valid
+  level: custom
+  name: Ext.code_signature.valid
+  normalize: []
+  short: Boolean to capture if the digital signature is verified against the binary
+    content.
+  type: boolean
 process.code_signature.exists:
   dashed_name: process-code-signature-exists
   description: Boolean to capture if a signature is present.


### PR DESCRIPTION
## Change Summary

Two things happened here:

1. There was a yaml-spacing error in `library` index, so now `process.Ext.code_signature` had its spacing fix, and build files regenerated
2. The build system was not copying over some older changes. No amount of `make` would pick these up. But deleting `alerts/fields/fields.yml` along with `library` and `process` finally picked up these changes.

Further discussion on preventing the second item from missing things is captured in #251 


## Release Target

8.3

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed any generated files (in `schema/`, `generated/`)
- [ ] ~~If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))~~
- [ ] ~~If this is a `metadata` change, I also updated both transform destination schemas to match~~

### For Transform changes:

- [ ] ~~The new transform successfully starts in Kibana~~
- [ ] ~~The corresponding transform destination schema was updated if necessary~~
