### PR TITLE
update transforms to be unattended

### DIFF
--- a/package/endpoint/elasticsearch/transform/metadata_current/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_current/default.json
@@ -28,5 +28,8 @@
             "field": "event.ingested",
             "delay": "1s"
         }
+    },
+    "settings": {
+        "unattended": true
     }
 }

--- a/package/endpoint/elasticsearch/transform/metadata_united/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_united/default.json
@@ -37,5 +37,8 @@
     "description": "Merges latest Endpoint and Agent metadata documents",
     "_meta": {
         "managed": true
+    },
+    "settings": {
+        "unattended": true
     }
 }


### PR DESCRIPTION
## Change Summary

Update current + united metadata transforms to be `settings.unattended: true`.

Related: https://github.com/elastic/security-team/issues/6165

## Release Target

`8.8`


### For Transform changes:

- [x] The new transform successfully starts in Kibana
