### PR TITLE
replace file.Ext.* with existing fields within alerts

### DIFF
--- a/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
@@ -186,7 +186,73 @@ fields:
                   type: {}
                   uid: {}
                   Ext:
-                    fields: "*"
+                    fields:
+                      code_signature:
+                        fields:
+                          exists: {}
+                          status: {}
+                          subject_name: {}
+                          trusted: {}
+                          valid: {}
+                      device:
+                        fields:
+                          bus_type: {}
+                          dos_name: {}
+                          nt_name: {}
+                          product_id: {}
+                          serial_number: {}
+                          vendor_id: {}
+                      entropy: {}
+                      entry_modified: {}
+                      header_bytes: {}
+                      header_data: {}
+                      malware_classification:
+                        fields:
+                          features:
+                            fields:
+                              data:
+                                fields:
+                                  buffer: {}
+                                  decompressed_size: {}
+                                  encoding: {}
+                          identifier: {}
+                          score: {}
+                          threshold: {}
+                          upx_packed: {}
+                          version: {}
+                      malware_signature:
+                        fields:
+                          all_names: {}
+                          identifier: {}
+                          primary:
+                            fields:
+                              matches: {}
+                              signature:
+                                fields:
+                                  hash:
+                                    fields:
+                                      sha256: {}
+                                  id: {}
+                                  name: {}
+                          secondary: {}
+                          version: {}
+                      monotonic_id: {}
+                      original:
+                        fields:
+                          gid: {}
+                          group: {}
+                          mode: {}
+                          name: {}
+                          owner: {}
+                          path: {}
+                          uid: {}
+                      quarantine_message: {}
+                      quarantine_path: {}
+                      quarantine_result: {}
+                      temp_file_path: {}
+                      windows:
+                        fields:
+                          zone_identifier: {}
               first_seen: {}
               last_seen: {}
               geo:

--- a/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
@@ -268,7 +268,73 @@ fields:
           file:
             fields:
               Ext:
-                fields: "*"
+                fields:
+                  code_signature:
+                    fields:
+                      exists: {}
+                      status: {}
+                      subject_name: {}
+                      trusted: {}
+                      valid: {}
+                  device:
+                    fields:
+                      bus_type: {}
+                      dos_name: {}
+                      nt_name: {}
+                      product_id: {}
+                      serial_number: {}
+                      vendor_id: {}
+                  entropy: {}
+                  entry_modified: {}
+                  header_bytes: {}
+                  header_data: {}
+                  malware_classification:
+                    fields:
+                      features:
+                        fields:
+                          data:
+                            fields:
+                              buffer: {}
+                              decompressed_size: {}
+                              encoding: {}
+                      identifier: {}
+                      score: {}
+                      threshold: {}
+                      upx_packed: {}
+                      version: {}
+                  malware_signature:
+                    fields:
+                      all_names: {}
+                      identifier: {}
+                      primary:
+                        fields:
+                          matches: {}
+                          signature:
+                            fields:
+                              hash:
+                                fields:
+                                  sha256: {}
+                              id: {}
+                              name: {}
+                      secondary: {}
+                      version: {}
+                  monotonic_id: {}
+                  original:
+                    fields:
+                      gid: {}
+                      group: {}
+                      mode: {}
+                      name: {}
+                      owner: {}
+                      path: {}
+                      uid: {}
+                  quarantine_message: {}
+                  quarantine_path: {}
+                  quarantine_result: {}
+                  temp_file_path: {}
+                  windows:
+                    fields:
+                      zone_identifier: {}
               accessed: {}
               attributes: {}
               code_signature:

--- a/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
@@ -316,7 +316,73 @@ fields:
           file:
             fields:
               Ext:
-                fields: "*"
+                fields:
+                  code_signature:
+                    fields:
+                      exists: {}
+                      status: {}
+                      subject_name: {}
+                      trusted: {}
+                      valid: {}
+                  device:
+                    fields:
+                      bus_type: {}
+                      dos_name: {}
+                      nt_name: {}
+                      product_id: {}
+                      serial_number: {}
+                      vendor_id: {}
+                  entropy: {}
+                  entry_modified: {}
+                  header_bytes: {}
+                  header_data: {}
+                  malware_classification:
+                    fields:
+                      features:
+                        fields:
+                          data:
+                            fields:
+                              buffer: {}
+                              decompressed_size: {}
+                              encoding: {}
+                      identifier: {}
+                      score: {}
+                      threshold: {}
+                      upx_packed: {}
+                      version: {}
+                  malware_signature:
+                    fields:
+                      all_names: {}
+                      identifier: {}
+                      primary:
+                        fields:
+                          matches: {}
+                          signature:
+                            fields:
+                              hash:
+                                fields:
+                                  sha256: {}
+                              id: {}
+                              name: {}
+                      secondary: {}
+                      version: {}
+                  monotonic_id: {}
+                  original:
+                    fields:
+                      gid: {}
+                      group: {}
+                      mode: {}
+                      name: {}
+                      owner: {}
+                      path: {}
+                      uid: {}
+                  quarantine_message: {}
+                  quarantine_path: {}
+                  quarantine_result: {}
+                  temp_file_path: {}
+                  windows:
+                    fields:
+                      zone_identifier: {}
               accessed: {}
               attributes: {}
               code_signature:

--- a/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
@@ -168,7 +168,73 @@ fields:
                   type: {}
                   uid: {}
                   Ext:
-                    fields: "*"
+                    fields:
+                      code_signature:
+                        fields:
+                          exists: {}
+                          status: {}
+                          subject_name: {}
+                          trusted: {}
+                          valid: {}
+                      device:
+                        fields:
+                          bus_type: {}
+                          dos_name: {}
+                          nt_name: {}
+                          product_id: {}
+                          serial_number: {}
+                          vendor_id: {}
+                      entropy: {}
+                      entry_modified: {}
+                      header_bytes: {}
+                      header_data: {}
+                      malware_classification:
+                        fields:
+                          features:
+                            fields:
+                              data:
+                                fields:
+                                  buffer: {}
+                                  decompressed_size: {}
+                                  encoding: {}
+                          identifier: {}
+                          score: {}
+                          threshold: {}
+                          upx_packed: {}
+                          version: {}
+                      malware_signature:
+                        fields:
+                          all_names: {}
+                          identifier: {}
+                          primary:
+                            fields:
+                              matches: {}
+                              signature:
+                                fields:
+                                  hash:
+                                    fields:
+                                      sha256: {}
+                                  id: {}
+                                  name: {}
+                          secondary: {}
+                          version: {}
+                      monotonic_id: {}
+                      original:
+                        fields:
+                          gid: {}
+                          group: {}
+                          mode: {}
+                          name: {}
+                          owner: {}
+                          path: {}
+                          uid: {}
+                      quarantine_message: {}
+                      quarantine_path: {}
+                      quarantine_result: {}
+                      temp_file_path: {}
+                      windows:
+                        fields:
+                          zone_identifier: {}
               first_seen: {}
               last_seen: {}
               geo:

--- a/custom_subsets/elastic_endpoint/alerts/ransomware_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/ransomware_event.yaml
@@ -168,7 +168,73 @@ fields:
                   type: {}
                   uid: {}
                   Ext:
-                    fields: "*"
+                    fields:
+                      code_signature:
+                        fields:
+                          exists: {}
+                          status: {}
+                          subject_name: {}
+                          trusted: {}
+                          valid: {}
+                      device:
+                        fields:
+                          bus_type: {}
+                          dos_name: {}
+                          nt_name: {}
+                          product_id: {}
+                          serial_number: {}
+                          vendor_id: {}
+                      entropy: {}
+                      entry_modified: {}
+                      header_bytes: {}
+                      header_data: {}
+                      malware_classification:
+                        fields:
+                          features:
+                            fields:
+                              data:
+                                fields:
+                                  buffer: {}
+                                  decompressed_size: {}
+                                  encoding: {}
+                          identifier: {}
+                          score: {}
+                          threshold: {}
+                          upx_packed: {}
+                          version: {}
+                      malware_signature:
+                        fields:
+                          all_names: {}
+                          identifier: {}
+                          primary:
+                            fields:
+                              matches: {}
+                              signature:
+                                fields:
+                                  hash:
+                                    fields:
+                                      sha256: {}
+                                  id: {}
+                                  name: {}
+                          secondary: {}
+                          version: {}
+                      monotonic_id: {}
+                      original:
+                        fields:
+                          gid: {}
+                          group: {}
+                          mode: {}
+                          name: {}
+                          owner: {}
+                          path: {}
+                          uid: {}
+                      quarantine_message: {}
+                      quarantine_path: {}
+                      quarantine_result: {}
+                      temp_file_path: {}
+                      windows:
+                        fields:
+                          zone_identifier: {}
               first_seen: {}
               last_seen: {}
               geo:
