### PR TITLE
Added Registry Rollback Fields to Package

### DIFF
--- a/custom_schemas/custom_responses.yml
+++ b/custom_schemas/custom_responses.yml
@@ -46,6 +46,11 @@
       type: keyword
       description: Destination file path
 
+    - name: action.file.reason
+      level: custom
+      type: long
+      description: Combined USN file modification reason
+
     - name: action.file.attributes
       level: custom
       type: keyword
@@ -60,6 +65,16 @@
       level: custom
       type: keyword
       description: Source file attributes
+    
+    - name: action.key.actions
+      level: custom
+      type: keyword
+      description: Actions taken by Registry Rollback for key
+
+    - name: action.key.path
+      level: custom
+      type: keyword
+      description: NT path of registry key recovered by Rollback 
 
     - name: message
       level: custom

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -400,6 +400,23 @@
       ignore_above: 1024
       description: Destination file path
       default_field: false
+    - name: action.file.reason
+      level: custom
+      type: long
+      description: Combined USN file modification reason
+      default_field: false
+    - name: action.key.actions
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Actions taken by Registry Rollback for key
+      default_field: false
+    - name: action.key.path
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: NT path of registry key recovered by Rollback
+      default_field: false
     - name: action.source.attributes
       level: custom
       type: keyword

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -67,6 +67,9 @@ sent by the endpoint.
 | Responses.action.field | Field in the triggering event to use as input for action | text |
 | Responses.action.file.attributes | Destination file attributes | keyword |
 | Responses.action.file.path | Destination file path | keyword |
+| Responses.action.file.reason | Combined USN file modification reason | long |
+| Responses.action.key.actions | Actions taken by Registry Rollback for key | keyword |
+| Responses.action.key.path | NT path of registry key recovered by Rollback | keyword |
 | Responses.action.source.attributes | Source file attributes | keyword |
 | Responses.action.source.path | Source file path | keyword |
 | Responses.action.state | Index of event in events array to use for field lookup | long |

--- a/schemas/v1/alerts/rule_detection_event.yaml
+++ b/schemas/v1/alerts/rule_detection_event.yaml
@@ -85,6 +85,35 @@ Responses.action.file.path:
   normalize: []
   short: Destination file path
   type: keyword
+Responses.action.file.reason:
+  dashed_name: Responses-action-file-reason
+  description: Combined USN file modification reason
+  flat_name: Responses.action.file.reason
+  level: custom
+  name: action.file.reason
+  normalize: []
+  short: Combined USN file modification reason
+  type: long
+Responses.action.key.actions:
+  dashed_name: Responses-action-key-actions
+  description: Actions taken by Registry Rollback for key
+  flat_name: Responses.action.key.actions
+  ignore_above: 1024
+  level: custom
+  name: action.key.actions
+  normalize: []
+  short: Actions taken by Registry Rollback for key
+  type: keyword
+Responses.action.key.path:
+  dashed_name: Responses-action-key-path
+  description: NT path of registry key recovered by Rollback
+  flat_name: Responses.action.key.path
+  ignore_above: 1024
+  level: custom
+  name: action.key.path
+  normalize: []
+  short: NT path of registry key recovered by Rollback
+  type: keyword
 Responses.action.source.attributes:
   dashed_name: Responses-action-source-attributes
   description: Source file attributes


### PR DESCRIPTION
## Change Summary
Added fields for Registry Rollback

Sample document:

```json
            "@timestamp": "2023-03-24T09:17:08.0Z",
            "action": {
                "action": "registry_rollback",
                "key": {
                    "actions": [
                        "Deleted"
                    ],
                    "path": "\\REGISTRY\\MACHINE\\SOFTWARE\\WOW6432Node\\TestRollback\\2"
                }
            },
            "message": "Successful production registry rollback",
            "result": 0
```





### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
