### PR TITLE
Revert "update transforms to be unattended (#353)"

### DIFF
--- a/package/endpoint/elasticsearch/transform/metadata_current/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_current/default.json
@@ -28,8 +28,5 @@
             "field": "event.ingested",
             "delay": "1s"
         }
-    },
-    "settings": {
-        "unattended": true
     }
 }

--- a/package/endpoint/elasticsearch/transform/metadata_united/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_united/default.json
@@ -37,8 +37,5 @@
     "description": "Merges latest Endpoint and Agent metadata documents",
     "_meta": {
         "managed": true
-    },
-    "settings": {
-        "unattended": true
     }
 }

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.8.0-preview-1
+version: 8.8.0-preview-2
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 # The default type is integration and will be set if empty.


### PR DESCRIPTION
## Change Summary

Revert `unattended` transform option. This change is causing package install to occasionally fail. Since `unattended` means the transform will never throw, fleet doesn't reattempt to reinstall the transform destination indices during transient package install failures leaving the destination indices uncreated.