@@ -250,7 +316,73 @@ fields:
           file:
             fields:
               Ext:
-                fields: "*"
+                fields:
+                  code_signature:
+                    fields:
+                      exists: {}
+                      status: {}
+                      subject_name: {}
+                      trusted: {}
+                      valid: {}
+                  device:
+                    fields:
+                      bus_type: {}
+                      dos_name: {}
+                      nt_name: {}
+                      product_id: {}
+                      serial_number: {}
+                      vendor_id: {}
+                  entropy: {}
+                  entry_modified: {}
+                  header_bytes: {}
+                  header_data: {}
+                  malware_classification:
+                    fields:
+                      features:
+                        fields:
+                          data:
+                            fields:
+                              buffer: {}
+                              decompressed_size: {}
+                              encoding: {}
+                      identifier: {}
+                      score: {}
+                      threshold: {}
+                      upx_packed: {}
+                      version: {}
+                  malware_signature:
+                    fields:
+                      all_names: {}
+                      identifier: {}
+                      primary:
+                        fields:
+                          matches: {}
+                          signature:
+                            fields:
+                              hash:
+                                fields:
+                                  sha256: {}
+                              id: {}
+                              name: {}
+                      secondary: {}
+                      version: {}
+                  monotonic_id: {}
+                  original:
+                    fields:
+                      gid: {}
+                      group: {}
+                      mode: {}
+                      name: {}
+                      owner: {}
+                      path: {}
+                      uid: {}
+                  quarantine_message: {}
+                  quarantine_path: {}
+                  quarantine_result: {}
+                  temp_file_path: {}
+                  windows:
+                    fields:
+                      zone_identifier: {}
               accessed: {}
               attributes: {}
               code_signature:

--- a/custom_subsets/elastic_endpoint/alerts/rule_detection_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/rule_detection_event.yaml
@@ -72,7 +72,73 @@ fields:
                   type: {}
                   uid: {}
                   Ext:
-                    fields: "*"
+                    fields:
+                      code_signature:
+                        fields:
+                          exists: {}
+                          status: {}
+                          subject_name: {}
+                          trusted: {}
+                          valid: {}
+                      device:
+                        fields:
+                          bus_type: {}
+                          dos_name: {}
+                          nt_name: {}
+                          product_id: {}
+                          serial_number: {}
+                          vendor_id: {}
+                      entropy: {}
+                      entry_modified: {}
+                      header_bytes: {}
+                      header_data: {}
+                      malware_classification:
+                        fields:
+                          features:
+                            fields:
+                              data:
+                                fields:
+                                  buffer: {}
+                                  decompressed_size: {}
+                                  encoding: {}
+                          identifier: {}
+                          score: {}
+                          threshold: {}
+                          upx_packed: {}
+                          version: {}
+                      malware_signature:
+                        fields:
+                          all_names: {}
+                          identifier: {}
+                          primary:
+                            fields:
+                              matches: {}
+                              signature:
+                                fields:
+                                  hash:
+                                    fields:
+                                      sha256: {}
+                                  id: {}
+                                  name: {}
+                          secondary: {}
+                          version: {}
+                      monotonic_id: {}
+                      original:
+                        fields:
+                          gid: {}
+                          group: {}
+                          mode: {}
+                          name: {}
+                          owner: {}
+                          path: {}
+                          uid: {}
+                      quarantine_message: {}
+                      quarantine_path: {}
+                      quarantine_result: {}
+                      temp_file_path: {}
+                      windows:
+                        fields:
+                          zone_identifier: {}
               first_seen: {}
               last_seen: {}
               geo:
@@ -154,7 +220,73 @@ fields:
           file:
             fields:
               Ext:
