### PR TITLE
Update ECS to 8.7-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 # we are intentionally pinning the ECS version here, when ecs releases a new version
 # we'll discuss whether we need to release a new package and bump the version here
-ECS_GIT_REF ?= v8.5.2
+# b1caa2327113d6f9f92782eeb2c36bcbf6f4b031 is 8.7-dev
+ECS_GIT_REF ?= b1caa2327113d6f9f92782eeb2c36bcbf6f4b031
 
 # This variable specifies to location of the package-storage repo. It is used for automatically creating a PR
 # to release a new endpoint package. This can be overridden with the location on your file system using the config.mk

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 # we are intentionally pinning the ECS version here, when ecs releases a new version
 # we'll discuss whether we need to release a new package and bump the version here
-# b1caa2327113d6f9f92782eeb2c36bcbf6f4b031 is 8.7-dev
-ECS_GIT_REF ?= b1caa2327113d6f9f92782eeb2c36bcbf6f4b031
+# cd3227cb3eb0de7e422aef90a64321ac68f7896e is 8.7-dev
+ECS_GIT_REF ?= cd3227cb3eb0de7e422aef90a64321ac68f7896e
 
 # This variable specifies to location of the package-storage repo. It is used for automatically creating a PR
 # to release a new endpoint package. This can be overridden with the location on your file system using the config.mk

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -4163,7 +4163,7 @@
       ignore_above: 1024
       description: 'Name of the host.
 
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+        It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host.'
     - name: os.Ext
       level: custom
       type: object
@@ -8102,6 +8102,37 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: enrichments.indicator.file.elf.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).'
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: enrichments.indicator.file.elf.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: enrichments.indicator.file.elf.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: enrichments.indicator.file.elf.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: enrichments.indicator.file.elf.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: enrichments.indicator.file.elf.header.abi_version
       level: extended
       type: keyword
@@ -8150,10 +8181,31 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: enrichments.indicator.file.elf.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: enrichments.indicator.file.elf.imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: enrichments.indicator.file.elf.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names and types.
+      default_field: false
+    - name: enrichments.indicator.file.elf.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported element names and types.
       default_field: false
     - name: enrichments.indicator.file.elf.sections
       level: extended
@@ -8203,6 +8255,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: enrichments.indicator.file.elf.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: enrichments.indicator.file.elf.sections.virtual_address
       level: extended
@@ -8546,7 +8604,7 @@
       type: keyword
       ignore_above: 1024
       description: Traffic Light Protocol sharing markings.
-      example: WHITE
+      example: CLEAR
       default_field: false
     - name: enrichments.indicator.modified_at
       level: extended
@@ -9483,6 +9541,37 @@
       type: flattened
       description: List of exported element names and types.
       default_field: false
+    - name: indicator.file.elf.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).'
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: indicator.file.elf.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: indicator.file.elf.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: indicator.file.elf.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: indicator.file.elf.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
     - name: indicator.file.elf.header.abi_version
       level: extended
       type: keyword
@@ -9531,10 +9620,31 @@
       ignore_above: 1024
       description: Version of the ELF header.
       default_field: false
+    - name: indicator.file.elf.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in an ELF file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        This is an ELF implementation of the Windows PE imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
     - name: indicator.file.elf.imports
       level: extended
       type: flattened
       description: List of imported element names and types.
+      default_field: false
+    - name: indicator.file.elf.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names and types.
+      default_field: false
+    - name: indicator.file.elf.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported element names and types.
       default_field: false
     - name: indicator.file.elf.sections
       level: extended
@@ -9584,6 +9694,12 @@
       type: keyword
       ignore_above: 1024
       description: ELF Section List type.
+      default_field: false
+    - name: indicator.file.elf.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
       default_field: false
     - name: indicator.file.elf.sections.virtual_address
       level: extended
@@ -9927,7 +10043,7 @@
       type: keyword
       ignore_above: 1024
       description: Traffic Light Protocol sharing markings.
-      example: WHITE
+      example: CLEAR
       default_field: false
     - name: indicator.modified_at
       level: extended

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -245,7 +245,7 @@
       ignore_above: 1024
       description: 'Name of the host.
 
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+        It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host.'
     - name: os.Ext
       level: custom
       type: object

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -942,7 +942,7 @@
       ignore_above: 1024
       description: 'Name of the host.
 
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+        It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host.'
     - name: os.Ext
       level: custom
       type: object

--- a/package/endpoint/data_stream/library/fields/fields.yml
+++ b/package/endpoint/data_stream/library/fields/fields.yml
@@ -899,7 +899,7 @@
       ignore_above: 1024
       description: 'Name of the host.
 
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+        It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host.'
     - name: os.Ext
       level: custom
       type: object

--- a/package/endpoint/data_stream/metadata/fields/fields.yml
+++ b/package/endpoint/data_stream/metadata/fields/fields.yml
@@ -382,7 +382,7 @@
       ignore_above: 1024
       description: 'Name of the host.
 
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+        It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host.'
     - name: os.Ext
       level: custom
       type: object

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -908,7 +908,7 @@
       ignore_above: 1024
       description: 'Name of the host.
 
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+        It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host.'
     - name: os.Ext
       level: custom
       type: object

