### PR TITLE
change the GA changelog reference link, to appease the linter

### DIFF
--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -139,4 +139,4 @@
   changes:
     - description: GA Release
       type: enhancement
-      link: https://github.com/elastic/endpoint-package/tree/v1.0.0
+      link: https://github.com/elastic/endpoint-package/pull/160


### PR DESCRIPTION
## Change Summary

the elastic package linter apparently _reads and parses_ the links in the changelog, and didn't like that I pointed to a tag. It expects an issue/PR. So This replaces that old entry with the PR where the same work was done.
