### PR TITLE
Mitigation policies

### DIFF
--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -330,6 +330,14 @@
         Leave unpopulated if the validity or trust of the certificate was unchecked.
       example: ERROR_UNTRUSTED_ROOT
 
+    - name: Ext.mitigation_policies
+      level: custom
+      type: keyword
+      short: Process mitigation policies.
+      description: >
+        Process mitigation policies include SignaturePolicy, DynamicCodePolicy, UserShadowStackPolicy, ControlFlowGuardPolicy, etc.
+        Examples include Microsoft only, CF Guard, User Shadow Stack enabled
+
     - name: Ext.real
       level: custom
       type: object

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -162,6 +162,7 @@ fields:
               trusted: {}
               valid: {}
           defense_evasions: {}
+          mitigation_policies: {}
           dll:
             fields:
               name: {}

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -875,6 +875,12 @@
       description: Process ID.
       example: 4242
       default_field: false
+    - name: Ext.mitigation_policies
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Process mitigation policies include SignaturePolicy, DynamicCodePolicy, UserShadowStackPolicy, ControlFlowGuardPolicy, etc. Examples include Microsoft only, CF Guard, User Shadow Stack enabled
+      default_field: false
     - name: Ext.protection
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/process/sample_event.json
+++ b/package/endpoint/data_stream/process/sample_event.json
@@ -72,6 +72,11 @@
                     "status": "trusted"
                 }
             ],
+            "mitigation_policies": [
+                "Microsoft only, Opt-in to restrict to Microsoft, Windows Store and WHQL",
+                "Cet dynamic APIs can only be called out of proc",
+                "CF Guard"
+            ],
             "device": {
                 "volume_device_type": "Disk File System"
             },

--- a/package/endpoint/data_stream/process/sample_event.json
+++ b/package/endpoint/data_stream/process/sample_event.json
@@ -74,7 +74,7 @@
             ],
             "mitigation_policies": [
                 "Microsoft only, Opt-in to restrict to Microsoft, Windows Store and WHQL",
-                "Cet dynamic APIs can only be called out of proc",
+                "CET dynamic APIs can only be called out of proc",
                 "CF Guard"
             ],
             "device": {

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2093,6 +2093,7 @@ sent by the endpoint.
 | process.Ext.effective_parent.executable | Executable name for the effective process. | keyword |
 | process.Ext.effective_parent.name | Process name for the effective process. | keyword |
 | process.Ext.effective_parent.pid | Process ID. | long |
+| process.Ext.mitigation_policies | Process mitigation policies include SignaturePolicy, DynamicCodePolicy, UserShadowStackPolicy, ControlFlowGuardPolicy, etc. Examples include Microsoft only, CF Guard, User Shadow Stack enabled | keyword |
 | process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | process.Ext.relative_file_creation_time | Number of seconds since the process's file was created. This number may be negative if the file's timestamp is in the future. | double |
 | process.Ext.relative_file_name_modify_time | Number of seconds since the process's name was modified. This information can come from the NTFS MFT. This number may be negative if the file's timestamp is in the future. | double |

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1525,6 +1525,18 @@ process.Ext.effective_parent.pid:
   original_fieldset: Effective_process
   short: Process ID.
   type: long
+process.Ext.mitigation_policies:
+  dashed_name: process-Ext-mitigation-policies
+  description: Process mitigation policies include SignaturePolicy, DynamicCodePolicy,
+    UserShadowStackPolicy, ControlFlowGuardPolicy, etc. Examples include Microsoft
+    only, CF Guard, User Shadow Stack enabled
+  flat_name: process.Ext.mitigation_policies
+  ignore_above: 1024
+  level: custom
+  name: Ext.mitigation_policies
+  normalize: []
+  short: Process mitigation policies.
+  type: keyword
 process.Ext.protection:
   dashed_name: process-Ext-protection
   description: Indicates the protection level of this process.  Uses the same syntax


### PR DESCRIPTION
## Change Summary
Add `mitigation_policies` to Windows process creation events.

### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->
```
                "mitigation_policies": [
                    "Microsoft only",
                    "CET dynamic APIs can only be called out of proc",
                    "CF Guard"
                ],
```


## Sample document:
[Here](https://gist.github.com/Trinity2019/850860a400ec54605300532b2eeed565)'s a sample process event document.

## Release Target

8.7.0

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes



