### PR TITLE
8.4.1 release

### DIFF
--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: endpoint
 title: Endpoint and Cloud Security
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.4.1-dev.0
+version: 8.4.1
 categories: ["security", "cloud"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 # The default type is integration and will be set if empty.


### PR DESCRIPTION
_Presumably_, when this is merged, it will release `8.4.1` package to package-storage **V2**.

I am doing this slightly differently (and manually) to test if v2 storage deploys will work with single merges like this.

Once this is merged, we can deploy to package storage v1 from the commit generated by this merge