### PR TITLE
Add release branches to deploy instructions

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -96,7 +96,11 @@ pipeline {
     }
     stage('Publish') {
       when {
-        branch 'master'
+        anyOf {
+          branch 'master';
+          branch pattern: '[78]\\.\\d+',
+                 comparator: 'REGEXP'
+        }
       }
       steps {
         withGithubNotify(context: "Publish") {


### PR DESCRIPTION
## Change Summary

This sets up auto-publishing from our release branches to package-storage v2.


So now, to publish some changes that need to be backported to package in the`8.2` series, for example:

- make commits and merge to `master` as usual (this then gets auto-published to latest package)
- backport to `8.2` branch similar to the `kibana` repo flow
- when merged into `8.2` branch, the prerelease (`8.2.1-dev.1`) is then auto-published and can be tested
- to production-deploy, a commit that sets the version on `8.2` branch to `v8.2.1` then cuts a full production release.
