### PR TITLE
add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The security onboarding team manages this package.
+* @elastic/security-onboarding-and-lifecycle-mgt


### PR DESCRIPTION
## Change Summary

set codeowners to OLM team so we can require team approval on PRs

---

pushes *and* merges to `master` branch now come with auto-deployment. So this is a step to lock-down access or accidental merges from being deployed live without intention. Without this, 1 approval from any person would be sufficient to merge