### PR TITLE
Update 8.6 branch Jenkins file to publish 8.6.x line Endpoint packages

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -205,7 +205,7 @@ def signUnpublishedArtifactsWithElastic(builtPackagesPath) {
 }
 
 def uploadUnpublishedToPackageStorage(builtPackagesPath) {
-  def dryRun = env.BRANCH_NAME != 'master'
+  def dryRun = env.BRANCH_NAME != '8.6'
   if (dryRun) {
     echo "Dry run: endpoint-package won't be published"
   }


### PR DESCRIPTION
## Change Summary

This updates the Jenkins file for the `8.6` branch to publish new packages on the `8.6.x` line.  It should publish any incremented `8.6.x` packages merged to the `8.6` branch.
