### PR TITLE
Add fields connected to rules and alerts

### DIFF
--- a/custom_schemas/custom_base.yml
+++ b/custom_schemas/custom_base.yml
@@ -85,6 +85,7 @@
     - name: data.rule_name
       level: custom
       type: keyword
+      index: false
       short: EndpointActions.data.rule_name
       description: >
         Name of the rule that triggered the action

--- a/custom_schemas/custom_base.yml
+++ b/custom_schemas/custom_base.yml
@@ -52,6 +52,13 @@
       description: >
         The action request information
 
+    - name: data.alert_ids
+      level: custom
+      type: keyword
+      short: EndpointActions.data.alert_ids
+      description: >
+        List of alert ids that triggered the action
+
     - name: data.command
       type: alias
       path: EndpointActions.data.command
@@ -67,6 +74,20 @@
       short: EndpointActions.data.comment
       description: >
         A comment that describes the action that is requested
+
+    - name: data.rule_id
+      level: custom
+      type: keyword
+      short: EndpointActions.data.rule_id
+      description: >
+        ID of the rule that triggered the action
+
+    - name: data.rule_name
+      level: custom
+      type: keyword
+      short: EndpointActions.data.rule_name
+      description: >
+        Name of the rule that triggered the action
 
     - name: expiration
       type: alias

--- a/custom_schemas/custom_base.yml
+++ b/custom_schemas/custom_base.yml
@@ -52,7 +52,7 @@
       description: >
         The action request information
 
-    - name: data.alert_ids
+    - name: data.alert_id
       type: alias
       path: EndpointActions.data.alert_ids
       level: custom
@@ -75,22 +75,6 @@
       short: EndpointActions.data.comment
       description: >
         A comment that describes the action that is requested
-
-    - name: data.rule_id
-      type: alias
-      path: EndpointActions.data.rule_id
-      level: custom
-      short: EndpointActions.data.rule_id
-      description: >
-        ID of the rule that triggered the action
-
-    - name: data.rule_name
-      type: alias
-      path: EndpointActions.data.rule_name
-      level: custom
-      short: EndpointActions.data.rule_name
-      description: >
-        Name of the rule that triggered the action
 
     - name: expiration
       type: alias
@@ -124,6 +108,23 @@
       short: user id
       description: >
         The user id
+
+    - name: rule_id
+      type: alias
+      path: rule.id
+      level: custom
+      short: rule id
+      description: >
+        ID of the rule that triggered the action
+
+    - name: rule_name
+      type: alias
+      path: rule.name
+      level: custom
+      short: rule name
+      description: >
+        Name of the rule that triggered the action
+
 
     # response alias fields
     - name: completed_at

--- a/custom_schemas/custom_base.yml
+++ b/custom_schemas/custom_base.yml
@@ -54,9 +54,9 @@
 
     - name: data.alert_id
       type: alias
-      path: EndpointActions.data.alert_ids
+      path: EndpointActions.data.alert_id
       level: custom
-      short: EndpointActions.data.alert_ids
+      short: EndpointActions.data.alert_id
       description: >
         List of alert ids that triggered the action
 

--- a/custom_schemas/custom_endpoint_actions.yml
+++ b/custom_schemas/custom_endpoint_actions.yml
@@ -67,6 +67,7 @@
 
     - name: data.rule_name
       type: keyword
+      index: false
       level: custom
       short: rule name
       description: >

--- a/custom_schemas/custom_endpoint_actions.yml
+++ b/custom_schemas/custom_endpoint_actions.yml
@@ -58,21 +58,6 @@
       description: >
         A comment that describes the action that is requested
 
-    - name: data.rule_id
-      type: keyword
-      level: custom
-      short: rule id
-      description: >
-        ID of the rule that triggered the action
-
-    - name: data.rule_name
-      type: keyword
-      index: false
-      level: custom
-      short: rule name
-      description: >
-        Name of the rule that triggered the action
-
     - name: type
       type: keyword
       level: custom

--- a/custom_schemas/custom_endpoint_actions.yml
+++ b/custom_schemas/custom_endpoint_actions.yml
@@ -36,10 +36,10 @@
       description: >
         The action request information
 
-    - name: data.alert_ids
+    - name: data.alert_id
       type: keyword
       level: custom
-      short: alert ids
+      short: alert id
       description: >
         List of alert ids that triggered the action
     

--- a/custom_subsets/elastic_endpoint/actions/actions.yaml
+++ b/custom_subsets/elastic_endpoint/actions/actions.yaml
@@ -23,6 +23,10 @@ fields:
   agent:
     fields:
       id: {}
