### PR TITLE
[8.6][backport] Rename session -> session_info and restore legacy keyword field (#318)

### DIFF
--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -281,6 +281,12 @@
       description: >
         Process authentication ID
 
+    - name: Ext.session
+      level: custom
+      type: keyword
+      description: >
+        Session information for the current process
+
     - name: Ext.code_signature
       level: custom
       type: nested
@@ -377,43 +383,43 @@
         Indicates the protection level of this process.  Uses the same syntax as Process Explorer.
         Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light.
 
-    - name: Ext.session.logon_type
+    - name: Ext.session_info.logon_type
       level: custom
       type: keyword
       description: >
         Session logon type.  Examples include Interactive, Network, and Service.
         
-    - name: Ext.session.client_address
+    - name: Ext.session_info.client_address
       level: custom
       type: keyword
       description: >
         Client's IPv4 or IPv6 address as a string, if available.
         
-    - name: Ext.session.id
+    - name: Ext.session_info.id
       level: custom
       type: unsigned_long
       description: >
         Session ID
         
-    - name: Ext.session.authentication_package
+    - name: Ext.session_info.authentication_package
       level: custom
       type: keyword
       description: >
         Name of authentication package used to log on, such as NTLM, Kerberos, or CloudAP
 
-    - name: Ext.session.relative_logon_time
+    - name: Ext.session_info.relative_logon_time
       level: custom
       type: double
       description: >
         Process creation time, relative to logon time, in seconds.
         
-    - name: Ext.session.relative_password_age
+    - name: Ext.session_info.relative_password_age
       level: custom
       type: double
       description: >
         Process creation time, relative to the last time the password was changed, in seconds.
 
-    - name: Ext.session.user_flags
+    - name: Ext.session_info.user_flags
       level: custom
       type: keyword
       description: >

--- a/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
@@ -779,6 +779,7 @@ fields:
           ancestry: {}
           authentication_id: {}
           services: {}
+          session: {}
           user: {}
           code_signature:
             fields:
@@ -1008,6 +1009,7 @@ fields:
               ancestry: {}
               authentication_id: {}
               services: {}
+              session: {}
               user: {}
               code_signature:
                 fields:

--- a/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
@@ -648,6 +648,7 @@ fields:
           dll:
             fields: *dll-fields
           services: {}
+          session: {}
           user: {}
           code_signature:
             fields:

--- a/custom_subsets/elastic_endpoint/alerts/ransomware_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/ransomware_event.yaml
@@ -622,6 +622,7 @@ fields:
           ancestry: {}
           authentication_id: {}
           services: {}
+          session: {}
           user: {}
           code_signature:
             fields:

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -179,7 +179,8 @@ fields:
           protection: {}
           relative_file_creation_time: {}
           relative_file_name_modify_time: {}
-          session:
+          session: {}
+          session_info:
             fields:
               logon_type: {}
               client_address: {}

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -1293,6 +1293,12 @@
       ignore_above: 1024
       description: Services running in this process.
       default_field: false
+    - name: process.Ext.session
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Session information for the current process
+      default_field: false
     - name: process.Ext.token.domain
       level: custom
       type: keyword
@@ -4974,6 +4980,12 @@
       type: keyword
       ignore_above: 1024
       description: Services running in this process.
+      default_field: false
+    - name: Ext.session
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Session information for the current process
       default_field: false
     - name: Ext.token.domain
       level: custom

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -891,40 +891,46 @@
       type: double
       description: Number of seconds since the process's name was modified. This information can come from the NTFS MFT. This number may be negative if the file's timestamp is in the future.
       default_field: false
-    - name: Ext.session.authentication_package
+    - name: Ext.session
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Session information for the current process
+      default_field: false
+    - name: Ext.session_info.authentication_package
       level: custom
       type: keyword
       ignore_above: 1024
       description: Name of authentication package used to log on, such as NTLM, Kerberos, or CloudAP
       default_field: false
-    - name: Ext.session.client_address
+    - name: Ext.session_info.client_address
       level: custom
       type: keyword
       ignore_above: 1024
       description: Client's IPv4 or IPv6 address as a string, if available.
       default_field: false
-    - name: Ext.session.id
+    - name: Ext.session_info.id
       level: custom
       type: unsigned_long
       description: Session ID
       default_field: false
-    - name: Ext.session.logon_type
+    - name: Ext.session_info.logon_type
       level: custom
       type: keyword
       ignore_above: 1024
       description: Session logon type.  Examples include Interactive, Network, and Service.
       default_field: false
-    - name: Ext.session.relative_logon_time
+    - name: Ext.session_info.relative_logon_time
       level: custom
       type: double
       description: Process creation time, relative to logon time, in seconds.
       default_field: false
-    - name: Ext.session.relative_password_age
+    - name: Ext.session_info.relative_password_age
       level: custom
       type: double
       description: Process creation time, relative to the last time the password was changed, in seconds.
       default_field: false
-    - name: Ext.session.user_flags
+    - name: Ext.session_info.user_flags
       level: custom
       type: keyword
       ignore_above: 1024

--- a/package/endpoint/data_stream/process/sample_event.json
+++ b/package/endpoint/data_stream/process/sample_event.json
@@ -91,7 +91,7 @@
             },
             "relative_file_creation_time": 48628704.4029488,
             "relative_file_name_modify_time": 48628704.4029488,