--- a/package/endpoint/data_stream/network/fields/fields.yml
+++ b/package/endpoint/data_stream/network/fields/fields.yml
@@ -564,7 +564,7 @@
       ignore_above: 1024
       description: 'Name of the host.
 
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+        It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host.'
     - name: os.Ext
       level: custom
       type: object

--- a/package/endpoint/data_stream/policy/fields/fields.yml
+++ b/package/endpoint/data_stream/policy/fields/fields.yml
@@ -691,7 +691,7 @@
       ignore_above: 1024
       description: 'Name of the host.
 
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+        It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host.'
     - name: os.Ext
       level: custom
       type: object

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -527,7 +527,7 @@
       ignore_above: 1024
       description: 'Name of the host.
 
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+        It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host.'
     - name: os.Ext
       level: custom
       type: object

--- a/package/endpoint/data_stream/registry/fields/fields.yml
+++ b/package/endpoint/data_stream/registry/fields/fields.yml
@@ -464,7 +464,7 @@
       ignore_above: 1024
       description: 'Name of the host.
 
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+        It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host.'
     - name: os.Ext
       level: custom
       type: object

--- a/package/endpoint/data_stream/security/fields/fields.yml
+++ b/package/endpoint/data_stream/security/fields/fields.yml
@@ -424,7 +424,7 @@
       ignore_above: 1024
       description: 'Name of the host.
 
-        It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use.'
+        It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host.'
     - name: os.Ext
       level: custom
       type: object

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -565,7 +565,7 @@ sent by the endpoint.
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
 | host.os.Ext | Object for all custom defined fields to live in. | object |
 | host.os.Ext.variant | A string value or phrase that further aid to classify or qualify the operating system (OS).  For example the distribution for a Linux OS will be entered in this field. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
@@ -1085,6 +1085,11 @@ sent by the endpoint.
 | threat.enrichments.indicator.file.elf.cpu_type | CPU type of the ELF file. | keyword |
 | threat.enrichments.indicator.file.elf.creation_date | Extracted when possible from the file's metadata. Indicates when it was built or compiled. It can also be faked by malware creators. | date |
 | threat.enrichments.indicator.file.elf.exports | List of exported element names and types. | flattened |
+| threat.enrichments.indicator.file.elf.go_import_hash | A hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values. The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma). | keyword |
+| threat.enrichments.indicator.file.elf.go_imports | List of imported Go language element names and types. | flattened |
+| threat.enrichments.indicator.file.elf.go_imports_names_entropy | Shannon entropy calculation from the list of Go imports. | long |
+| threat.enrichments.indicator.file.elf.go_imports_names_var_entropy | Variance for Shannon entropy calculation from the list of Go imports. | long |
+| threat.enrichments.indicator.file.elf.go_stripped | Set to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable. | boolean |
 | threat.enrichments.indicator.file.elf.header.abi_version | Version of the ELF Application Binary Interface (ABI). | keyword |
 | threat.enrichments.indicator.file.elf.header.class | Header class of the ELF file. | keyword |
 | threat.enrichments.indicator.file.elf.header.data | Data table of the ELF header. | keyword |
@@ -1093,7 +1098,10 @@ sent by the endpoint.
 | threat.enrichments.indicator.file.elf.header.os_abi | Application Binary Interface (ABI) of the Linux OS. | keyword |
 | threat.enrichments.indicator.file.elf.header.type | Header type of the ELF file. | keyword |
 | threat.enrichments.indicator.file.elf.header.version | Version of the ELF header. | keyword |
+| threat.enrichments.indicator.file.elf.import_hash | A hash of the imports in an ELF file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values. This is an ELF implementation of the Windows PE imphash. | keyword |
 | threat.enrichments.indicator.file.elf.imports | List of imported element names and types. | flattened |
+| threat.enrichments.indicator.file.elf.imports_names_entropy | Shannon entropy calculation from the list of imported element names and types. | long |
+| threat.enrichments.indicator.file.elf.imports_names_var_entropy | Variance for Shannon entropy calculation from the list of imported element names and types. | long |
 | threat.enrichments.indicator.file.elf.sections | An array containing an object for each section of the ELF file. The keys that should be present in these objects are defined by sub-fields underneath `elf.sections.*`. | nested |
 | threat.enrichments.indicator.file.elf.sections.chi2 | Chi-square probability distribution of the section. | long |
 | threat.enrichments.indicator.file.elf.sections.entropy | Shannon entropy calculation from the section. | long |
@@ -1102,6 +1110,7 @@ sent by the endpoint.
 | threat.enrichments.indicator.file.elf.sections.physical_offset | ELF Section List offset. | keyword |
 | threat.enrichments.indicator.file.elf.sections.physical_size | ELF Section List physical size. | long |
 | threat.enrichments.indicator.file.elf.sections.type | ELF Section List type. | keyword |