+  rule:
+    fields:
+      id: {}
+      name: {}
   error:
     fields:
       code: {}

--- a/package/endpoint/data_stream/action_responses/fields/fields.yml
+++ b/package/endpoint/data_stream/action_responses/fields/fields.yml
@@ -111,8 +111,9 @@
     - name: data.rule_name
       level: custom
       type: keyword
-      ignore_above: 1024
       description: Name of the rule that triggered the action
+      index: false
+      doc_values: false
       default_field: false
     - name: started_at
       level: custom

--- a/package/endpoint/data_stream/action_responses/fields/fields.yml
+++ b/package/endpoint/data_stream/action_responses/fields/fields.yml
@@ -74,7 +74,7 @@
       type: object
       description: The action request information
       default_field: false
-    - name: data.alert_ids
+    - name: data.alert_id
       level: custom
       type: keyword
       ignore_above: 1024

--- a/package/endpoint/data_stream/action_responses/fields/fields.yml
+++ b/package/endpoint/data_stream/action_responses/fields/fields.yml
@@ -26,7 +26,7 @@
   type: alias
   description: Request completion timestamp when the response is done executing. Usually matches with @timestamp.
   path: EndpointActions.completed_at
-- name: data.alert_ids
+- name: data.alert_id
   level: custom
   type: alias
   description: List of alert ids that triggered the action
@@ -41,16 +41,6 @@
   type: alias
   description: A comment that describes the action that is requested
   path: EndpointActions.data.comment
-- name: data.rule_id
-  level: custom
-  type: alias
-  description: ID of the rule that triggered the action
-  path: EndpointActions.data.rule_id
-- name: data.rule_name
-  level: custom
-  type: alias
-  description: Name of the rule that triggered the action
-  path: EndpointActions.data.rule_name
 - name: started_at
   level: custom
   type: alias
@@ -101,19 +91,6 @@
       level: custom
       type: text
       description: A comment that describes the action that is requested
-      default_field: false
-    - name: data.rule_id
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: ID of the rule that triggered the action
-      default_field: false
-    - name: data.rule_name
-      level: custom
-      type: keyword
-      description: Name of the rule that triggered the action
-      index: false
-      doc_values: false
       default_field: false
     - name: started_at
       level: custom

--- a/package/endpoint/data_stream/action_responses/fields/fields.yml
+++ b/package/endpoint/data_stream/action_responses/fields/fields.yml
@@ -111,7 +111,6 @@
     - name: data.rule_name
       level: custom
       type: keyword
-      index: false
       ignore_above: 1024
       description: Name of the rule that triggered the action
       default_field: false

--- a/package/endpoint/data_stream/action_responses/fields/fields.yml
+++ b/package/endpoint/data_stream/action_responses/fields/fields.yml
@@ -30,7 +30,7 @@
   level: custom
   type: alias
   description: List of alert ids that triggered the action
-  path: EndpointActions.data.alert_ids
+  path: EndpointActions.data.alert_id
 - name: data.command
   level: custom
   type: alias

--- a/package/endpoint/data_stream/action_responses/fields/fields.yml
+++ b/package/endpoint/data_stream/action_responses/fields/fields.yml
@@ -111,6 +111,7 @@
     - name: data.rule_name
       level: custom
       type: keyword
+      index: false
       ignore_above: 1024
       description: Name of the rule that triggered the action
       default_field: false

--- a/package/endpoint/data_stream/actions/fields/fields.yml
+++ b/package/endpoint/data_stream/actions/fields/fields.yml
@@ -25,7 +25,7 @@
   level: custom
   type: alias
   description: List of alert ids that triggered the action
-  path: EndpointActions.data.alert_ids
+  path: EndpointActions.data.alert_id
 - name: data.command
   level: custom
   type: alias

--- a/package/endpoint/data_stream/actions/fields/fields.yml
+++ b/package/endpoint/data_stream/actions/fields/fields.yml
@@ -111,8 +111,9 @@
     - name: data.rule_name
       level: custom
       type: keyword
-      ignore_above: 1024
       description: Name of the rule that triggered the action
+      index: false
+      doc_values: false
       default_field: false
     - name: expiration
       level: custom

--- a/package/endpoint/data_stream/actions/fields/fields.yml
+++ b/package/endpoint/data_stream/actions/fields/fields.yml
@@ -89,7 +89,7 @@
     - name: data.rule_id
       level: custom
       type: keyword
-      description: Id of the rule that triggered the action
+      description: ID of the rule that triggered the action
       default_field: false
     - name: data.rule_name
       level: custom

