### PR TITLE
[8.5] attested_user and attested_groups added to process.entry_leader

### DIFF
--- a/custom_schemas/custom_group.yml
+++ b/custom_schemas/custom_group.yml
@@ -7,6 +7,15 @@
     The group fields are meant to represent groups that are relevant to the
     event.
   type: group
+  reusable:
+    top_level: true
+    expected:
+      - at: process
+        as: attested_groups
+        short_override: The externally attested groups based on an external source such as the Kube API.
+        beta: Reusing the `group` fields in this location is currently considered beta.
+        normalize:
+          - array
   fields:
     - name: domain
       level: extended

--- a/custom_schemas/custom_user.yml
+++ b/custom_schemas/custom_user.yml
@@ -15,6 +15,11 @@
     top_level: true
     expected:
       - host
+      - at: process
+        as: attested_user
+        short_override: The externally attested user based on an external source such as the Kube API.
+        beta: Reusing the `user` fields in this location is currently considered beta.
+
   fields:
     - name: group
       level: extended

--- a/custom_subsets/elastic_endpoint/process/linux_event_model_event.yaml
+++ b/custom_subsets/elastic_endpoint/process/linux_event_model_event.yaml
@@ -234,6 +234,13 @@ fields:
             fields:
               id: {}
               name: {}
+          attested_user:
+            fields:
+              id: {}
+              name: {}
+          attested_groups:
+            fields:
+              name: {}
       session_leader:
         fields:
           args: {}

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -1062,6 +1062,29 @@
         This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity.'
       example: 4
       default_field: false
+    - name: entry_leader.attested_groups.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Name of the group.
+      default_field: false
+    - name: entry_leader.attested_user.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier of the user.
+      example: S-1-5-21-202424912787-2692429404-2351956786-1000
+      default_field: false
+    - name: entry_leader.attested_user.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: match_only_text
+      description: Short name or login of the user.
+      example: a.einstein
+      default_field: false
     - name: entry_leader.command_line
       level: extended
       type: wildcard

--- a/package/endpoint/data_stream/process/sample_event.json
+++ b/package/endpoint/data_stream/process/sample_event.json
@@ -50,6 +50,15 @@
         }
     },
     "process": {
+        "entry_leader": {
+            "attested_user": {
+                "id": "123",
+                "name": "userA"
+            },
+            "attested_groups": {
+                "name": "groupA"
+            }
+        },
         "Ext": {
             "ancestry": [
                 "NGM5YzljYjMtZjgwZi00NGQ4LTljODktNjE2ODI0M2I3ZjIxLTYwMC0xMzI5MzU0OTExMC40NjgyMjI3MDA=",

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2099,6 +2099,9 @@ sent by the endpoint.
 | process.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |
 | process.entry_leader.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.entry_leader.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
+| process.entry_leader.attested_groups.name | Name of the group. | keyword |
+| process.entry_leader.attested_user.id | Unique identifier of the user. | keyword |
+| process.entry_leader.attested_user.name | Short name or login of the user. | keyword |
 | process.entry_leader.command_line | Full command line that started the process, including the absolute path to the executable, and all arguments. Some arguments may be filtered to protect sensitive information. | wildcard |
 | process.entry_leader.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |
 | process.entry_leader.entry_meta.source.ip | IP address of the source (IPv4 or IPv6). | ip |

--- a/schemas/v1/process/linux_event_model_event.yaml
+++ b/schemas/v1/process/linux_event_model_event.yaml
@@ -474,6 +474,45 @@ process.entry_leader.args_count:
   original_fieldset: process
   short: Length of the process.args array.
   type: long
+process.entry_leader.attested_groups.name:
+  dashed_name: process-entry-leader-attested-groups-name
+  description: Name of the group.
+  flat_name: process.entry_leader.attested_groups.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  original_fieldset: group
+  short: Name of the group.
+  type: keyword
+process.entry_leader.attested_user.id:
+  dashed_name: process-entry-leader-attested-user-id
+  description: Unique identifier of the user.
+  example: S-1-5-21-202424912787-2692429404-2351956786-1000
+  flat_name: process.entry_leader.attested_user.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: user
+  short: Unique identifier of the user.
+  type: keyword
+process.entry_leader.attested_user.name:
+  dashed_name: process-entry-leader-attested-user-name
+  description: Short name or login of the user.
+  example: a.einstein
+  flat_name: process.entry_leader.attested_user.name
+  ignore_above: 1024
+  level: core
+  multi_fields:
+  - flat_name: process.entry_leader.attested_user.name.text
+    name: text
+    type: match_only_text
+  name: name
+  normalize: []
+  original_fieldset: user
+  short: Short name or login of the user.
+  type: keyword
 process.entry_leader.command_line:
   dashed_name: process-entry-leader-command-line
   description: 'Full command line that started the process, including the absolute


### PR DESCRIPTION
## Change Summary

The following fields/mappings:
process.entry_leader.attested_user.id
process.entry_leader.attested_user.name
process.entry_leader.attested_groups.name

### Sample values
```
process.entry_leader.attested_user.id: '123'
process.entry_leader.attested_user.name: 'daniel'
process.entry_leader.attested_groups = [
  { name: 'sudoers' },
  { name: 'docker' }
]
```

Sample document:

```json
    "process": {
        .....
        "entry_leader": {
            .....
            "attested_user": {
                "id": "123",
                "name": "userA"
            },
            "attested_groups": [
                { "name": "groupA" }
            ]
        },
    }
```


## Release Target
8.5

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