+| threat.enrichments.indicator.file.elf.sections.var_entropy | Variance for Shannon entropy calculation from the section. | long |
 | threat.enrichments.indicator.file.elf.sections.virtual_address | ELF Section List virtual address. | long |
 | threat.enrichments.indicator.file.elf.sections.virtual_size | ELF Section List virtual size. | long |
 | threat.enrichments.indicator.file.elf.segments | An array containing an object for each segment of the ELF file. The keys that should be present in these objects are defined by sub-fields underneath `elf.segments.*`. | nested |
@@ -1288,6 +1297,11 @@ sent by the endpoint.
 | threat.indicator.file.elf.cpu_type | CPU type of the ELF file. | keyword |
 | threat.indicator.file.elf.creation_date | Extracted when possible from the file's metadata. Indicates when it was built or compiled. It can also be faked by malware creators. | date |
 | threat.indicator.file.elf.exports | List of exported element names and types. | flattened |
+| threat.indicator.file.elf.go_import_hash | A hash of the Go language imports in an ELF file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values. The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma). | keyword |
+| threat.indicator.file.elf.go_imports | List of imported Go language element names and types. | flattened |
+| threat.indicator.file.elf.go_imports_names_entropy | Shannon entropy calculation from the list of Go imports. | long |
+| threat.indicator.file.elf.go_imports_names_var_entropy | Variance for Shannon entropy calculation from the list of Go imports. | long |
+| threat.indicator.file.elf.go_stripped | Set to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable. | boolean |
 | threat.indicator.file.elf.header.abi_version | Version of the ELF Application Binary Interface (ABI). | keyword |
 | threat.indicator.file.elf.header.class | Header class of the ELF file. | keyword |
 | threat.indicator.file.elf.header.data | Data table of the ELF header. | keyword |
@@ -1296,7 +1310,10 @@ sent by the endpoint.
 | threat.indicator.file.elf.header.os_abi | Application Binary Interface (ABI) of the Linux OS. | keyword |
 | threat.indicator.file.elf.header.type | Header type of the ELF file. | keyword |
 | threat.indicator.file.elf.header.version | Version of the ELF header. | keyword |
+| threat.indicator.file.elf.import_hash | A hash of the imports in an ELF file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values. This is an ELF implementation of the Windows PE imphash. | keyword |
 | threat.indicator.file.elf.imports | List of imported element names and types. | flattened |
+| threat.indicator.file.elf.imports_names_entropy | Shannon entropy calculation from the list of imported element names and types. | long |
+| threat.indicator.file.elf.imports_names_var_entropy | Variance for Shannon entropy calculation from the list of imported element names and types. | long |
 | threat.indicator.file.elf.sections | An array containing an object for each section of the ELF file. The keys that should be present in these objects are defined by sub-fields underneath `elf.sections.*`. | nested |
 | threat.indicator.file.elf.sections.chi2 | Chi-square probability distribution of the section. | long |
 | threat.indicator.file.elf.sections.entropy | Shannon entropy calculation from the section. | long |
@@ -1305,6 +1322,7 @@ sent by the endpoint.
 | threat.indicator.file.elf.sections.physical_offset | ELF Section List offset. | keyword |
 | threat.indicator.file.elf.sections.physical_size | ELF Section List physical size. | long |
 | threat.indicator.file.elf.sections.type | ELF Section List type. | keyword |
+| threat.indicator.file.elf.sections.var_entropy | Variance for Shannon entropy calculation from the section. | long |
 | threat.indicator.file.elf.sections.virtual_address | ELF Section List virtual address. | long |
 | threat.indicator.file.elf.sections.virtual_size | ELF Section List virtual size. | long |
 | threat.indicator.file.elf.segments | An array containing an object for each segment of the ELF file. The keys that should be present in these objects are defined by sub-fields underneath `elf.segments.*`. | nested |
@@ -1569,7 +1587,7 @@ sent by the endpoint.
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
 | host.os.Ext | Object for all custom defined fields to live in. | object |
 | host.os.Ext.variant | A string value or phrase that further aid to classify or qualify the operating system (OS).  For example the distribution for a Linux OS will be entered in this field. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
@@ -1758,7 +1776,7 @@ sent by the endpoint.
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
 | host.os.Ext | Object for all custom defined fields to live in. | object |
 | host.os.Ext.variant | A string value or phrase that further aid to classify or qualify the operating system (OS).  For example the distribution for a Linux OS will be entered in this field. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
@@ -1893,7 +1911,7 @@ sent by the endpoint.
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
 | host.os.Ext | Object for all custom defined fields to live in. | object |
 | host.os.Ext.variant | A string value or phrase that further aid to classify or qualify the operating system (OS).  For example the distribution for a Linux OS will be entered in this field. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
@@ -2055,7 +2073,7 @@ sent by the endpoint.
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
 | host.os.Ext | Object for all custom defined fields to live in. | object |
 | host.os.Ext.variant | A string value or phrase that further aid to classify or qualify the operating system (OS).  For example the distribution for a Linux OS will be entered in this field. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