--- a/package/endpoint/data_stream/actions/fields/fields.yml
+++ b/package/endpoint/data_stream/actions/fields/fields.yml
@@ -69,6 +69,11 @@
       type: object
       description: The action request information
       default_field: false
+    - name: data.alert_ids
+      level: custom
+      type: keyword
+      description: List of alert ids that triggered the action
+      default_field: false
     - name: data.command
       level: custom
       type: keyword
@@ -80,6 +85,16 @@
       level: custom
       type: text
       description: A comment that describes the action that is requested
+      default_field: false
+    - name: data.rule_id
+      level: custom
+      type: keyword
+      description: Id of the rule that triggered the action
+      default_field: false
+    - name: data.rule_name
+      level: custom
+      type: keyword
+      description: Name of the rule that triggered the action
       default_field: false
     - name: expiration
       level: custom

--- a/package/endpoint/data_stream/actions/fields/fields.yml
+++ b/package/endpoint/data_stream/actions/fields/fields.yml
@@ -74,7 +74,7 @@
       type: object
       description: The action request information
       default_field: false
-    - name: data.alert_ids
+    - name: data.alert_id
       level: custom
       type: keyword
       ignore_above: 1024

--- a/package/endpoint/data_stream/actions/fields/fields.yml
+++ b/package/endpoint/data_stream/actions/fields/fields.yml
@@ -94,6 +94,7 @@
     - name: data.rule_name
       level: custom
       type: keyword
+      index: false
       description: Name of the rule that triggered the action
       default_field: false
     - name: expiration

--- a/package/endpoint/data_stream/actions/fields/fields.yml
+++ b/package/endpoint/data_stream/actions/fields/fields.yml
@@ -21,7 +21,7 @@
   type: alias
   description: 'Alias field that maps to {agent: {id}}'
   path: agent.id
-- name: data.alert_ids
+- name: data.alert_id
   level: custom
   type: alias
   description: List of alert ids that triggered the action
@@ -36,16 +36,6 @@
   type: alias
   description: A comment that describes the action that is requested
   path: EndpointActions.data.comment
-- name: data.rule_id
-  level: custom
-  type: alias
-  description: ID of the rule that triggered the action
-  path: EndpointActions.data.rule_id
-- name: data.rule_name
-  level: custom
-  type: alias
-  description: Name of the rule that triggered the action
-  path: EndpointActions.data.rule_name
 - name: expiration
   level: custom
   type: alias
@@ -101,19 +91,6 @@
       level: custom
       type: text
       description: A comment that describes the action that is requested
-      default_field: false
-    - name: data.rule_id
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: ID of the rule that triggered the action
-      default_field: false
-    - name: data.rule_name
-      level: custom
-      type: keyword
-      description: Name of the rule that triggered the action
-      index: false
-      doc_values: false
       default_field: false
     - name: expiration
       level: custom
@@ -319,6 +296,29 @@
         `event.type` represents a categorization "sub-bucket" that, when used along with the `event.category` field values, enables filtering events down to a level appropriate for single visualization.
 
         This field is an array. This will allow proper categorization of some events that fall in multiple event types.'
+- name: rule
+  title: Rule
+  group: 2
+  description: 'Rule fields are used to capture the specifics of any observer or agent rules that generate alerts or other notable events.
+
+    Examples of data sources that would populate the rule fields include: network admission control platforms, network or host IDS/IPS, network firewalls, web application firewalls, url filters, endpoint detection and response (EDR) systems, etc.'
+  type: group
+  default_field: true
+  fields:
+    - name: id
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: A rule ID that is unique within the scope of an agent, observer, or other entity using the rule for detection of this event.
+      example: 101
+      default_field: false
+    - name: name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The name of the rule or signature generating the event.
+      example: BLOCK_DNS_over_TLS
+      default_field: false
 - name: user
   title: User
   group: 2

--- a/package/endpoint/data_stream/actions/fields/fields.yml
+++ b/package/endpoint/data_stream/actions/fields/fields.yml
@@ -112,7 +112,6 @@
       level: custom
       type: keyword
       ignore_above: 1024
-      index: false
       description: Name of the rule that triggered the action
       default_field: false
     - name: expiration

--- a/schemas/v1/action_responses/action_responses.yaml
+++ b/schemas/v1/action_responses/action_responses.yaml
@@ -77,27 +77,6 @@ EndpointActions.data.comment:
   norms: false
   short: comment text
   type: text
