### PR TITLE
Stop using legacy syntax for parameters on triggerRemoteJob

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -189,7 +189,9 @@ def signUnpublishedArtifactsWithElastic(builtPackagesPath) {
     triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
       job: 'https://internal-ci.elastic.co/job/elastic+unified-release+master+sign-artifacts-with-gpg',
       token: TOKEN,
-      parameters: "gcs_input_path=${env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH}",
+      parameters: [
+        gcs_input_path: env.INFRA_SIGNING_BUCKET_ARTIFACTS_PATH,
+      ],
       useCrumbCache: false,
       useJobInfoCache: false)
   }
@@ -225,13 +227,14 @@ def uploadUnpublishedToPackageStorage(builtPackagesPath) {
           triggerRemoteJob(auth: CredentialsAuth(credentials: 'local-readonly-api-token'),
             job: 'https://internal-ci.elastic.co/job/package_storage/job/publishing-job-remote',
             token: TOKEN,
-            parameters: """
-              dry_run=${dryRun}
-              gs_package_build_zip_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}
-              gs_package_signature_path=${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig
-              legacy_package=true""",
-              useCrumbCache: true,
-              useJobInfoCache: true)
+            parameters: [
+              dry_run: dryRun,
+              gs_package_build_zip_path: "${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}",
+              gs_package_signature_path: "${env.PACKAGE_STORAGE_INTERNAL_BUCKET_QUEUE_PUBLISHING_PATH}/${packageZip}.sig",
+              legacy_package: true,
+            ],
+            useCrumbCache: true,
+            useJobInfoCache: true)
         }
       }
     }


### PR DESCRIPTION
String-based syntax for parameters of `triggerRemoteJob` doesn't work on latest Jenkins LTS. Migrate to the new map-based syntax.

Issue found in https://github.com/elastic/elastic-package/pull/928, solution evaluated in https://github.com/elastic/elastic-package/pull/929.