-            "session": {
+            "session_info": {
                 "logon_type": "Interactive",
                 "client_address": "127.0.0.1",
                 "id": 1,

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -194,6 +194,7 @@ sent by the endpoint.
 | Target.process.Ext.memory_region.strings | Array of strings found within the memory region. | keyword |
 | Target.process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | Target.process.Ext.services | Services running in this process. | keyword |
+| Target.process.Ext.session | Session information for the current process | keyword |
 | Target.process.Ext.token.domain | Domain of token user. | keyword |
 | Target.process.Ext.token.elevation | Whether the token is elevated or not | boolean |
 | Target.process.Ext.token.elevation_type | What level of elevation the token has | keyword |
@@ -681,6 +682,7 @@ sent by the endpoint.
 | process.Ext.memory_region.strings | Array of strings found within the memory region. | keyword |
 | process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | process.Ext.services | Services running in this process. | keyword |
+| process.Ext.session | Session information for the current process | keyword |
 | process.Ext.token.domain | Domain of token user. | keyword |
 | process.Ext.token.elevation | Whether the token is elevated or not | boolean |
 | process.Ext.token.elevation_type | What level of elevation the token has | keyword |
@@ -2096,13 +2098,14 @@ sent by the endpoint.
 | process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | process.Ext.relative_file_creation_time | Number of seconds since the process's file was created. This number may be negative if the file's timestamp is in the future. | double |
 | process.Ext.relative_file_name_modify_time | Number of seconds since the process's name was modified. This information can come from the NTFS MFT. This number may be negative if the file's timestamp is in the future. | double |
-| process.Ext.session.authentication_package | Name of authentication package used to log on, such as NTLM, Kerberos, or CloudAP | keyword |
-| process.Ext.session.client_address | Client's IPv4 or IPv6 address as a string, if available. | keyword |
-| process.Ext.session.id | Session ID | unsigned_long |
-| process.Ext.session.logon_type | Session logon type.  Examples include Interactive, Network, and Service. | keyword |
-| process.Ext.session.relative_logon_time | Process creation time, relative to logon time, in seconds. | double |
-| process.Ext.session.relative_password_age | Process creation time, relative to the last time the password was changed, in seconds. | double |
-| process.Ext.session.user_flags | List of user flags associated with this logon session. Examples include LOGON_NTLMV2_ENABLED and LOGON_WINLOGON. | keyword |
+| process.Ext.session | Session information for the current process | keyword |
+| process.Ext.session_info.authentication_package | Name of authentication package used to log on, such as NTLM, Kerberos, or CloudAP | keyword |
+| process.Ext.session_info.client_address | Client's IPv4 or IPv6 address as a string, if available. | keyword |
+| process.Ext.session_info.id | Session ID | unsigned_long |
+| process.Ext.session_info.logon_type | Session logon type.  Examples include Interactive, Network, and Service. | keyword |
+| process.Ext.session_info.relative_logon_time | Process creation time, relative to logon time, in seconds. | double |
+| process.Ext.session_info.relative_password_age | Process creation time, relative to the last time the password was changed, in seconds. | double |
+| process.Ext.session_info.user_flags | List of user flags associated with this logon session. Examples include LOGON_NTLMV2_ENABLED and LOGON_WINLOGON. | keyword |
 | process.Ext.token.elevation | Whether the token is elevated or not | boolean |
 | process.Ext.token.elevation_level | What level of elevation the token has | keyword |
 | process.Ext.token.elevation_type | What level of elevation the token has | keyword |

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -862,6 +862,17 @@ Target.process.Ext.services:
   original_fieldset: process
   short: Services running in this process.
   type: keyword
+Target.process.Ext.session:
+  dashed_name: Target-process-Ext-session
+  description: Session information for the current process
+  flat_name: Target.process.Ext.session
+  ignore_above: 1024
+  level: custom
+  name: Ext.session
+  normalize: []
+  original_fieldset: process
+  short: Session information for the current process
+  type: keyword
 Target.process.Ext.token.domain:
   dashed_name: Target-process-Ext-token-domain
   description: Domain of token user.
@@ -5788,6 +5799,16 @@ process.Ext.services:
   name: Ext.services
   normalize: []
   short: Services running in this process.
+  type: keyword
+process.Ext.session:
+  dashed_name: process-Ext-session
+  description: Session information for the current process
+  flat_name: process.Ext.session
+  ignore_above: 1024
+  level: custom
+  name: Ext.session
+  normalize: []
+  short: Session information for the current process
   type: keyword
 process.Ext.token.domain:
   dashed_name: process-Ext-token-domain

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -1196,6 +1196,17 @@ Target.process.Ext.services:
   original_fieldset: process
   short: Services running in this process.
   type: keyword
+Target.process.Ext.session:
+  dashed_name: Target-process-Ext-session
+  description: Session information for the current process
+  flat_name: Target.process.Ext.session
+  ignore_above: 1024
+  level: custom
+  name: Ext.session
+  normalize: []
+  original_fieldset: process
+  short: Session information for the current process
+  type: keyword
 Target.process.Ext.token.domain:
   dashed_name: Target-process-Ext-token-domain
   description: Domain of token user.
@@ -6408,6 +6419,16 @@ process.Ext.services:
   name: Ext.services
   normalize: []
   short: Services running in this process.
+  type: keyword
+process.Ext.session:
+  dashed_name: process-Ext-session
+  description: Session information for the current process
+  flat_name: process.Ext.session
+  ignore_above: 1024
+  level: custom
+  name: Ext.session
+  normalize: []
+  short: Session information for the current process
   type: keyword
 process.Ext.token.domain:
   dashed_name: process-Ext-token-domain

--- a/schemas/v1/alerts/ransomware_event.yaml
+++ b/schemas/v1/alerts/ransomware_event.yaml
@@ -2566,6 +2566,16 @@ process.Ext.services:
   normalize: []
   short: Services running in this process.
   type: keyword
+process.Ext.session:
+  dashed_name: process-Ext-session
+  description: Session information for the current process
+  flat_name: process.Ext.session
+  ignore_above: 1024
+  level: custom
+  name: Ext.session
+  normalize: []
+  short: Session information for the current process
+  type: keyword
 process.Ext.token.domain:
   dashed_name: process-Ext-token-domain
   description: Domain of token user.

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1558,75 +1558,85 @@ process.Ext.relative_file_name_modify_time:
   normalize: []
   short: Number of seconds since the process's name was modified
   type: double
-process.Ext.session.authentication_package:
-  dashed_name: process-Ext-session-authentication-package
-  description: Name of authentication package used to log on, such as NTLM, Kerberos,
-    or CloudAP
-  flat_name: process.Ext.session.authentication_package
+process.Ext.session:
+  dashed_name: process-Ext-session
+  description: Session information for the current process
+  flat_name: process.Ext.session
   ignore_above: 1024
   level: custom
-  name: Ext.session.authentication_package
+  name: Ext.session
+  normalize: []
+  short: Session information for the current process
+  type: keyword
+process.Ext.session_info.authentication_package:
+  dashed_name: process-Ext-session-info-authentication-package
+  description: Name of authentication package used to log on, such as NTLM, Kerberos,
+    or CloudAP
+  flat_name: process.Ext.session_info.authentication_package
+  ignore_above: 1024
+  level: custom
+  name: Ext.session_info.authentication_package
   normalize: []
   short: Name of authentication package used to log on, such as NTLM, Kerberos, or
     CloudAP
   type: keyword
-process.Ext.session.client_address:
-  dashed_name: process-Ext-session-client-address
+process.Ext.session_info.client_address:
+  dashed_name: process-Ext-session-info-client-address
   description: Client's IPv4 or IPv6 address as a string, if available.
-  flat_name: process.Ext.session.client_address
+  flat_name: process.Ext.session_info.client_address
   ignore_above: 1024
   level: custom
-  name: Ext.session.client_address
+  name: Ext.session_info.client_address
   normalize: []
   short: Client's IPv4 or IPv6 address as a string, if available.
   type: keyword
-process.Ext.session.id:
-  dashed_name: process-Ext-session-id
+process.Ext.session_info.id:
+  dashed_name: process-Ext-session-info-id
   description: Session ID
-  flat_name: process.Ext.session.id
+  flat_name: process.Ext.session_info.id
   level: custom
-  name: Ext.session.id
+  name: Ext.session_info.id
   normalize: []
   short: Session ID
   type: unsigned_long
-process.Ext.session.logon_type:
-  dashed_name: process-Ext-session-logon-type
+process.Ext.session_info.logon_type:
+  dashed_name: process-Ext-session-info-logon-type
   description: Session logon type.  Examples include Interactive, Network, and Service.
-  flat_name: process.Ext.session.logon_type
+  flat_name: process.Ext.session_info.logon_type
   ignore_above: 1024
   level: custom
-  name: Ext.session.logon_type
+  name: Ext.session_info.logon_type
   normalize: []
   short: Session logon type.  Examples include Interactive, Network, and Service.
   type: keyword
-process.Ext.session.relative_logon_time:
-  dashed_name: process-Ext-session-relative-logon-time
+process.Ext.session_info.relative_logon_time:
+  dashed_name: process-Ext-session-info-relative-logon-time
   description: Process creation time, relative to logon time, in seconds.
-  flat_name: process.Ext.session.relative_logon_time
+  flat_name: process.Ext.session_info.relative_logon_time
   level: custom
-  name: Ext.session.relative_logon_time
+  name: Ext.session_info.relative_logon_time
   normalize: []
   short: Process creation time, relative to logon time, in seconds.
   type: double
-process.Ext.session.relative_password_age:
-  dashed_name: process-Ext-session-relative-password-age
+process.Ext.session_info.relative_password_age:
+  dashed_name: process-Ext-session-info-relative-password-age
   description: Process creation time, relative to the last time the password was changed,
     in seconds.
-  flat_name: process.Ext.session.relative_password_age
+  flat_name: process.Ext.session_info.relative_password_age
   level: custom
-  name: Ext.session.relative_password_age
+  name: Ext.session_info.relative_password_age
   normalize: []
   short: Process creation time, relative to the last time the password was changed,
     in seconds.
   type: double
-process.Ext.session.user_flags:
-  dashed_name: process-Ext-session-user-flags
+process.Ext.session_info.user_flags:
+  dashed_name: process-Ext-session-info-user-flags
   description: List of user flags associated with this logon session. Examples include
     LOGON_NTLMV2_ENABLED and LOGON_WINLOGON.
-  flat_name: process.Ext.session.user_flags
+  flat_name: process.Ext.session_info.user_flags
   ignore_above: 1024
   level: custom
-  name: Ext.session.user_flags
+  name: Ext.session_info.user_flags
   normalize: []
   short: List of user flags associated with this logon session. Examples include LOGON_NTLMV2_ENABLED
     and LOGON_WINLOGON.


### PR DESCRIPTION
backports #318 to 8.4