@@ -2442,7 +2460,7 @@ sent by the endpoint.
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
 | host.os.Ext | Object for all custom defined fields to live in. | object |
 | host.os.Ext.variant | A string value or phrase that further aid to classify or qualify the operating system (OS).  For example the distribution for a Linux OS will be entered in this field. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
@@ -2565,7 +2583,7 @@ sent by the endpoint.
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
 | host.os.Ext | Object for all custom defined fields to live in. | object |
 | host.os.Ext.variant | A string value or phrase that further aid to classify or qualify the operating system (OS).  For example the distribution for a Linux OS will be entered in this field. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
@@ -2682,7 +2700,7 @@ sent by the endpoint.
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
 | host.os.Ext | Object for all custom defined fields to live in. | object |
 | host.os.Ext.variant | A string value or phrase that further aid to classify or qualify the operating system (OS).  For example the distribution for a Linux OS will be entered in this field. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
@@ -2792,7 +2810,7 @@ Metrics documents contain performance information about the endpoint executable 
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
 | host.os.Ext | Object for all custom defined fields to live in. | object |
 | host.os.Ext.variant | A string value or phrase that further aid to classify or qualify the operating system (OS).  For example the distribution for a Linux OS will be entered in this field. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |
@@ -2853,7 +2871,7 @@ Metrics documents contain performance information about the endpoint executable 
 | host.id | Unique host id. As hostname is not always unique, use values that are meaningful in your environment. Example: The current usage of `beat.name`. | keyword |
 | host.ip | Host ip addresses. | ip |
 | host.mac | Host MAC addresses. The notation format from RFC 7042 is suggested: Each octet (that is, 8-bit byte) is represented by two [uppercase] hexadecimal digits giving the value of the octet as an unsigned integer. Successive octets are separated by a hyphen. | keyword |
-| host.name | Name of the host. It can contain what `hostname` returns on Unix systems, the fully qualified domain name, or a name specified by the user. The sender decides which value to use. | keyword |
+| host.name | Name of the host. It can contain what hostname returns on Unix systems, the fully qualified domain name (FQDN), or a name specified by the user. The recommended value is the lowercase FQDN of the host. | keyword |
 | host.os.Ext | Object for all custom defined fields to live in. | object |
 | host.os.Ext.variant | A string value or phrase that further aid to classify or qualify the operating system (OS).  For example the distribution for a Linux OS will be entered in this field. | keyword |
 | host.os.family | OS family (such as redhat, debian, freebsd, windows). | keyword |

--- a/schemas/v1/action_responses/action_responses.yaml
+++ b/schemas/v1/action_responses/action_responses.yaml
@@ -269,6 +269,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -438,6 +456,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in

--- a/schemas/v1/actions/actions.yaml
+++ b/schemas/v1/actions/actions.yaml
@@ -257,6 +257,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -426,6 +444,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -3114,6 +3114,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -3283,6 +3301,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -5193,8 +5217,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core
@@ -8433,6 +8458,67 @@ threat.enrichments.indicator.file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+threat.enrichments.indicator.file.elf.go_import_hash:
+  dashed_name: threat-enrichments-indicator-file-elf-go-import-hash
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.enrichments.indicator.file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.enrichments.indicator.file.elf.go_imports:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.enrichments.indicator.file.elf.go_imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.elf.go_imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.elf.go_stripped:
+  dashed_name: threat-enrichments-indicator-file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.enrichments.indicator.file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.enrichments.indicator.file.elf.header.abi_version:
   dashed_name: threat-enrichments-indicator-file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -8521,6 +8607,22 @@ threat.enrichments.indicator.file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+threat.enrichments.indicator.file.elf.import_hash:
+  dashed_name: threat-enrichments-indicator-file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.enrichments.indicator.file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 threat.enrichments.indicator.file.elf.imports:
   dashed_name: threat-enrichments-indicator-file-elf-imports
   description: List of imported element names and types.
@@ -8532,6 +8634,31 @@ threat.enrichments.indicator.file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+threat.enrichments.indicator.file.elf.imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.enrichments.indicator.file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.enrichments.indicator.file.elf.imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.enrichments.indicator.file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.enrichments.indicator.file.elf.sections:
   dashed_name: threat-enrichments-indicator-file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -8623,6 +8750,17 @@ threat.enrichments.indicator.file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+threat.enrichments.indicator.file.elf.sections.var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.enrichments.indicator.file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 threat.enrichments.indicator.file.elf.sections.virtual_address:
   dashed_name: threat-enrichments-indicator-file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -9214,11 +9352,13 @@ threat.enrichments.indicator.last_seen:
 threat.enrichments.indicator.marking.tlp:
   dashed_name: threat-enrichments-indicator-marking-tlp
   description: Traffic Light Protocol sharing markings.
-  example: WHITE
+  example: CLEAR
   expected_values:
   - WHITE
+  - CLEAR
   - GREEN
   - AMBER
+  - AMBER+STRICT
   - RED
   flat_name: threat.enrichments.indicator.marking.tlp
   ignore_above: 1024
