### PR TITLE
[Security Solution] Fix united index template

### DIFF
--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
@@ -336,11 +336,11 @@
                                 },
                                 "last_checkin_message": {
                                     "type": "text",
-                                    "enabled": false
+                                    "index": false
                                 },
                                 "last_updated": {
                                     "type": "date"
-                                },
+                                },                                
                                 "local_metadata": {
                                     "properties": {
                                         "elastic": {

--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
@@ -340,7 +340,7 @@
                                 },
                                 "last_updated": {
                                     "type": "date"
-                                },                                
+                                },
                                 "local_metadata": {
                                     "properties": {
                                         "elastic": {


### PR DESCRIPTION
## Change Summary
This PR fixes a bug in the `metadata-united` index pattern.  Before, Fleet would fail to install the Endpoint package citing the `metadata_united` index pattern as invalid.

Before we were using the `enabled` field like this:
```
"last_checkin_message": {
    "type": "text",
    "enabled": false
},
```

`"enabled"` does not look like it's compatible with `"type": "text"` .  I assumed the intention was to not index the field, so I added `"index:" "false"` to replace `"enabled"`.  After this change, Fleet is able to install the Endpoint package.


## Release Target

`8.5`

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [x] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [x] The new transform successfully starts in Kibana
- [x] The corresponding transform destination schema was updated if necessary
