### PR TITLE
add attack_surface_reduction

### DIFF
--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -228,6 +228,18 @@
         but not a simple sum of the actions
       short: overall status of behavior_protection
 
+    - name: policy.applied.response.configurations.attack_surface_reduction.concerned_actions
+      level: custom
+      type: keyword
+      description: all actions that were taken for attack surface reduction
+
+    - name: policy.applied.response.configurations.attack_surface_reduction.status
+      level: custom
+      type: keyword
+      description: >
+        the overall status of attack surface reduction, this is correlated to the status of
+        concerned actions but not a simple sum of the actions
+      short: overall status of attack surface reduction
 
     - name: policy.applied.response.diagnostic
       level: custom

--- a/package/endpoint/data_stream/policy/fields/fields.yml
+++ b/package/endpoint/data_stream/policy/fields/fields.yml
@@ -182,6 +182,18 @@
       ignore_above: 1024
       description: the overall status of antivirus registration, this is correlated to the status of concerned actions but  not a simple sum of the actions
       default_field: false
+    - name: policy.applied.response.configurations.attack_surface_reduction.concerned_actions
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: all actions that were taken for attack surface reduction
+      default_field: false
+    - name: policy.applied.response.configurations.attack_surface_reduction.status
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: the overall status of attack surface reduction, this is correlated to the status of concerned actions but not a simple sum of the actions
+      default_field: false
     - name: policy.applied.response.configurations.behavior_protection.concerned_actions
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/policy/sample_event.json
+++ b/package/endpoint/data_stream/policy/sample_event.json
@@ -157,6 +157,19 @@
                                 "detect_thread_events"
                             ],
                             "status": "success"
+                        },
+                        "attack_surface_reduction": {
+                            "concerned_actions": [
+                                "agent_connectivity",
+                                "configure_credential_hardening",
+                                "download_global_artifacts",
+                                "download_user_artifacts",
+                                "workflow",
+                                "load_config",
+                                "configure_kernel",
+                                "connect_kernel"
+                            ],
+                            "status": "success"
                         }
                     },
                     "diagnostic": {
@@ -434,6 +447,11 @@
                     {
                         "name": "workflow",
                         "message": "Successfully executed all workflows",
+                        "status": "success"
+                    },
+                    {
+                        "name": "configure_credential_hardening",
+                        "message": "Successfully configured credential hardening",
                         "status": "success"
                     }
                 ],

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -287,6 +287,27 @@ Endpoint.policy.applied.response.configurations.antivirus_registration.status:
   normalize: []
   short: the overall status of antivirus registration
   type: keyword
+Endpoint.policy.applied.response.configurations.attack_surface_reduction.concerned_actions:
+  dashed_name: Endpoint-policy-applied-response-configurations-attack-surface-reduction-concerned-actions
+  description: all actions that were taken for attack surface reduction
+  flat_name: Endpoint.policy.applied.response.configurations.attack_surface_reduction.concerned_actions
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.response.configurations.attack_surface_reduction.concerned_actions
+  normalize: []
+  short: all actions that were taken for attack surface reduction
+  type: keyword
+Endpoint.policy.applied.response.configurations.attack_surface_reduction.status:
+  dashed_name: Endpoint-policy-applied-response-configurations-attack-surface-reduction-status
+  description: the overall status of attack surface reduction, this is correlated
+    to the status of concerned actions but not a simple sum of the actions
+  flat_name: Endpoint.policy.applied.response.configurations.attack_surface_reduction.status
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.response.configurations.attack_surface_reduction.status
+  normalize: []
+  short: overall status of attack surface reduction
+  type: keyword
 Endpoint.policy.applied.response.configurations.behavior_protection.concerned_actions:
   dashed_name: Endpoint-policy-applied-response-configurations-behavior-protection-concerned-actions
   description: all actions that were taken for behavior_protection


### PR DESCRIPTION
## Change Summary

Endpoint is adding a new protection on Windows in 8.4, this is the associated policy response configuration for it.

cc @calladoum-elastic @magermark 

### Sample values

This is pretty standard stuff, but I updated the sample doc which can be checked out.

Sample document:

This is pretty standard stuff, but I updated the sample doc which can be checked out.

## Release Target

8.4

## Q/A

N/A

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
