### PR TITLE
Disable default Lint in make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ endif
 
 all: $(VENV_DIR) $(ECS_TAG_REF) $(PKG_FIELDS_TARGETS) $(DOC_TARGET) $(ESTC_PKG_BIN) $(SCHEMA_TARGETS) $(ECS_FLAT_TARGETS) $(ES_7_TARGETS)
 	cd $(PKG_DIR) && $(ESTC_PKG_BIN) format
-	cd $(PKG_DIR) && $(ESTC_PKG_BIN) lint
 
 mac-deps:
 	@echo Installing gsed for mac


### PR DESCRIPTION
## Change Summary

Until such time that this package is brought into spec, the linter will fail. The problems have expanded past the changelog entry. For now, `lint` is being removed as a default `make` step so that the package will build without error (when linting is the sole error source).

Linting is being sorted out separately, and will be added to the CI system, so it is likely less necessary to have it as _part_ of the build step, but will be available as `make lint` to test locally, when it is working


This addresses problems like #236 