-EndpointActions.data.rule_id:
-  dashed_name: EndpointActions-data-rule-id
-  description: ID of the rule that triggered the action
-  flat_name: EndpointActions.data.rule_id
-  ignore_above: 1024
-  level: custom
-  name: data.rule_id
-  normalize: []
-  short: rule id
-  type: keyword
-EndpointActions.data.rule_name:
-  dashed_name: EndpointActions-data-rule-name
-  description: Name of the rule that triggered the action
-  doc_values: false
-  flat_name: EndpointActions.data.rule_name
-  index: false
-  level: custom
-  name: data.rule_name
-  normalize: []
-  short: rule name
-  type: keyword
 EndpointActions.started_at:
   dashed_name: EndpointActions-started-at
   description: Timestamp of start of request
@@ -162,12 +141,12 @@ completed_at:
   path: EndpointActions.completed_at
   short: completed at
   type: alias
-data.alert_ids:
-  dashed_name: data-alert-ids
+data.alert_id:
+  dashed_name: data-alert-id
   description: List of alert ids that triggered the action
-  flat_name: data.alert_ids
+  flat_name: data.alert_id
   level: custom
-  name: data.alert_ids
+  name: data.alert_id
   normalize: []
   path: EndpointActions.data.alert_ids
   short: EndpointActions.data.alert_ids
@@ -191,26 +170,6 @@ data.comment:
   normalize: []
   path: EndpointActions.data.comment
   short: EndpointActions.data.comment
-  type: alias
-data.rule_id:
-  dashed_name: data-rule-id
-  description: ID of the rule that triggered the action
-  flat_name: data.rule_id
-  level: custom
-  name: data.rule_id
-  normalize: []
-  path: EndpointActions.data.rule_id
-  short: EndpointActions.data.rule_id
-  type: alias
-data.rule_name:
-  dashed_name: data-rule-name
-  description: Name of the rule that triggered the action
-  flat_name: data.rule_name
-  level: custom
-  name: data.rule_name
-  normalize: []
-  path: EndpointActions.data.rule_name
-  short: EndpointActions.data.rule_name
   type: alias
 data_stream.dataset:
   dashed_name: data-stream-dataset

--- a/schemas/v1/action_responses/action_responses.yaml
+++ b/schemas/v1/action_responses/action_responses.yaml
@@ -90,8 +90,9 @@ EndpointActions.data.rule_id:
 EndpointActions.data.rule_name:
   dashed_name: EndpointActions-data-rule-name
   description: Name of the rule that triggered the action
+  doc_values: false
   flat_name: EndpointActions.data.rule_name
-  ignore_above: 1024
+  index: false
   level: custom
   name: data.rule_name
   normalize: []

--- a/schemas/v1/action_responses/action_responses.yaml
+++ b/schemas/v1/action_responses/action_responses.yaml
@@ -148,8 +148,8 @@ data.alert_id:
   level: custom
   name: data.alert_id
   normalize: []
-  path: EndpointActions.data.alert_ids
-  short: EndpointActions.data.alert_ids
+  path: EndpointActions.data.alert_id
+  short: EndpointActions.data.alert_id
   type: alias
 data.command:
   dashed_name: data-command

--- a/schemas/v1/action_responses/action_responses.yaml
+++ b/schemas/v1/action_responses/action_responses.yaml
@@ -46,15 +46,15 @@ EndpointActions.data:
   normalize: []
   short: data
   type: object
-EndpointActions.data.alert_ids:
-  dashed_name: EndpointActions-data-alert-ids
+EndpointActions.data.alert_id:
+  dashed_name: EndpointActions-data-alert-id
   description: List of alert ids that triggered the action
-  flat_name: EndpointActions.data.alert_ids
+  flat_name: EndpointActions.data.alert_id
   ignore_above: 1024
   level: custom
-  name: data.alert_ids
+  name: data.alert_id
   normalize: []
-  short: alert ids
+  short: alert id
   type: keyword
 EndpointActions.data.command:
   dashed_name: EndpointActions-data-command

--- a/schemas/v1/actions/actions.yaml
+++ b/schemas/v1/actions/actions.yaml
@@ -80,8 +80,9 @@ EndpointActions.data.rule_id:
 EndpointActions.data.rule_name:
   dashed_name: EndpointActions-data-rule-name
   description: Name of the rule that triggered the action
+  doc_values: false
   flat_name: EndpointActions.data.rule_name
-  ignore_above: 1024
+  index: false
   level: custom
   name: data.rule_name
   normalize: []

--- a/schemas/v1/actions/actions.yaml
+++ b/schemas/v1/actions/actions.yaml
@@ -67,27 +67,6 @@ EndpointActions.data.comment:
   norms: false
   short: comment text
   type: text
