### PR TITLE
Update integration name to Elastic Defend

### DIFF
--- a/doc_templates/endpoint/docs/README.md
+++ b/doc_templates/endpoint/docs/README.md
@@ -1,6 +1,6 @@
-# Endpoint and Cloud Security Integration
+# Elastic Defend Integration
 
-This integration sets up templates and index patterns required for Endpoint and Cloud Security.
+This integration sets up templates and index patterns required for Elastic Defend.
 
 ## Compatibility
 

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1,6 +1,6 @@
-# Endpoint and Cloud Security Integration
+# Elastic Defend Integration
 
-This integration sets up templates and index patterns required for Endpoint and Cloud Security.
+This integration sets up templates and index patterns required for Elastic Defend.
 
 ## Compatibility
 

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -1,6 +1,6 @@
 format_version: 1.0.0
 name: endpoint
-title: Endpoint and Cloud Security
+title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
 version: 8.5.0-dev.0
 categories: ["security", "cloud"]


### PR DESCRIPTION
## Change Summary

Part of this ticket: https://github.com/elastic/security-team/issues/4759

Update the integration name to Elastic Defend.

Made the package and ran it locally:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/56395104/186729999-5ff660de-2d2e-4553-b724-b6d3acf9c2d6.png">

No mapping changes in this PR.

## Release Target

8.5


## Q/A

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