-                fields: "*"
+                fields:
+                  code_signature:
+                    fields:
+                      exists: {}
+                      status: {}
+                      subject_name: {}
+                      trusted: {}
+                      valid: {}
+                  device:
+                    fields:
+                      bus_type: {}
+                      dos_name: {}
+                      nt_name: {}
+                      product_id: {}
+                      serial_number: {}
+                      vendor_id: {}
+                  entropy: {}
+                  entry_modified: {}
+                  header_bytes: {}
+                  header_data: {}
+                  malware_classification:
+                    fields:
+                      features:
+                        fields:
+                          data:
+                            fields:
+                              buffer: {}
+                              decompressed_size: {}
+                              encoding: {}
+                      identifier: {}
+                      score: {}
+                      threshold: {}
+                      upx_packed: {}
+                      version: {}
+                  malware_signature:
+                    fields:
+                      all_names: {}
+                      identifier: {}
+                      primary:
+                        fields:
+                          matches: {}
+                          signature:
+                            fields:
+                              hash:
+                                fields:
+                                  sha256: {}
+                              id: {}
+                              name: {}
+                      secondary: {}
+                      version: {}
+                  monotonic_id: {}
+                  original:
+                    fields:
+                      gid: {}
+                      group: {}
+                      mode: {}
+                      name: {}
+                      owner: {}
+                      path: {}
+                      uid: {}
+                  quarantine_message: {}
+                  quarantine_path: {}
+                  quarantine_result: {}
+                  temp_file_path: {}
+                  windows:
+                    fields:
+                      zone_identifier: {}
               accessed: {}
               attributes: {}
               code_signature:

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -7678,14 +7678,6 @@
       ignore_above: 1024
       description: VendorID of the device. It is provided by the vendor of the device.
       default_field: false
-    - name: enrichments.indicator.file.Ext.device.volume_device_type
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: 'Volume device type.
-
-        Following are examples of the most frequently seen volume device types: Disk File System CD-ROM File System'
-      default_field: false
     - name: enrichments.indicator.file.Ext.entropy
       level: custom
       type: double
@@ -9066,14 +9058,6 @@
       type: keyword
       ignore_above: 1024
       description: VendorID of the device. It is provided by the vendor of the device.
-      default_field: false
-    - name: indicator.file.Ext.device.volume_device_type
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: 'Volume device type.
-
-        Following are examples of the most frequently seen volume device types: Disk File System CD-ROM File System'
       default_field: false
     - name: indicator.file.Ext.entropy
       level: custom

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1016,7 +1016,6 @@ sent by the endpoint.
 | threat.enrichments.indicator.file.Ext.device.product_id | ProductID of the device. It is provided by the vendor of the device if any. | keyword |
 | threat.enrichments.indicator.file.Ext.device.serial_number | Serial Number of the device. It is provided by the vendor of the device if any. | keyword |
 | threat.enrichments.indicator.file.Ext.device.vendor_id | VendorID of the device. It is provided by the vendor of the device. | keyword |
-| threat.enrichments.indicator.file.Ext.device.volume_device_type | Volume device type. Following are examples of the most frequently seen volume device types: Disk File System CD-ROM File System | keyword |
 | threat.enrichments.indicator.file.Ext.entropy | Entropy calculation of file's header and footer used to check file integrity. | double |
 | threat.enrichments.indicator.file.Ext.entry_modified | Time of last status change.  See `st_ctim` member of `struct stat`. | double |
 | threat.enrichments.indicator.file.Ext.header_bytes | First 16 bytes of file used to check file integrity. | keyword |
@@ -1220,7 +1219,6 @@ sent by the endpoint.
 | threat.indicator.file.Ext.device.product_id | ProductID of the device. It is provided by the vendor of the device if any. | keyword |
 | threat.indicator.file.Ext.device.serial_number | Serial Number of the device. It is provided by the vendor of the device if any. | keyword |
 | threat.indicator.file.Ext.device.vendor_id | VendorID of the device. It is provided by the vendor of the device. | keyword |
