### PR TITLE
Add session data to Windows process creation events

### DIFF
--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -276,12 +276,6 @@
       description: >
         Process authentication ID
 
-    - name: Ext.session
-      level: custom
-      type: keyword
-      description: >
-        Session information for the current process
-
     - name: Ext.code_signature
       level: custom
       type: nested
@@ -377,6 +371,49 @@
       description: >
         Indicates the protection level of this process.  Uses the same syntax as Process Explorer.
         Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light.
+
+    - name: Ext.session.logon_type
+      level: custom
+      type: keyword
+      description: >
+        Session logon type.  Examples include Interactive, Network, and Service.
+        
+    - name: Ext.session.client_address
+      level: custom
+      type: keyword
+      description: >
+        Client's IPv4 or IPv6 address as a string, if available.
+        
+    - name: Ext.session.id
+      level: custom
+      type: unsigned_long
+      description: >
+        Session ID
+        
+    - name: Ext.session.authentication_package
+      level: custom
+      type: keyword
+      description: >
+        Name of authentication package used to log on, such as NTLM, Kerberos, or CloudAP
+
+    - name: Ext.session.relative_logon_time
+      level: custom
+      type: double
+      description: >
+        Process creation time, relative to logon time, in seconds.
+        
+    - name: Ext.session.relative_password_age
+      level: custom
+      type: double
+      description: >
+        Process creation time, relative to the last time the password was changed, in seconds.
+
+    - name: Ext.session.user_flags
+      level: custom
+      type: keyword
+      description: >
+        List of user flags associated with this logon session.
+        Examples include LOGON_NTLMV2_ENABLED and LOGON_WINLOGON.
 
     - name: Ext.device.bus_type
       level: custom

--- a/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
@@ -762,7 +762,6 @@ fields:
           ancestry: {}
           authentication_id: {}
           services: {}
-          session: {}
           user: {}
           code_signature:
             fields:
@@ -992,7 +991,6 @@ fields:
               ancestry: {}
               authentication_id: {}
               services: {}
-              session: {}
               user: {}
               code_signature:
                 fields:

--- a/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
@@ -648,7 +648,6 @@ fields:
           dll:
             fields: *dll-fields
           services: {}
-          session: {}
           user: {}
           code_signature:
             fields:

--- a/custom_subsets/elastic_endpoint/alerts/ransomware_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/ransomware_event.yaml
@@ -622,7 +622,6 @@ fields:
           ancestry: {}
           authentication_id: {}
           services: {}
-          session: {}
           user: {}
           code_signature:
             fields:

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -179,7 +179,15 @@ fields:
           protection: {}
           relative_file_creation_time: {}
           relative_file_name_modify_time: {}
-          session: {}
+          session:
+            fields:
+              logon_type: {}
+              client_address: {}
+              id: {}
+              authentication_package: {}
+              relative_logon_time: {}
+              relative_password_age: {}
+              user_flags: {}
           token:
             fields:
               elevation: {}

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -1293,12 +1293,6 @@
       ignore_above: 1024
       description: Services running in this process.
       default_field: false
-    - name: process.Ext.session
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: Session information for the current process
-      default_field: false
     - name: process.Ext.token.domain
       level: custom
       type: keyword
@@ -4926,12 +4920,6 @@
       type: keyword
       ignore_above: 1024
       description: Services running in this process.
-      default_field: false
-    - name: Ext.session
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: Session information for the current process
       default_field: false
     - name: Ext.token.domain
       level: custom

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -891,11 +891,44 @@
       type: double
       description: Number of seconds since the process's name was modified. This information can come from the NTFS MFT. This number may be negative if the file's timestamp is in the future.
       default_field: false
-    - name: Ext.session
+    - name: Ext.session.authentication_package
       level: custom
       type: keyword
       ignore_above: 1024
-      description: Session information for the current process
+      description: Name of authentication package used to log on, such as NTLM, Kerberos, or CloudAP
+      default_field: false
+    - name: Ext.session.client_address
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Client's IPv4 or IPv6 address as a string, if available.
+      default_field: false
+    - name: Ext.session.id
+      level: custom
+      type: unsigned_long
+      description: Session ID
+      default_field: false
+    - name: Ext.session.logon_type
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Session logon type.  Examples include Interactive, Network, and Service.
+      default_field: false
+    - name: Ext.session.relative_logon_time
+      level: custom
+      type: double
+      description: Process creation time, relative to logon time, in seconds.
+      default_field: false
+    - name: Ext.session.relative_password_age
+      level: custom
+      type: double
+      description: Process creation time, relative to the last time the password was changed, in seconds.
+      default_field: false
+    - name: Ext.session.user_flags
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: List of user flags associated with this logon session. Examples include LOGON_NTLMV2_ENABLED and LOGON_WINLOGON.
       default_field: false
     - name: Ext.token.elevation
       level: custom

