### PR TITLE
master -> main

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -97,7 +97,7 @@ pipeline {
     stage('Publish') {
       when {
         anyOf {
-          branch 'master';
+          branch 'main';
           branch pattern: '[78]\\.\\d+',
                  comparator: 'REGEXP'
         }
@@ -205,7 +205,7 @@ def signUnpublishedArtifactsWithElastic(builtPackagesPath) {
 }
 
 def uploadUnpublishedToPackageStorage(builtPackagesPath) {
-  def dryRun = env.BRANCH_NAME != 'master'
+  def dryRun = env.BRANCH_NAME != 'main'
   if (dryRun) {
     echo "Dry run: endpoint-package won't be published"
   }

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ In the Kibana UI, if you want to add a field to appear as "exceptionable", appea
 
 There are three environments that provide different functionality for packages: snapshot, staging, and production.
 
-Snapshot is used for testing packages. It is mainly used by running kibana from source off the `master` branch. The endpoint package's
+Snapshot is used for testing packages. It is mainly used by running kibana from source off the `main` branch. The endpoint package's
 release manager script releases to `snapshot`.
 
 Staging is for packages that need a little more testing but are almost ready for production.
@@ -121,10 +121,10 @@ release is a little different in that it will remove the `-dev.#` portion of the
 endpoint-package repo.
 
 After choosing the type of release, the script will prompt for the remote branch in the endpoint-package repo that should be released. Most release will
-probably come from the `master` branch because this is where the latest package code is developed. If a bugfix is needed for an already released package,
+probably come from the `main` branch because this is where the latest package code is developed. If a bugfix is needed for an already released package,
 then we'll need to use a release branch (e.g. 7.9). Once the remote branch is chosen a draft PR will be opened to the `snapshot` branch for the package-storage repo.
-If this is a `prod` release and the branch used was `master`, the script will prompt for which version part (`major`, `minor`, or `patch`) should be increased for the next
-future release. If the branch was not `master` then the script only increments the `patch` part of the version because it
+If this is a `prod` release and the branch used was `main`, the script will prompt for which version part (`major`, `minor`, or `patch`) should be increased for the next
+future release. If the branch was not `main` then the script only increments the `patch` part of the version because it
 assumes a release branch was being used (e.g. 7.9, 7.10, etc).
 
 ### Creating new docker images

--- a/scripts/release_manager/main.py
+++ b/scripts/release_manager/main.py
@@ -33,8 +33,8 @@ def print_capture(res):
 
 def prompt_bump(current_version, released_branch):
     click.echo('Current version is: {}'.format(current_version))
-    if released_branch != 'master':
-        click.echo('Bumping the patch version because the base release branch was not master')
+    if released_branch != 'main':
+        click.echo('Bumping the patch version because the base release branch was not main')
         part = 'patch'
     else:
         part = click.prompt('Bump which version part?', default='minor', type=click.Choice(['major', 'minor', 'patch'],
@@ -158,14 +158,14 @@ def add_remote(repo, name, url):
 
 def get_upstream_branch(repo):
     branches = [b.name.split('/')[1] for b in repo.remote(UPSTREAM).refs]
-    upstream_branch = click.prompt('Which upstream branch should we release from?', default='master',
+    upstream_branch = click.prompt('Which upstream branch should we release from?', default='main',
                                    type=click.Choice(branches))
     return upstream_branch
 
 
 def delete_old_branch(repo, name, remote='origin'):
     # switch to a different branch before deleting
-    repo.git.checkout('master')
+    repo.git.checkout('main')
     try:
         repo.git.branch(D=name)
     except git.exc.GitCommandError as e:
@@ -205,9 +205,9 @@ def get_release_branch(repo):
 
 
 def update_backport(repo, release_branch, upstream_branch):
-    # backporting only applies to commits that go to master so if the original release
-    # was not targeting master then don't add anything to the .backportrc.json file
-    if upstream_branch != 'master':
+    # backporting only applies to commits that go to main so if the original release
+    # was not targeting main then don't add anything to the .backportrc.json file
+    if upstream_branch != 'main':
         return
 
     click.echo('Updating .backportrc.json file')


### PR DESCRIPTION
## Change Summary

The primary branch for this repo was changed from `master` to `main`. This updates some scripts and CI wherever there was a reference to the old branch name