-| threat.indicator.file.Ext.device.volume_device_type | Volume device type. Following are examples of the most frequently seen volume device types: Disk File System CD-ROM File System | keyword |
 | threat.indicator.file.Ext.entropy | Entropy calculation of file's header and footer used to check file integrity. | double |
 | threat.indicator.file.Ext.entry_modified | Time of last status change.  See `st_ctim` member of `struct stat`. | double |
 | threat.indicator.file.Ext.header_bytes | First 16 bytes of file used to check file integrity. | keyword |

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -7654,20 +7654,6 @@ threat.enrichments.indicator.file.Ext.device.vendor_id:
   original_fieldset: file
   short: VendorID of the device.
   type: keyword
-threat.enrichments.indicator.file.Ext.device.volume_device_type:
-  dashed_name: threat-enrichments-indicator-file-Ext-device-volume-device-type
-  description: 'Volume device type.
-
-    Following are examples of the most frequently seen volume device types: Disk File
-    System CD-ROM File System'
-  flat_name: threat.enrichments.indicator.file.Ext.device.volume_device_type
-  ignore_above: 1024
-  level: custom
-  name: Ext.device.volume_device_type
-  normalize: []
-  original_fieldset: file
-  short: Volume device type.
-  type: keyword
 threat.enrichments.indicator.file.Ext.entropy:
   dashed_name: threat-enrichments-indicator-file-Ext-entropy
   description: Entropy calculation of file's header and footer used to check file

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -10195,20 +10195,6 @@ threat.indicator.file.Ext.device.vendor_id:
   original_fieldset: file
   short: VendorID of the device.
   type: keyword
-threat.indicator.file.Ext.device.volume_device_type:
-  dashed_name: threat-indicator-file-Ext-device-volume-device-type
-  description: 'Volume device type.
-
-    Following are examples of the most frequently seen volume device types: Disk File
-    System CD-ROM File System'
-  flat_name: threat.indicator.file.Ext.device.volume_device_type
-  ignore_above: 1024
-  level: custom
-  name: Ext.device.volume_device_type
-  normalize: []
-  original_fieldset: file
-  short: Volume device type.
-  type: keyword
 threat.indicator.file.Ext.entropy:
   dashed_name: threat-indicator-file-Ext-entropy
   description: Entropy calculation of file's header and footer used to check file

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -11694,20 +11694,6 @@ threat.indicator.file.Ext.device.vendor_id:
   original_fieldset: file
   short: VendorID of the device.
   type: keyword
-threat.indicator.file.Ext.device.volume_device_type:
-  dashed_name: threat-indicator-file-Ext-device-volume-device-type
-  description: 'Volume device type.
-
-    Following are examples of the most frequently seen volume device types: Disk File
-    System CD-ROM File System'
-  flat_name: threat.indicator.file.Ext.device.volume_device_type
-  ignore_above: 1024
-  level: custom
-  name: Ext.device.volume_device_type
-  normalize: []
-  original_fieldset: file
-  short: Volume device type.
-  type: keyword
 threat.indicator.file.Ext.entropy:
   dashed_name: threat-indicator-file-Ext-entropy
   description: Entropy calculation of file's header and footer used to check file

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -9167,20 +9167,6 @@ threat.enrichments.indicator.file.Ext.device.vendor_id:
   original_fieldset: file
   short: VendorID of the device.
   type: keyword
-threat.enrichments.indicator.file.Ext.device.volume_device_type:
-  dashed_name: threat-enrichments-indicator-file-Ext-device-volume-device-type
-  description: 'Volume device type.
-
-    Following are examples of the most frequently seen volume device types: Disk File
-    System CD-ROM File System'
-  flat_name: threat.enrichments.indicator.file.Ext.device.volume_device_type
-  ignore_above: 1024
-  level: custom
-  name: Ext.device.volume_device_type
-  normalize: []
-  original_fieldset: file
-  short: Volume device type.
-  type: keyword
 threat.enrichments.indicator.file.Ext.entropy:
   dashed_name: threat-enrichments-indicator-file-Ext-entropy
   description: Entropy calculation of file's header and footer used to check file

--- a/schemas/v1/alerts/ransomware_event.yaml
+++ b/schemas/v1/alerts/ransomware_event.yaml
@@ -4470,20 +4470,6 @@ threat.enrichments.indicator.file.Ext.device.vendor_id:
   original_fieldset: file
   short: VendorID of the device.
   type: keyword
