### PR TITLE
add new `.fleet-agents` fields to united index

### DIFF
--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
@@ -334,6 +334,10 @@
                                 "last_checkin_status": {
                                     "type": "keyword"
                                 },
+                                "last_checkin_message": {
+                                    "type": "text",
+                                    "enabled": false
+                                },
                                 "last_updated": {
                                     "type": "date"
                                 },
@@ -515,6 +519,10 @@
                                     "type": "date"
                                 },
                                 "user_provided_metadata": {
+                                    "type": "object",
+                                    "enabled": false
+                                },
+                                "components": {
                                     "type": "object",
                                     "enabled": false
                                 }


### PR DESCRIPTION
## Change Summary

Updating united index mapping to include new fields in `.fleet-agents`: https://github.com/elastic/elasticsearch/pull/89599. Left both as `enabled: false` since I don't believe we'll need to be searching on them.


## Release Target

8.5


### For mapping changes:

- [x] If this is a `metadata` change, I also updated both transform destination schemas to match