-EndpointActions.data.rule_id:
-  dashed_name: EndpointActions-data-rule-id
-  description: ID of the rule that triggered the action
-  flat_name: EndpointActions.data.rule_id
-  ignore_above: 1024
-  level: custom
-  name: data.rule_id
-  normalize: []
-  short: rule id
-  type: keyword
-EndpointActions.data.rule_name:
-  dashed_name: EndpointActions-data-rule-name
-  description: Name of the rule that triggered the action
-  doc_values: false
-  flat_name: EndpointActions.data.rule_name
-  index: false
-  level: custom
-  name: data.rule_name
-  normalize: []
-  short: rule name
-  type: keyword
 EndpointActions.expiration:
   dashed_name: EndpointActions-expiration
   description: Request expiration timestamp
@@ -150,12 +129,12 @@ agents:
   path: agent.id
   short: alias field for agent.id
   type: alias
-data.alert_ids:
-  dashed_name: data-alert-ids
+data.alert_id:
+  dashed_name: data-alert-id
   description: List of alert ids that triggered the action
-  flat_name: data.alert_ids
+  flat_name: data.alert_id
   level: custom
-  name: data.alert_ids
+  name: data.alert_id
   normalize: []
   path: EndpointActions.data.alert_ids
   short: EndpointActions.data.alert_ids
@@ -179,26 +158,6 @@ data.comment:
   normalize: []
   path: EndpointActions.data.comment
   short: EndpointActions.data.comment
-  type: alias
-data.rule_id:
-  dashed_name: data-rule-id
-  description: ID of the rule that triggered the action
-  flat_name: data.rule_id
-  level: custom
-  name: data.rule_id
-  normalize: []
-  path: EndpointActions.data.rule_id
-  short: EndpointActions.data.rule_id
-  type: alias
-data.rule_name:
-  dashed_name: data-rule-name
-  description: Name of the rule that triggered the action
-  flat_name: data.rule_name
-  level: custom
-  name: data.rule_name
-  normalize: []
-  path: EndpointActions.data.rule_name
-  short: EndpointActions.data.rule_name
   type: alias
 data_stream.dataset:
   dashed_name: data-stream-dataset
@@ -824,6 +783,29 @@ input_type:
   path: EndpointActions.input_type
   short: input_type
   type: alias
+rule.id:
+  dashed_name: rule-id
+  description: A rule ID that is unique within the scope of an agent, observer, or
+    other entity using the rule for detection of this event.
+  example: 101
+  flat_name: rule.id
+  ignore_above: 1024
+  level: extended
+  name: id
+  normalize: []
+  short: Rule ID
+  type: keyword
+rule.name:
+  dashed_name: rule-name
+  description: The name of the rule or signature generating the event.
+  example: BLOCK_DNS_over_TLS
+  flat_name: rule.name
+  ignore_above: 1024
+  level: extended
+  name: name
+  normalize: []
+  short: Rule name
+  type: keyword
 type:
   dashed_name: type
   description: Distinguishes the type of input. Usually set to `INPUT_ACTION`

--- a/schemas/v1/actions/actions.yaml
+++ b/schemas/v1/actions/actions.yaml
@@ -136,8 +136,8 @@ data.alert_id:
   level: custom
   name: data.alert_id
   normalize: []
-  path: EndpointActions.data.alert_ids
-  short: EndpointActions.data.alert_ids
+  path: EndpointActions.data.alert_id
+  short: EndpointActions.data.alert_id
   type: alias
 data.command:
   dashed_name: data-command

--- a/schemas/v1/actions/actions.yaml
+++ b/schemas/v1/actions/actions.yaml
@@ -36,15 +36,15 @@ EndpointActions.data:
   normalize: []
   short: data
   type: object
-EndpointActions.data.alert_ids:
-  dashed_name: EndpointActions-data-alert-ids
+EndpointActions.data.alert_id:
+  dashed_name: EndpointActions-data-alert-id
   description: List of alert ids that triggered the action
-  flat_name: EndpointActions.data.alert_ids
+  flat_name: EndpointActions.data.alert_id
   ignore_above: 1024
   level: custom
-  name: data.alert_ids
+  name: data.alert_id
   normalize: []
-  short: alert ids
+  short: alert id
   type: keyword
 EndpointActions.data.command:
   dashed_name: EndpointActions-data-command


### PR DESCRIPTION
Closes: https://github.com/elastic/security-team/issues/5929

Not sure if we need rule_name, but from what I remember, it was agreed that we wanted it. 