--- a/package/endpoint/data_stream/process/sample_event.json
+++ b/package/endpoint/data_stream/process/sample_event.json
@@ -90,7 +90,20 @@
                 "pid": 2732
             },
             "relative_file_creation_time": 48628704.4029488,
-            "relative_file_name_modify_time": 48628704.4029488
+            "relative_file_name_modify_time": 48628704.4029488,
+            "session": {
+                "logon_type": "Interactive",
+                "client_address": "127.0.0.1",
+                "id": 1,
+                "authentication_package": "NTLM",
+                "relative_logon_time": 0.1,
+                "relative_password_age": 2592000.123,
+                "user_flags": [
+                    "LOGON_EXTRA_SIDS",
+                    "LOGON_NTLMV2_ENABLED",
+                    "LOGON_WINLOGON"
+                ]
+            }
         },
         "parent": {
             "args": [],

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -194,7 +194,6 @@ sent by the endpoint.
 | Target.process.Ext.memory_region.strings | Array of strings found within the memory region. | keyword |
 | Target.process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | Target.process.Ext.services | Services running in this process. | keyword |
-| Target.process.Ext.session | Session information for the current process | keyword |
 | Target.process.Ext.token.domain | Domain of token user. | keyword |
 | Target.process.Ext.token.elevation | Whether the token is elevated or not | boolean |
 | Target.process.Ext.token.elevation_type | What level of elevation the token has | keyword |
@@ -673,7 +672,6 @@ sent by the endpoint.
 | process.Ext.memory_region.strings | Array of strings found within the memory region. | keyword |
 | process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | process.Ext.services | Services running in this process. | keyword |
-| process.Ext.session | Session information for the current process | keyword |
 | process.Ext.token.domain | Domain of token user. | keyword |
 | process.Ext.token.elevation | Whether the token is elevated or not | boolean |
 | process.Ext.token.elevation_type | What level of elevation the token has | keyword |
@@ -2089,7 +2087,13 @@ sent by the endpoint.
 | process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | process.Ext.relative_file_creation_time | Number of seconds since the process's file was created. This number may be negative if the file's timestamp is in the future. | double |
 | process.Ext.relative_file_name_modify_time | Number of seconds since the process's name was modified. This information can come from the NTFS MFT. This number may be negative if the file's timestamp is in the future. | double |
-| process.Ext.session | Session information for the current process | keyword |
+| process.Ext.session.authentication_package | Name of authentication package used to log on, such as NTLM, Kerberos, or CloudAP | keyword |
+| process.Ext.session.client_address | Client's IPv4 or IPv6 address as a string, if available. | keyword |
+| process.Ext.session.id | Session ID | unsigned_long |
+| process.Ext.session.logon_type | Session logon type.  Examples include Interactive, Network, and Service. | keyword |
+| process.Ext.session.relative_logon_time | Process creation time, relative to logon time, in seconds. | double |
+| process.Ext.session.relative_password_age | Process creation time, relative to the last time the password was changed, in seconds. | double |
+| process.Ext.session.user_flags | List of user flags associated with this logon session. Examples include LOGON_NTLMV2_ENABLED and LOGON_WINLOGON. | keyword |
 | process.Ext.token.elevation | Whether the token is elevated or not | boolean |
 | process.Ext.token.elevation_level | What level of elevation the token has | keyword |
 | process.Ext.token.elevation_type | What level of elevation the token has | keyword |

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -862,17 +862,6 @@ Target.process.Ext.services:
   original_fieldset: process
   short: Services running in this process.
   type: keyword
-Target.process.Ext.session:
-  dashed_name: Target-process-Ext-session
-  description: Session information for the current process
-  flat_name: Target.process.Ext.session
-  ignore_above: 1024
-  level: custom
-  name: Ext.session
-  normalize: []
-  original_fieldset: process
-  short: Session information for the current process
-  type: keyword
 Target.process.Ext.token.domain:
   dashed_name: Target-process-Ext-token-domain
   description: Domain of token user.
@@ -5700,16 +5689,6 @@ process.Ext.services:
   name: Ext.services
   normalize: []
   short: Services running in this process.
-  type: keyword
-process.Ext.session:
-  dashed_name: process-Ext-session
-  description: Session information for the current process
-  flat_name: process.Ext.session
-  ignore_above: 1024
-  level: custom
-  name: Ext.session
-  normalize: []
-  short: Session information for the current process
   type: keyword
 process.Ext.token.domain:
   dashed_name: process-Ext-token-domain

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -1196,17 +1196,6 @@ Target.process.Ext.services:
   original_fieldset: process
   short: Services running in this process.
   type: keyword
-Target.process.Ext.session:
-  dashed_name: Target-process-Ext-session
-  description: Session information for the current process
-  flat_name: Target.process.Ext.session
-  ignore_above: 1024
-  level: custom
-  name: Ext.session
-  normalize: []
-  original_fieldset: process
-  short: Session information for the current process
-  type: keyword
 Target.process.Ext.token.domain:
   dashed_name: Target-process-Ext-token-domain
   description: Domain of token user.
@@ -6419,16 +6408,6 @@ process.Ext.services:
   name: Ext.services
   normalize: []
   short: Services running in this process.
-  type: keyword
-process.Ext.session:
-  dashed_name: process-Ext-session
-  description: Session information for the current process
-  flat_name: process.Ext.session
-  ignore_above: 1024
-  level: custom
-  name: Ext.session
-  normalize: []
-  short: Session information for the current process
   type: keyword
 process.Ext.token.domain:
   dashed_name: process-Ext-token-domain

--- a/schemas/v1/alerts/ransomware_event.yaml
+++ b/schemas/v1/alerts/ransomware_event.yaml
@@ -2566,16 +2566,6 @@ process.Ext.services:
   normalize: []
   short: Services running in this process.
   type: keyword
-process.Ext.session:
-  dashed_name: process-Ext-session
-  description: Session information for the current process
-  flat_name: process.Ext.session
-  ignore_above: 1024
-  level: custom
-  name: Ext.session
-  normalize: []
-  short: Session information for the current process
-  type: keyword
 process.Ext.token.domain:
   dashed_name: process-Ext-token-domain
   description: Domain of token user.

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1558,15 +1558,78 @@ process.Ext.relative_file_name_modify_time:
   normalize: []
   short: Number of seconds since the process's name was modified
   type: double
-process.Ext.session:
-  dashed_name: process-Ext-session
-  description: Session information for the current process
-  flat_name: process.Ext.session
+process.Ext.session.authentication_package:
+  dashed_name: process-Ext-session-authentication-package
+  description: Name of authentication package used to log on, such as NTLM, Kerberos,
+    or CloudAP
+  flat_name: process.Ext.session.authentication_package
   ignore_above: 1024
   level: custom
-  name: Ext.session
+  name: Ext.session.authentication_package
   normalize: []
-  short: Session information for the current process
+  short: Name of authentication package used to log on, such as NTLM, Kerberos, or
+    CloudAP
+  type: keyword
+process.Ext.session.client_address:
+  dashed_name: process-Ext-session-client-address
+  description: Client's IPv4 or IPv6 address as a string, if available.
+  flat_name: process.Ext.session.client_address
+  ignore_above: 1024
+  level: custom
+  name: Ext.session.client_address
+  normalize: []
+  short: Client's IPv4 or IPv6 address as a string, if available.
+  type: keyword
+process.Ext.session.id:
+  dashed_name: process-Ext-session-id
+  description: Session ID
+  flat_name: process.Ext.session.id
+  level: custom
+  name: Ext.session.id
+  normalize: []
+  short: Session ID
+  type: unsigned_long
+process.Ext.session.logon_type:
+  dashed_name: process-Ext-session-logon-type
+  description: Session logon type.  Examples include Interactive, Network, and Service.
+  flat_name: process.Ext.session.logon_type
+  ignore_above: 1024
+  level: custom
+  name: Ext.session.logon_type
+  normalize: []
+  short: Session logon type.  Examples include Interactive, Network, and Service.
+  type: keyword
+process.Ext.session.relative_logon_time:
+  dashed_name: process-Ext-session-relative-logon-time
+  description: Process creation time, relative to logon time, in seconds.
+  flat_name: process.Ext.session.relative_logon_time
+  level: custom
+  name: Ext.session.relative_logon_time
+  normalize: []
+  short: Process creation time, relative to logon time, in seconds.
+  type: double
+process.Ext.session.relative_password_age:
+  dashed_name: process-Ext-session-relative-password-age
+  description: Process creation time, relative to the last time the password was changed,
+    in seconds.
+  flat_name: process.Ext.session.relative_password_age
+  level: custom
+  name: Ext.session.relative_password_age
+  normalize: []
+  short: Process creation time, relative to the last time the password was changed,
+    in seconds.
+  type: double
+process.Ext.session.user_flags:
+  dashed_name: process-Ext-session-user-flags
+  description: List of user flags associated with this logon session. Examples include
+    LOGON_NTLMV2_ENABLED and LOGON_WINLOGON.
+  flat_name: process.Ext.session.user_flags
+  ignore_above: 1024
+  level: custom
+  name: Ext.session.user_flags
+  normalize: []
+  short: List of user flags associated with this logon session. Examples include LOGON_NTLMV2_ENABLED
+    and LOGON_WINLOGON.
   type: keyword
 process.Ext.token.elevation:
   dashed_name: process-Ext-token-elevation


### PR DESCRIPTION
## Change Summary

Add session data to Windows process creation events.

### Sample values

See my changes to `package/endpoint/data_stream/process/sample_event.json`

## Release Target

8.6.0

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
