### PR TITLE
prep the 8.6.x dev branch

### DIFF
--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,3 +1,8 @@
+- version: "8.6.1-next"
+  changes:
+    - description: ""
+      type: enhancement
+      link: ""
 - version: "8.6.0"
   changes:
     - description: Add entity_id to file and network

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.6.0
+version: 8.6.1-next
 categories: ["security", "cloud"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 # The default type is integration and will be set if empty.


### PR DESCRIPTION
## Change Summary

Setup `8.6` branch with correct prerelease version tags

The empty changelog entry is annoyingly required for lint passing