### PR TITLE
Update unsupported u64 type to unsigned_long

### DIFF
--- a/custom_schemas/custom_dll.yml
+++ b/custom_schemas/custom_dll.yml
@@ -128,7 +128,7 @@
         
     - name: Ext.size
       level: custom
-      type: u64
+      type: long
       short: Size of DLL
       description: >
         Size of DLL

--- a/custom_schemas/custom_dll.yml
+++ b/custom_schemas/custom_dll.yml
@@ -128,7 +128,7 @@
         
     - name: Ext.size
       level: custom
-      type: long
+      type: unsigned_long
       short: Size of DLL
       description: >
         Size of DLL

--- a/package/endpoint/data_stream/library/fields/fields.yml
+++ b/package/endpoint/data_stream/library/fields/fields.yml
@@ -294,7 +294,7 @@
       default_field: false
     - name: Ext.size
       level: custom
-      type: long
+      type: unsigned_long
       description: Size of DLL
       default_field: false
     - name: code_signature.exists

--- a/package/endpoint/data_stream/library/fields/fields.yml
+++ b/package/endpoint/data_stream/library/fields/fields.yml
@@ -294,7 +294,7 @@
       default_field: false
     - name: Ext.size
       level: custom
-      type: u64
+      type: long
       description: Size of DLL
       default_field: false
     - name: code_signature.exists

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1675,7 +1675,7 @@ sent by the endpoint.
 | dll.Ext.load_index | A DLL can be loaded into a process multiple times. This field indicates the Nth time that this DLL has been loaded. The first load index is 1. | unsigned_long |
 | dll.Ext.relative_file_creation_time | Number of seconds since the DLL's file was created. This number may be negative if the file's timestamp is in the future. | double |
 | dll.Ext.relative_file_name_modify_time | Number of seconds since the DLL's name was modified. This information can come from the NTFS MFT. This number may be negative if the file's timestamp is in the future. | double |
-| dll.Ext.size | Size of DLL | long |
+| dll.Ext.size | Size of DLL | unsigned_long |
 | dll.code_signature.exists | Boolean to capture if a signature is present. | boolean |
 | dll.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
 | dll.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1675,7 +1675,7 @@ sent by the endpoint.
 | dll.Ext.load_index | A DLL can be loaded into a process multiple times. This field indicates the Nth time that this DLL has been loaded. The first load index is 1. | unsigned_long |
 | dll.Ext.relative_file_creation_time | Number of seconds since the DLL's file was created. This number may be negative if the file's timestamp is in the future. | double |
 | dll.Ext.relative_file_name_modify_time | Number of seconds since the DLL's name was modified. This information can come from the NTFS MFT. This number may be negative if the file's timestamp is in the future. | double |
-| dll.Ext.size | Size of DLL | u64 |
+| dll.Ext.size | Size of DLL | long |
 | dll.code_signature.exists | Boolean to capture if a signature is present. | boolean |
 | dll.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
 | dll.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -437,7 +437,7 @@ dll.Ext.size:
   name: Ext.size
   normalize: []
   short: Size of DLL
-  type: long
+  type: unsigned_long
 dll.code_signature.exists:
   dashed_name: dll-code-signature-exists
   description: Boolean to capture if a signature is present.

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -437,7 +437,7 @@ dll.Ext.size:
   name: Ext.size
   normalize: []
   short: Size of DLL
-  type: u64
+  type: long
 dll.code_signature.exists:
   dashed_name: dll-code-signature-exists
   description: Boolean to capture if a signature is present.


### PR DESCRIPTION
## Change Summary

When installing the new Endpoint package with the 8.7.0 changes, the addition of a type `u64` is causing the package to fail to install.  This changes this to be `unsigned_long` which is a supported type and can be installed.

The merge that introduced the unsupported type was only applied to the 8.7.0 line, so we just need to fix it here before releasing the new package.  The problem has not been released to production.

PR with the u64 type: https://github.com/elastic/endpoint-package/pull/329

Console error with u64 type:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/56395104/215589227-6d8a3fcd-e78f-4e01-a934-6a60d4c93475.png">

new installed template with `unsigned_long`
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/56395104/215592212-ebf4b22a-101b-4606-b797-d444304848ed.png">

### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json


```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