-threat.enrichments.indicator.file.Ext.device.volume_device_type:
-  dashed_name: threat-enrichments-indicator-file-Ext-device-volume-device-type
-  description: 'Volume device type.
-
-    Following are examples of the most frequently seen volume device types: Disk File
-    System CD-ROM File System'
-  flat_name: threat.enrichments.indicator.file.Ext.device.volume_device_type
-  ignore_above: 1024
-  level: custom
-  name: Ext.device.volume_device_type
-  normalize: []
-  original_fieldset: file
-  short: Volume device type.
-  type: keyword
 threat.enrichments.indicator.file.Ext.entropy:
   dashed_name: threat-enrichments-indicator-file-Ext-entropy
   description: Entropy calculation of file's header and footer used to check file
@@ -7010,20 +6996,6 @@ threat.indicator.file.Ext.device.vendor_id:
   normalize: []
   original_fieldset: file
   short: VendorID of the device.
-  type: keyword
-threat.indicator.file.Ext.device.volume_device_type:
-  dashed_name: threat-indicator-file-Ext-device-volume-device-type
-  description: 'Volume device type.
-
-    Following are examples of the most frequently seen volume device types: Disk File
-    System CD-ROM File System'
-  flat_name: threat.indicator.file.Ext.device.volume_device_type
-  ignore_above: 1024
-  level: custom
-  name: Ext.device.volume_device_type
-  normalize: []
-  original_fieldset: file
-  short: Volume device type.
   type: keyword
 threat.indicator.file.Ext.entropy:
   dashed_name: threat-indicator-file-Ext-entropy

--- a/schemas/v1/alerts/rule_detection_event.yaml
+++ b/schemas/v1/alerts/rule_detection_event.yaml
@@ -656,20 +656,6 @@ threat.enrichments.indicator.file.Ext.device.vendor_id:
   original_fieldset: file
   short: VendorID of the device.
   type: keyword
-threat.enrichments.indicator.file.Ext.device.volume_device_type:
-  dashed_name: threat-enrichments-indicator-file-Ext-device-volume-device-type
-  description: 'Volume device type.
-
-    Following are examples of the most frequently seen volume device types: Disk File
-    System CD-ROM File System'
-  flat_name: threat.enrichments.indicator.file.Ext.device.volume_device_type
-  ignore_above: 1024
-  level: custom
-  name: Ext.device.volume_device_type
-  normalize: []
-  original_fieldset: file
-  short: Volume device type.
-  type: keyword
 threat.enrichments.indicator.file.Ext.entropy:
   dashed_name: threat-enrichments-indicator-file-Ext-entropy
   description: Entropy calculation of file's header and footer used to check file
@@ -3196,20 +3182,6 @@ threat.indicator.file.Ext.device.vendor_id:
   normalize: []
   original_fieldset: file
   short: VendorID of the device.
-  type: keyword
-threat.indicator.file.Ext.device.volume_device_type:
-  dashed_name: threat-indicator-file-Ext-device-volume-device-type
-  description: 'Volume device type.
-
-    Following are examples of the most frequently seen volume device types: Disk File
-    System CD-ROM File System'
-  flat_name: threat.indicator.file.Ext.device.volume_device_type
-  ignore_above: 1024
-  level: custom
-  name: Ext.device.volume_device_type
-  normalize: []
-  original_fieldset: file
-  short: Volume device type.
   type: keyword
 threat.indicator.file.Ext.entropy:
   dashed_name: threat-indicator-file-Ext-entropy


### PR DESCRIPTION
## Change Summary

in alerts, we had a glob-field (threat.enrichments or intel ... file.Ext.*) which pulls in any `file.Ext..` field as they are added in the future. This is probably pulling in more fields than intended, so we are taking the practice of replacing any `*` with explicit field trees as they come up.

So this is replacing the `...file.Ext.*` with whatever fields existed up to now (knowing that we need some further field pruning in the future). This should result in a net-nothing diff, aside from below:

The exception to this is `.. Ext.device.volume_device_type` which was just added in #276 and explicitly noted as an unwanted field. So those are excluded. We do see those being removed from the final product


## Release Target

8.4 stack (8.4.1 package)

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes

