### PR TITLE
bump prerelease version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -242,10 +242,6 @@ def uploadUnpublishedToPackageStorage(builtPackagesPath) {
 }
 
 def isAlreadyPublished(packageZip) {
-  // always publish prerelease
-  if (packageZip.contains("-next")) {
-    return false
-  }
   def responseCode = httpRequest(method: "HEAD",
     url: "https://package-storage.elastic.co/artifacts/packages/${packageZip}",
     response_code_only: true)

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.8.0-next
+version: 8.8.0-preview-1
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 # The default type is integration and will be set if empty.


### PR DESCRIPTION
## Change Summary

- bump version
- revert jenkins prerelease force publish

bumping prerelease version so we can test `unattended` changes in prerelease. version format changed to `x.x.x-preview-x` as that's how apm is doing it and what we've been referred to as an example. technically apm uses a timestamp at the end but that will require more work.

also reverting jenkins prerelease force publish logic since EPR won't overwrite existing version regardless.