### PR TITLE
Update `run-registry` command and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,7 @@ The Ingest Manager will now use your locally running package registry for retrie
 within Kibana does some caching after it has downloaded a package, so if you are not seeing your changes you might
 need to restart Kibana and Elasticsearch.
 
-If you want to check you are using the correct Ingest manager go to Management -> Integrations in Kibana and search for Elastic Defend. Observe the version number. You should see the `-dev` or `-next` sufix in the version.
-
-If you are testing changes, you are likely testing a pre-release version.  In order to test the pre-release package, you must enable the 
-`Display beta integrations` switch on the Management -> Integration page.  After you turn this switch on, you will see a `beta` version of the Elastic Defend integration in the UI.  Add this integration to an Agent Policy to install your package and test it.
+If you want to check you are using the correct Ingest manager go to Management -> Integrations in Kibana and search for Elastic Defend. It is likely that you are testing a pre-release version. In order to test properly, enable the Display beta integrations switch on this page. Afterwards, you will see a beta version of Elastic Defend in the UI. Observe the version number. You should see the -dev or -next sufix in the version. Add this version of Elastic Defend to your Agent Policy to install the package and test it.
 
 If you don't see your version in the Integration you want to make sure the Ingest Manager is running correctly you can try a request to test it:
 
@@ -90,7 +87,7 @@ curl "http://localhost:8080/search?package=endpoint"
 
 If you see a JSON response, the Ingest Manager is running and it is probably a problem in your Kibana configuration. If you don't get a response you should check the running Ingest Manager process you probably started with docker.
 
-To ensure that the package your testing is in your locally running registry, add the `prerelease` flag to the query param.
+Note, since you are likely testing a pre-release version of the package, to ensure that the dev package that you're testing is in your locally running registry, add the `prerelease` flag to the query param.
 
 ```bash
 curl "http://localhost:8080/search?package=endpoint&prerelease=true"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ The Ingest Manager will now use your locally running package registry for retrie
 within Kibana does some caching after it has downloaded a package, so if you are not seeing your changes you might
 need to restart Kibana and Elasticsearch.
 
-If you want to check you are using the correct Ingest manager go to Management -> Integrations in Kibana and search for Endpoint Security. Observe the version number. You should see the `-dev` sufix in the version.
+If you want to check you are using the correct Ingest manager go to Management -> Integrations in Kibana and search for Elastic Defend. Observe the version number. You should see the `-dev` or `-next` sufix in the version.
+
+If you are testing changes, you are likely testing a pre-release version.  In order to test the pre-release package, you must enable the 
+`Display beta integrations` switch on the Management -> Integration page.  After you turn this switch on, you will see a `beta` version of the Elastic Defend integration in the UI.  Add this integration to an Agent Policy to install your package and test it.
 
 If you don't see your version in the Integration you want to make sure the Ingest Manager is running correctly you can try a request to test it:
 
@@ -86,6 +89,12 @@ curl "http://localhost:8080/search?package=endpoint"
 ```
 
 If you see a JSON response, the Ingest Manager is running and it is probably a problem in your Kibana configuration. If you don't get a response you should check the running Ingest Manager process you probably started with docker.
+
+To ensure that the package your testing is in your locally running registry, add the `prerelease` flag to the query param.
+
+```bash
+curl "http://localhost:8080/search?package=endpoint&prerelease=true"
+```
 
 ### PR the changes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,9 @@ version: "3.8"
 services:
   package-registry:
     # to use the latest package-registry alone you can use: docker.elastic.co/package-registry/package-registry:master
-    image: docker.elastic.co/package-registry/distribution:production
+    environment:
+      - EPR_FEATURE_PROXY_MODE=true
+    image: docker.elastic.co/package-registry/package-registry:main
     volumes:
       - ./package-registry.config.yml:/package-registry/config.yml
       - ./out/packages:/packages/endpoint-package

--- a/package-registry.config.yml
+++ b/package-registry.config.yml
@@ -1,6 +1,3 @@
 package_paths:
-  - /packages/production
-  - /packages/staging
-  - /packages/snapshot
   - /packages/endpoint-package
 dev_mode: true


### PR DESCRIPTION
## Change Summary

All packages are now pushed to a single place at `https://epr.elastic.co/`.  As a result, use a new environment variable in the registry docker to pull all other packages from the central registry.

In addition, update the README to show how to properly test your in development Endpoint package.