@@ -10967,6 +11107,67 @@ threat.indicator.file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+threat.indicator.file.elf.go_import_hash:
+  dashed_name: threat-indicator-file-elf-go-import-hash
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.indicator.file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.indicator.file.elf.go_imports:
+  dashed_name: threat-indicator-file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.indicator.file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.indicator.file.elf.go_imports_names_entropy:
+  dashed_name: threat-indicator-file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.elf.go_imports_names_var_entropy:
+  dashed_name: threat-indicator-file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.elf.go_stripped:
+  dashed_name: threat-indicator-file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.indicator.file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.indicator.file.elf.header.abi_version:
   dashed_name: threat-indicator-file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -11055,6 +11256,22 @@ threat.indicator.file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+threat.indicator.file.elf.import_hash:
+  dashed_name: threat-indicator-file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.indicator.file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 threat.indicator.file.elf.imports:
   dashed_name: threat-indicator-file-elf-imports
   description: List of imported element names and types.
@@ -11066,6 +11283,31 @@ threat.indicator.file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+threat.indicator.file.elf.imports_names_entropy:
+  dashed_name: threat-indicator-file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.indicator.file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.indicator.file.elf.imports_names_var_entropy:
+  dashed_name: threat-indicator-file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.indicator.file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.indicator.file.elf.sections:
   dashed_name: threat-indicator-file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -11157,6 +11399,17 @@ threat.indicator.file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+threat.indicator.file.elf.sections.var_entropy:
+  dashed_name: threat-indicator-file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.indicator.file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 threat.indicator.file.elf.sections.virtual_address:
   dashed_name: threat-indicator-file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -11748,11 +12001,13 @@ threat.indicator.last_seen:
 threat.indicator.marking.tlp:
   dashed_name: threat-indicator-marking-tlp
   description: Traffic Light Protocol sharing markings.
-  example: WHITE
+  example: CLEAR
   expected_values:
   - WHITE
+  - CLEAR
   - GREEN
   - AMBER
+  - AMBER+STRICT
   - RED
   flat_name: threat.indicator.marking.tlp
   ignore_above: 1024

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -4200,6 +4200,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -4369,6 +4387,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -5105,8 +5129,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core
@@ -9870,6 +9895,67 @@ threat.enrichments.indicator.file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+threat.enrichments.indicator.file.elf.go_import_hash:
+  dashed_name: threat-enrichments-indicator-file-elf-go-import-hash
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.enrichments.indicator.file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.enrichments.indicator.file.elf.go_imports:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.enrichments.indicator.file.elf.go_imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.elf.go_imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.elf.go_stripped:
+  dashed_name: threat-enrichments-indicator-file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.enrichments.indicator.file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.enrichments.indicator.file.elf.header.abi_version:
   dashed_name: threat-enrichments-indicator-file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -9958,6 +10044,22 @@ threat.enrichments.indicator.file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+threat.enrichments.indicator.file.elf.import_hash:
+  dashed_name: threat-enrichments-indicator-file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.enrichments.indicator.file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 threat.enrichments.indicator.file.elf.imports:
   dashed_name: threat-enrichments-indicator-file-elf-imports
   description: List of imported element names and types.
@@ -9969,6 +10071,31 @@ threat.enrichments.indicator.file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+threat.enrichments.indicator.file.elf.imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.enrichments.indicator.file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.enrichments.indicator.file.elf.imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.enrichments.indicator.file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.enrichments.indicator.file.elf.sections:
   dashed_name: threat-enrichments-indicator-file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -10060,6 +10187,17 @@ threat.enrichments.indicator.file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+threat.enrichments.indicator.file.elf.sections.var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.enrichments.indicator.file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 threat.enrichments.indicator.file.elf.sections.virtual_address:
   dashed_name: threat-enrichments-indicator-file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -10651,11 +10789,13 @@ threat.enrichments.indicator.last_seen:
 threat.enrichments.indicator.marking.tlp:
   dashed_name: threat-enrichments-indicator-marking-tlp
   description: Traffic Light Protocol sharing markings.
-  example: WHITE
+  example: CLEAR
   expected_values:
   - WHITE
+  - CLEAR
   - GREEN
   - AMBER
+  - AMBER+STRICT
   - RED
   flat_name: threat.enrichments.indicator.marking.tlp
   ignore_above: 1024
@@ -12404,6 +12544,67 @@ threat.indicator.file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+threat.indicator.file.elf.go_import_hash:
+  dashed_name: threat-indicator-file-elf-go-import-hash
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.indicator.file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.indicator.file.elf.go_imports:
+  dashed_name: threat-indicator-file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.indicator.file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.indicator.file.elf.go_imports_names_entropy:
+  dashed_name: threat-indicator-file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.elf.go_imports_names_var_entropy:
+  dashed_name: threat-indicator-file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.elf.go_stripped:
+  dashed_name: threat-indicator-file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.indicator.file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.indicator.file.elf.header.abi_version:
   dashed_name: threat-indicator-file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -12492,6 +12693,22 @@ threat.indicator.file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+threat.indicator.file.elf.import_hash:
+  dashed_name: threat-indicator-file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.indicator.file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 threat.indicator.file.elf.imports:
   dashed_name: threat-indicator-file-elf-imports
   description: List of imported element names and types.
@@ -12503,6 +12720,31 @@ threat.indicator.file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+threat.indicator.file.elf.imports_names_entropy:
+  dashed_name: threat-indicator-file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.indicator.file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.indicator.file.elf.imports_names_var_entropy:
+  dashed_name: threat-indicator-file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.indicator.file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.indicator.file.elf.sections:
   dashed_name: threat-indicator-file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -12594,6 +12836,17 @@ threat.indicator.file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+threat.indicator.file.elf.sections.var_entropy:
+  dashed_name: threat-indicator-file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.indicator.file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 threat.indicator.file.elf.sections.virtual_address:
   dashed_name: threat-indicator-file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -13185,11 +13438,13 @@ threat.indicator.last_seen:
 threat.indicator.marking.tlp:
   dashed_name: threat-indicator-marking-tlp
   description: Traffic Light Protocol sharing markings.
-  example: WHITE
+  example: CLEAR
   expected_values:
   - WHITE
+  - CLEAR
   - GREEN
   - AMBER
+  - AMBER+STRICT
   - RED
   flat_name: threat.indicator.marking.tlp
   ignore_above: 1024

--- a/schemas/v1/alerts/ransomware_event.yaml
+++ b/schemas/v1/alerts/ransomware_event.yaml
@@ -1153,6 +1153,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -1322,6 +1340,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -2058,8 +2082,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core
@@ -5150,6 +5175,67 @@ threat.enrichments.indicator.file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+threat.enrichments.indicator.file.elf.go_import_hash:
+  dashed_name: threat-enrichments-indicator-file-elf-go-import-hash
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.enrichments.indicator.file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.enrichments.indicator.file.elf.go_imports:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.enrichments.indicator.file.elf.go_imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.elf.go_imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.elf.go_stripped:
+  dashed_name: threat-enrichments-indicator-file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.enrichments.indicator.file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.enrichments.indicator.file.elf.header.abi_version:
   dashed_name: threat-enrichments-indicator-file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -5238,6 +5324,22 @@ threat.enrichments.indicator.file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+threat.enrichments.indicator.file.elf.import_hash:
+  dashed_name: threat-enrichments-indicator-file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.enrichments.indicator.file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 threat.enrichments.indicator.file.elf.imports:
   dashed_name: threat-enrichments-indicator-file-elf-imports
   description: List of imported element names and types.
@@ -5249,6 +5351,31 @@ threat.enrichments.indicator.file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+threat.enrichments.indicator.file.elf.imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.enrichments.indicator.file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.enrichments.indicator.file.elf.imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.enrichments.indicator.file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.enrichments.indicator.file.elf.sections:
   dashed_name: threat-enrichments-indicator-file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -5340,6 +5467,17 @@ threat.enrichments.indicator.file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+threat.enrichments.indicator.file.elf.sections.var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.enrichments.indicator.file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 threat.enrichments.indicator.file.elf.sections.virtual_address:
   dashed_name: threat-enrichments-indicator-file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -5931,11 +6069,13 @@ threat.enrichments.indicator.last_seen:
 threat.enrichments.indicator.marking.tlp:
   dashed_name: threat-enrichments-indicator-marking-tlp
   description: Traffic Light Protocol sharing markings.
-  example: WHITE
+  example: CLEAR
   expected_values:
   - WHITE
+  - CLEAR
   - GREEN
   - AMBER
+  - AMBER+STRICT
   - RED
   flat_name: threat.enrichments.indicator.marking.tlp
   ignore_above: 1024
@@ -7684,6 +7824,67 @@ threat.indicator.file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+threat.indicator.file.elf.go_import_hash:
+  dashed_name: threat-indicator-file-elf-go-import-hash
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.indicator.file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.indicator.file.elf.go_imports:
+  dashed_name: threat-indicator-file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.indicator.file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.indicator.file.elf.go_imports_names_entropy:
+  dashed_name: threat-indicator-file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.elf.go_imports_names_var_entropy:
+  dashed_name: threat-indicator-file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.elf.go_stripped:
+  dashed_name: threat-indicator-file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.indicator.file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.indicator.file.elf.header.abi_version:
   dashed_name: threat-indicator-file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -7772,6 +7973,22 @@ threat.indicator.file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+threat.indicator.file.elf.import_hash:
+  dashed_name: threat-indicator-file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.indicator.file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 threat.indicator.file.elf.imports:
   dashed_name: threat-indicator-file-elf-imports
   description: List of imported element names and types.
@@ -7783,6 +8000,31 @@ threat.indicator.file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+threat.indicator.file.elf.imports_names_entropy:
+  dashed_name: threat-indicator-file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.indicator.file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.indicator.file.elf.imports_names_var_entropy:
+  dashed_name: threat-indicator-file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.indicator.file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.indicator.file.elf.sections:
   dashed_name: threat-indicator-file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -7874,6 +8116,17 @@ threat.indicator.file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+threat.indicator.file.elf.sections.var_entropy:
+  dashed_name: threat-indicator-file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.indicator.file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 threat.indicator.file.elf.sections.virtual_address:
   dashed_name: threat-indicator-file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -8465,11 +8718,13 @@ threat.indicator.last_seen:
 threat.indicator.marking.tlp:
   dashed_name: threat-indicator-marking-tlp
   description: Traffic Light Protocol sharing markings.
-  example: WHITE
+  example: CLEAR
   expected_values:
   - WHITE
+  - CLEAR
   - GREEN
   - AMBER
+  - AMBER+STRICT
   - RED
   flat_name: threat.indicator.marking.tlp
   ignore_above: 1024

--- a/schemas/v1/alerts/rule_detection_event.yaml
+++ b/schemas/v1/alerts/rule_detection_event.yaml
@@ -1330,6 +1330,67 @@ threat.enrichments.indicator.file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+threat.enrichments.indicator.file.elf.go_import_hash:
+  dashed_name: threat-enrichments-indicator-file-elf-go-import-hash
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.enrichments.indicator.file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.enrichments.indicator.file.elf.go_imports:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.enrichments.indicator.file.elf.go_imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.elf.go_imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.enrichments.indicator.file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.enrichments.indicator.file.elf.go_stripped:
+  dashed_name: threat-enrichments-indicator-file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.enrichments.indicator.file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.enrichments.indicator.file.elf.header.abi_version:
   dashed_name: threat-enrichments-indicator-file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -1418,6 +1479,22 @@ threat.enrichments.indicator.file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+threat.enrichments.indicator.file.elf.import_hash:
+  dashed_name: threat-enrichments-indicator-file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.enrichments.indicator.file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 threat.enrichments.indicator.file.elf.imports:
   dashed_name: threat-enrichments-indicator-file-elf-imports
   description: List of imported element names and types.
@@ -1429,6 +1506,31 @@ threat.enrichments.indicator.file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+threat.enrichments.indicator.file.elf.imports_names_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.enrichments.indicator.file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.enrichments.indicator.file.elf.imports_names_var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.enrichments.indicator.file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.enrichments.indicator.file.elf.sections:
   dashed_name: threat-enrichments-indicator-file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -1520,6 +1622,17 @@ threat.enrichments.indicator.file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+threat.enrichments.indicator.file.elf.sections.var_entropy:
+  dashed_name: threat-enrichments-indicator-file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.enrichments.indicator.file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 threat.enrichments.indicator.file.elf.sections.virtual_address:
   dashed_name: threat-enrichments-indicator-file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -2111,11 +2224,13 @@ threat.enrichments.indicator.last_seen:
 threat.enrichments.indicator.marking.tlp:
   dashed_name: threat-enrichments-indicator-marking-tlp
   description: Traffic Light Protocol sharing markings.
-  example: WHITE
+  example: CLEAR
   expected_values:
   - WHITE
+  - CLEAR
   - GREEN
   - AMBER
+  - AMBER+STRICT
   - RED
   flat_name: threat.enrichments.indicator.marking.tlp
   ignore_above: 1024
@@ -3864,6 +3979,67 @@ threat.indicator.file.elf.exports:
   original_fieldset: elf
   short: List of exported element names and types.
   type: flattened
+threat.indicator.file.elf.go_import_hash:
+  dashed_name: threat-indicator-file-elf-go-import-hash
+  description: 'A hash of the Go language imports in an ELF file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: threat.indicator.file.elf.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the Go language imports in an ELF file.
+  type: keyword
+threat.indicator.file.elf.go_imports:
+  dashed_name: threat-indicator-file-elf-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: threat.indicator.file.elf.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: elf
+  short: List of imported Go language element names and types.
+  type: flattened
+threat.indicator.file.elf.go_imports_names_entropy:
+  dashed_name: threat-indicator-file-elf-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.elf.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.elf.go_imports_names_var_entropy:
+  dashed_name: threat-indicator-file-elf-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: threat.indicator.file.elf.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+threat.indicator.file.elf.go_stripped:
+  dashed_name: threat-indicator-file-elf-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: threat.indicator.file.elf.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: elf
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
 threat.indicator.file.elf.header.abi_version:
   dashed_name: threat-indicator-file-elf-header-abi-version
   description: Version of the ELF Application Binary Interface (ABI).
@@ -3952,6 +4128,22 @@ threat.indicator.file.elf.header.version:
   original_fieldset: elf
   short: Version of the ELF header.
   type: keyword
+threat.indicator.file.elf.import_hash:
+  dashed_name: threat-indicator-file-elf-import-hash
+  description: 'A hash of the imports in an ELF file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is an ELF implementation of the Windows PE imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: threat.indicator.file.elf.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: elf
+  short: A hash of the imports in an ELF file.
+  type: keyword
 threat.indicator.file.elf.imports:
   dashed_name: threat-indicator-file-elf-imports
   description: List of imported element names and types.
@@ -3963,6 +4155,31 @@ threat.indicator.file.elf.imports:
   original_fieldset: elf
   short: List of imported element names and types.
   type: flattened
