### PR TITLE
always publish prerelease

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -242,6 +242,10 @@ def uploadUnpublishedToPackageStorage(builtPackagesPath) {
 }
 
 def isAlreadyPublished(packageZip) {
+  // always publish prerelease
+  if (packageZip.contains("-next")) {
+    return false
+  }
   def responseCode = httpRequest(method: "HEAD",
     url: "https://package-storage.elastic.co/artifacts/packages/${packageZip}",
     response_code_only: true)


### PR DESCRIPTION
## Change Summary

prerelease was only publishing on initial version change since publishing was checking for a version change. this change makes prerelease versions always publish.