### PR TITLE
[Fix] Make `process.Ext.api.name` indexable

### DIFF
--- a/custom_schemas/custom_api.yml
+++ b/custom_schemas/custom_api.yml
@@ -16,7 +16,6 @@
     - name: name
       level: custom
       type: keyword
-      index: true
       description: >
         The name of the API, usually the name of the function or system call.
 

--- a/custom_schemas/custom_api.yml
+++ b/custom_schemas/custom_api.yml
@@ -16,7 +16,7 @@
     - name: name
       level: custom
       type: keyword
-      index: false
+      index: true
       description: >
         The name of the API, usually the name of the function or system call.
 

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -358,9 +358,8 @@
     - name: Ext.api.name
       level: custom
       type: keyword
+      ignore_above: 1024
       description: The name of the API, usually the name of the function or system call.
-      index: false
-      doc_values: false
       default_field: false
     - name: Ext.api.parameters.desired_access
       level: custom

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -899,9 +899,8 @@ process.Ext.ancestry:
 process.Ext.api.name:
   dashed_name: process-Ext-api-name
   description: The name of the API, usually the name of the function or system call.
-  doc_values: false
   flat_name: process.Ext.api.name
-  index: false
+  ignore_above: 1024
   level: custom
   name: name
   normalize: []


### PR DESCRIPTION
## Change Summary

This small PR fixes an error in `custom_schemas/custom_api.yml` where the field  `process.Ext.api.name`  was marked as non-indexable when it should be.


## Release Target

8.7


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [x] If this is a `metadata` change, I also updated both transform destination schemas to match

