### PR TITLE
Relative file creation times for Process and DLL events

### DIFF
--- a/custom_schemas/custom_dll.yml
+++ b/custom_schemas/custom_dll.yml
@@ -108,6 +108,14 @@
         List of defense evasions found for this DLL.
         These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior.
         Examples tools that can cause defense evasions include KnownDlls hijacking and PPLDump.
+        
+    - name: Ext.file_age
+      level: custom
+      type: double
+      short: Number of seconds since the DLL's file was last modified.
+      description: >
+        Number of seconds since the DLL's file was last modified.
+        This number may be negative if the file's timestamp is in the future.
 
     - name: Ext.device.bus_type
       level: custom

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -352,6 +352,14 @@
         List of defense evasions found in this process.
         These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior.
         Examples tools that can cause defense evasions include Process Doppelganging and Process Herpaderping.
+        
+    - name: Ext.file_age
+      level: custom
+      type: double
+      short: Number of seconds since the executable's file was last modified.
+      description: >
+        Number of seconds since the executable's file was last modified.
+        This number may be negative if the file's timestamp is in the future.
 
     - name: Ext.protection
       level: custom

--- a/custom_subsets/elastic_endpoint/library/library.yaml
+++ b/custom_subsets/elastic_endpoint/library/library.yaml
@@ -210,3 +210,4 @@ fields:
              product_id: {}
              serial_number: {}
              vendor_id: {}
+          file_age: {}

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -175,6 +175,7 @@ fields:
               name: {}
               executable: {}
               entity_id: {}
+          file_age: {}
           protection: {}
           session: {}
           token:

--- a/package/endpoint/data_stream/library/fields/fields.yml
+++ b/package/endpoint/data_stream/library/fields/fields.yml
@@ -267,6 +267,11 @@
       ignore_above: 1024
       description: VendorID of the device. It is provided by the vendor of the device.
       default_field: false
+    - name: Ext.file_age
+      level: custom
+      type: double
+      description: Number of seconds since the DLL's file was last modified. This number may be negative if the file's timestamp is in the future.
+      default_field: false
     - name: Ext.load_index
       level: custom
       type: unsigned_long

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -843,6 +843,11 @@
       description: Process ID.
       example: 4242
       default_field: false
+    - name: Ext.file_age
+      level: custom
+      type: double
+      description: Number of seconds since the executable's file was last modified. This number may be negative if the file's timestamp is in the future.
+      default_field: false
     - name: Ext.protection
       level: custom
       type: keyword

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1655,6 +1655,7 @@ sent by the endpoint.
 | dll.Ext.device.product_id | ProductID of the device. It is provided by the vendor of the device if any. | keyword |
 | dll.Ext.device.serial_number | Serial Number of the device. It is provided by the vendor of the device if any. | keyword |
 | dll.Ext.device.vendor_id | VendorID of the device. It is provided by the vendor of the device. | keyword |
+| dll.Ext.file_age | Number of seconds since the DLL's file was last modified. This number may be negative if the file's timestamp is in the future. | double |
 | dll.Ext.load_index | A DLL can be loaded into a process multiple times. This field indicates the Nth time that this DLL has been loaded. The first load index is 1. | unsigned_long |
 | dll.code_signature.exists | Boolean to capture if a signature is present. | boolean |
 | dll.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
@@ -2065,6 +2066,7 @@ sent by the endpoint.
 | process.Ext.effective_parent.executable | Executable name for the effective process. | keyword |
 | process.Ext.effective_parent.name | Process name for the effective process. | keyword |
 | process.Ext.effective_parent.pid | Process ID. | long |
+| process.Ext.file_age | Number of seconds since the executable's file was last modified. This number may be negative if the file's timestamp is in the future. | double |
 | process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | process.Ext.session | Session information for the current process | keyword |
 | process.Ext.token.elevation | Whether the token is elevated or not | boolean |

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -383,6 +383,16 @@ dll.Ext.device.vendor_id:
   normalize: []
   short: VendorID of the device.
   type: keyword
+dll.Ext.file_age:
+  dashed_name: dll-Ext-file-age
+  description: Number of seconds since the DLL's file was last modified. This number
+    may be negative if the file's timestamp is in the future.
+  flat_name: dll.Ext.file_age
+  level: custom
+  name: Ext.file_age
+  normalize: []
+  short: Number of seconds since the DLL's file was last modified.
+  type: double
 dll.Ext.load_index:
   dashed_name: dll-Ext-load-index
   description: 'A DLL can be loaded into a process multiple times. This field indicates

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1511,6 +1511,16 @@ process.Ext.effective_parent.pid:
   original_fieldset: Effective_process
   short: Process ID.
   type: long
+process.Ext.file_age:
+  dashed_name: process-Ext-file-age
+  description: Number of seconds since the executable's file was last modified. This
+    number may be negative if the file's timestamp is in the future.
+  flat_name: process.Ext.file_age
+  level: custom
+  name: Ext.file_age
+  normalize: []
+  short: Number of seconds since the executable's file was last modified.
+  type: double
 process.Ext.protection:
   dashed_name: process-Ext-protection
   description: Indicates the protection level of this process.  Uses the same syntax


### PR DESCRIPTION
## Change Summary

DRAFT.  DO NOT REVIEW YET.

Add the EXE/DLL file's age to process and DLL events.


### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json


```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes