### PR TITLE
jjbb: use fleet-ci

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -4,7 +4,7 @@
 ##### GLOBAL METADATA
 
 - meta:
-    cluster: beats-ci
+    cluster: fleet-ci
 
 ##### JOB DEFAULTS
 

--- a/.ci/jobs/endpoint-package-mbp.yml
+++ b/.ci/jobs/endpoint-package-mbp.yml
@@ -12,7 +12,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: true
-          notification-context: 'beats-ci'
+          notification-context: 'fleet-ci'
           repo: endpoint-package
           repo-owner: elastic
           credentials-id: 2a9602aa-ab9f-4e52-baf3-b71ca88469c7-UserAndToken

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ assumes a release branch was being used (e.g. 7.9, 7.10, etc).
 Once the PR is merged to the `snapshot` branch CI will kick off a new build for that branch that will release a new docker image.
 The images can be located here: <https://container-library.elastic.co/r/package-registry/distribution>
 
-If for some reason the `snapshot` branch CI does kick off a new build, you can manually trigger it here: <https://beats-ci.elastic.co/blue/organizations/jenkins/Beats%2Fpackage-storage/branches>
+If for some reason the `snapshot` branch CI does kick off a new build, you can manually trigger it here: <https://fleet-ci.elastic.co/blue/organizations/jenkins/Beats%2Fpackage-storage/branches>
 
 ### Deploying a new registry with the package
 


### PR DESCRIPTION
## What is the problem this PR solves?

Use `fleet-ci`  to scale horizontally the CI.

## Why

In order to distribute the load and reduce a single point of failure,

## Actions

- [x] Create webhook to point to `fleet-ci`

## Issues

Package v1 won't be migrated to `fleet-ci` as discussed in https://github.com/elastic/package-storage/pull/3714 hence I didn't update the URL in the `README.md`