### PR TITLE
ignore _dev dirs for package-storage PR

### DIFF
--- a/scripts/release_manager/main.py
+++ b/scripts/release_manager/main.py
@@ -109,7 +109,8 @@ def create_pr(env, version, package_dir, package_storage_path):
     os.makedirs(endpoint_path, exist_ok=True)
 
     click.echo('Copying package to: {}'.format(package_ver_path))
-    shutil.copytree(os.path.join(package_dir, 'endpoint') + os.path.sep, package_ver_path)
+    ignored_patterns = shutil.ignore_patterns('_dev*')
+    shutil.copytree(os.path.join(package_dir, 'endpoint') + os.path.sep, package_ver_path, ignore=ignored_patterns)
     repo.git.add(package_ver_path)
     repo.git.commit(m='Adding endpoint package version {}'.format(version))
     repo.git.push(branch_name, u='origin')


### PR DESCRIPTION
## Change Summary

Ignore `_dev` dirs when creating PR to `package-storage` due to new `package-spec` restriction. Attempted to switch to `elastic-package publish` but `package-spec` currently doesn't have `transform` or `index_template` in the spec so we'll need to add those in before we can make this switch ([though there is an open PR to add transform to spec](https://github.com/elastic/package-spec/pull/307)).