+threat.indicator.file.elf.imports_names_entropy:
+  dashed_name: threat-indicator-file-elf-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: threat.indicator.file.elf.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+threat.indicator.file.elf.imports_names_var_entropy:
+  dashed_name: threat-indicator-file-elf-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: threat.indicator.file.elf.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
 threat.indicator.file.elf.sections:
   dashed_name: threat-indicator-file-elf-sections
   description: 'An array containing an object for each section of the ELF file.
@@ -4054,6 +4271,17 @@ threat.indicator.file.elf.sections.type:
   original_fieldset: elf
   short: ELF Section List type.
   type: keyword
+threat.indicator.file.elf.sections.var_entropy:
+  dashed_name: threat-indicator-file-elf-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: threat.indicator.file.elf.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: elf
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
 threat.indicator.file.elf.sections.virtual_address:
   dashed_name: threat-indicator-file-elf-sections-virtual-address
   description: ELF Section List virtual address.
@@ -4645,11 +4873,13 @@ threat.indicator.last_seen:
 threat.indicator.marking.tlp:
   dashed_name: threat-indicator-marking-tlp
   description: Traffic Light Protocol sharing markings.
-  example: WHITE
+  example: CLEAR
   expected_values:
   - WHITE
+  - CLEAR
   - GREEN
   - AMBER
+  - AMBER+STRICT
   - RED
   flat_name: threat.indicator.marking.tlp
   ignore_above: 1024

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -118,6 +118,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -287,6 +305,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -662,8 +686,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core

--- a/schemas/v1/collection/collection.yaml
+++ b/schemas/v1/collection/collection.yaml
@@ -82,6 +82,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -251,6 +269,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -362,6 +362,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -531,6 +549,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -1854,8 +1878,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core

--- a/schemas/v1/file/unquarantine.yaml
+++ b/schemas/v1/file/unquarantine.yaml
@@ -291,6 +291,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -460,6 +478,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -1004,8 +1028,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -714,6 +714,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -883,6 +901,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -1811,8 +1835,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core

--- a/schemas/v1/metadata/metadata.yaml
+++ b/schemas/v1/metadata/metadata.yaml
@@ -270,6 +270,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -439,6 +457,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -966,8 +990,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -1167,6 +1167,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -1336,6 +1354,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -1885,8 +1909,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core

--- a/schemas/v1/network/network.yaml
+++ b/schemas/v1/network/network.yaml
@@ -513,6 +513,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -682,6 +700,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -1278,8 +1302,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -830,6 +830,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -999,6 +1017,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -1512,8 +1536,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -261,6 +261,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -430,6 +448,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -1026,8 +1050,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core

--- a/schemas/v1/registry/registry.yaml
+++ b/schemas/v1/registry/registry.yaml
@@ -304,6 +304,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -473,6 +491,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -1069,8 +1093,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core

--- a/schemas/v1/security/security.yaml
+++ b/schemas/v1/security/security.yaml
@@ -261,6 +261,24 @@ event.action:
   type: keyword
 event.category:
   allowed_values:
+  - description: Events in this category annotate API calls that occured on a system.
+      Typical sources for those events could be from the Operating System level through
+      the native libraries (for example Windows Win32, Linux libc, etc.), or managed
+      sources of events (such as ETW, syslog), but can also include network protocols
+      (such as SOAP, RPC, Websocket, REST, etc.)
+    expected_event_types:
+    - access
+    - admin
+    - allowed
+    - change
+    - creation
+    - deletion
+    - denied
+    - end
+    - info
+    - start
+    - user
+    name: api
   - description: Events in this category are related to the challenge and response
       process in which credentials are supplied and verified to allow the creation
       of a session. Common sources for these logs are Windows event logs and ssh logs.
@@ -430,6 +448,12 @@ event.category:
     expected_event_types:
     - indicator
     name: threat
+  - description: Relating to vulnerability scan results. Use this category to analyze
+      vulnerabilities detected by Tenable, Qualys, internal scanners, and other vulnerability
+      management sources.
+    expected_event_types:
+    - info
+    name: vulnerability
   - description: 'Relating to web server access. Use this category to create a dashboard
       of web server/proxy activity from apache, IIS, nginx web servers, etc. Note:
       events from network observers such as Zeek http log may also be included in
@@ -1026,8 +1050,9 @@ host.name:
   dashed_name: host-name
   description: 'Name of the host.
 
-    It can contain what `hostname` returns on Unix systems, the fully qualified domain
-    name, or a name specified by the user. The sender decides which value to use.'
+    It can contain what hostname returns on Unix systems, the fully qualified domain
+    name (FQDN), or a name specified by the user. The recommended value is the lowercase
+    FQDN of the host.'
   flat_name: host.name
   ignore_above: 1024
   level: core


### PR DESCRIPTION
## Change Summary

Update ECS to the current HEAD of `ecs/8.7` (https://github.com/elastic/ecs/commits/8.7).

This gives us API events which Endpoint needs for Credential Access Events.

Once 8.7.0 ECS is tagged, we can update it again, but this is useful before FF so Endpoint can stay ECS-compliant.

## Release Target
8.7.0

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes