### PR TITLE
Add thread callstacks to process, file, registry, and image/library load events

### DIFF
--- a/custom_schemas/custom_call_stack.yml
+++ b/custom_schemas/custom_call_stack.yml
@@ -1,7 +1,7 @@
 ---
 - name: call_stack
   title: Call Stack
-  group: 2
+  group: 3
   short: Fields describing a stack frame.
   type: object
   description: >
@@ -11,6 +11,7 @@
     top_level: false
     expected:
       - process.thread.Ext
+      - process.parent.thread.Ext
   fields:
     - name: module_name
       level: custom

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -55,6 +55,16 @@
       description: Parent process' pid.
       example: 4241
 
+    - name: parent.thread
+      level: custom
+      type: object
+      description: The parent thread
+      
+    - name: parent.thread.Ext
+      level: custom
+      type: object
+      description: Object for all custom defined fields for the parent thread to live in.
+
     - name: parent.ppid
       level: extended
       type: long
@@ -107,6 +117,11 @@
       example: "ntdll.dll, example.exe, kernel32.dll, ntdll.dll"
       description: >
         Concatentation of the non-repeated modules in the call stack.
+        
+    - name: thread.Ext.call_stack
+      level: custom
+      type: nested
+      description: The thread's call stack
 
     - name: thread.Ext.call_stack_final_user_module
       level: custom

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -59,7 +59,7 @@
       level: custom
       type: object
       description: The parent thread
-      
+
     - name: parent.thread.Ext
       level: custom
       type: object
@@ -117,10 +117,10 @@
       example: "ntdll.dll, example.exe, kernel32.dll, ntdll.dll"
       description: >
         Concatentation of the non-repeated modules in the call stack.
-        
+
     - name: thread.Ext.call_stack
       level: custom
-      type: nested
+      type: object
       description: The thread's call stack
 
     - name: thread.Ext.call_stack_final_user_module

--- a/custom_subsets/elastic_endpoint/file/file.yaml
+++ b/custom_subsets/elastic_endpoint/file/file.yaml
@@ -142,6 +142,7 @@ fields:
           Ext:
             fields:
               call_stack:
+                enabled: true
                 fields:
                   symbol_info: {}
               call_stack_summary: {}

--- a/custom_subsets/elastic_endpoint/file/file.yaml
+++ b/custom_subsets/elastic_endpoint/file/file.yaml
@@ -139,6 +139,12 @@ fields:
       thread:
         fields:
           id: {}
+          Ext:
+            fields:
+              call_stack:
+                fields:
+                  symbol_info: {}
+              call_stack_summary: {}
       Ext:
         fields:
           ancestry: {}

--- a/custom_subsets/elastic_endpoint/library/library.yaml
+++ b/custom_subsets/elastic_endpoint/library/library.yaml
@@ -118,6 +118,13 @@ fields:
       thread:
         fields:
           id: {}
+          Ext:
+            fields:
+              call_stack:
+                enabled: true
+                fields:
+                  symbol_info: {}
+              call_stack_summary: {}
       Ext:
         fields:
           ancestry: {}

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -247,6 +247,11 @@ fields:
               name: {}
               Ext:
                 fields:
+                  call_stack:
+                    enabled: true
+                    fields:
+                      symbol_info: {}
+                  call_stack_summary: {}
                   call_stack_contains_unbacked: {}
           title: {}
           uptime: {}

--- a/custom_subsets/elastic_endpoint/registry/registry.yaml
+++ b/custom_subsets/elastic_endpoint/registry/registry.yaml
@@ -118,6 +118,13 @@ fields:
       thread:
         fields:
           id: {}
+          Ext:
+            fields:
+              call_stack:
+                enabled: true
+                fields:
+                  symbol_info: {}
+              call_stack_summary: {}
       Ext:
         fields:
           ancestry: {}

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -1294,6 +1294,12 @@
       type: object
       description: Object for all custom defined fields to live in.
       default_field: false
+    - name: thread.Ext.call_stack
+      level: custom
+      type: object
+      description: Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame.
+      enabled: true
+      default_field: false
     - name: thread.Ext.call_stack.symbol_info
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -1289,6 +1289,24 @@
         Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts.'
       example: c2c455d9f99375d
       default_field: false
+    - name: thread.Ext
+      level: custom
+      type: object
+      description: Object for all custom defined fields to live in.
+      default_field: false
+    - name: thread.Ext.call_stack.symbol_info
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The nearest symbol for `instruction_pointer`.
+      default_field: false
+    - name: thread.Ext.call_stack_summary
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Concatentation of the non-repeated modules in the call stack.
+      example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+      default_field: false
     - name: thread.id
       level: extended
       type: long

--- a/package/endpoint/data_stream/file/sample_event.json
+++ b/package/endpoint/data_stream/file/sample_event.json
@@ -54,7 +54,15 @@
         "name": "winlogbeat.exe",
         "pid": 4512,
         "thread": {
-            "id": 340
+            "id": 340,
+            "Ext": {
+                "call_stack": [
+                    {
+                        "symbol_info": "C:\\Windows\\System32\\ntdll.dll!RtlUserThreadStart+0x21"
+                    }
+                ],
+                "call_stack_summary": "ntdll.dll|kernelbase.dll|kernel32.dll|cmd.exe|kernel32.dll|ntdll.dll"
+            }
         },
         "entity_id": "Y2NiN2IxYTEtMzAzZS00MTZmLWI5NzUtMzExNzM3ZThlMTI1LTQ1MTItMTMyOTM1NDkyODYuNzQ2MjY0MDAw",
         "executable": "C:\\Program Files\\Winlogbeat\\winlogbeat.exe"

--- a/package/endpoint/data_stream/library/fields/fields.yml
+++ b/package/endpoint/data_stream/library/fields/fields.yml
@@ -1159,6 +1159,30 @@
       format: string
       description: Process id.
       example: 4242
+    - name: thread.Ext
+      level: custom
+      type: object
+      description: Object for all custom defined fields to live in.
+      default_field: false
+    - name: thread.Ext.call_stack
+      level: custom
+      type: object
+      description: Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame.
+      enabled: true
+      default_field: false
+    - name: thread.Ext.call_stack.symbol_info
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The nearest symbol for `instruction_pointer`.
+      default_field: false
+    - name: thread.Ext.call_stack_summary
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Concatentation of the non-repeated modules in the call stack.
+      example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+      default_field: false
     - name: thread.id
       level: extended
       type: long

--- a/package/endpoint/data_stream/library/sample_event.json
+++ b/package/endpoint/data_stream/library/sample_event.json
@@ -28,7 +28,18 @@
         "name": "VSSVC.exe",
         "pid": 4528,
         "entity_id": "NGM5YzljYjMtZjgwZi00NGQ4LTljODktNjE2ODI0M2I3ZjIxLTQ1MjgtMTMyOTM1NzEwODYuNjI4MzM0NzAw",
-        "executable": "C:\\Windows\\System32\\VSSVC.exe"
+        "executable": "C:\\Windows\\System32\\VSSVC.exe",
+        "thread": {
+            "id": 340,
+            "Ext": {
+                "call_stack": [
+                    {
+                        "symbol_info": "C:\\Windows\\System32\\ntdll.dll!RtlUserThreadStart+0x21"
+                    }
+                ],
+                "call_stack_summary": "ntdll.dll|kernelbase.dll|kernel32.dll|cmd.exe|kernel32.dll|ntdll.dll"
+            }
+        }
     },
     "dll": {
         "Ext": {

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -2216,10 +2216,29 @@
       type: object
       description: Object for all custom defined fields to live in.
       default_field: false
+    - name: parent.thread.Ext.call_stack
+      level: custom
+      type: object
+      description: Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame.
+      enabled: true
+      default_field: false
+    - name: parent.thread.Ext.call_stack.symbol_info
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The nearest symbol for `instruction_pointer`.
+      default_field: false
     - name: parent.thread.Ext.call_stack_contains_unbacked
       level: custom
       type: boolean
       description: Indicates whether the creating thread's stack contains frames pointing outside any known executable image.
+      default_field: false
+    - name: parent.thread.Ext.call_stack_summary
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Concatentation of the non-repeated modules in the call stack.
+      example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
       default_field: false
     - name: parent.thread.id
       level: extended

--- a/package/endpoint/data_stream/process/sample_event.json
+++ b/package/endpoint/data_stream/process/sample_event.json
@@ -120,6 +120,12 @@
             "executable": "C:\\Windows\\System32\\services.exe",
             "thread": {
                 "Ext": {
+                    "call_stack": [
+                        {
+                            "symbol_info": "C:\\Windows\\System32\\ntdll.dll!RtlUserThreadStart+0x21"
+                        }
+                    ],
+                    "call_stack_summary": "ntdll.dll|kernelbase.dll|kernel32.dll|cmd.exe|kernel32.dll|ntdll.dll",
                     "call_stack_contains_unbacked": true
                 }
             }

--- a/package/endpoint/data_stream/registry/fields/fields.yml
+++ b/package/endpoint/data_stream/registry/fields/fields.yml
@@ -724,6 +724,30 @@
       format: string
       description: Process id.
       example: 4242
+    - name: thread.Ext
+      level: custom
+      type: object
+      description: Object for all custom defined fields to live in.
+      default_field: false
+    - name: thread.Ext.call_stack
+      level: custom
+      type: object
+      description: Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame.
+      enabled: true
+      default_field: false
+    - name: thread.Ext.call_stack.symbol_info
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The nearest symbol for `instruction_pointer`.
+      default_field: false
+    - name: thread.Ext.call_stack_summary
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Concatentation of the non-repeated modules in the call stack.
+      example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+      default_field: false
     - name: thread.id
       level: extended
       type: long

--- a/package/endpoint/data_stream/registry/sample_event.json
+++ b/package/endpoint/data_stream/registry/sample_event.json
@@ -44,7 +44,18 @@
         "name": "svchost.exe",
         "pid": 2772,
         "entity_id": "NGM5YzljYjMtZjgwZi00NGQ4LTljODktNjE2ODI0M2I3ZjIxLTI3NzItMTMyOTM1NzE5ODguNjU3ODk4NjAw",
-        "executable": "C:\\Windows\\System32\\svchost.exe"
+        "executable": "C:\\Windows\\System32\\svchost.exe",
+        "thread": {
+            "id": 340,
+            "Ext": {
+                "call_stack": [
+                    {
+                        "symbol_info": "C:\\Windows\\System32\\ntdll.dll!RtlUserThreadStart+0x21"
+                    }
+                ],
+                "call_stack_summary": "ntdll.dll|kernelbase.dll|kernel32.dll|cmd.exe|kernel32.dll|ntdll.dll"
+            }
+        }
     },
     "message": "Endpoint registry event",
     "@timestamp": "2022-04-04T18:53:09.1283846Z",

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1653,6 +1653,9 @@ sent by the endpoint.
 | process.pid | Process id. | long |
 | process.ppid | Parent process' pid. | long |
 | process.session_leader.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |
+| process.thread.Ext | Object for all custom defined fields to live in. | object |
+| process.thread.Ext.call_stack.symbol_info | The nearest symbol for `instruction_pointer`. | keyword |
+| process.thread.Ext.call_stack_summary | Concatentation of the non-repeated modules in the call stack. | keyword |
 | process.thread.id | Thread ID. | long |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_code | Two-letter code representing continent's name. | keyword |

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2321,7 +2321,10 @@ sent by the endpoint.
 | process.parent.supplemental_groups.id | Unique identifier for the group on the system/platform. | keyword |
 | process.parent.supplemental_groups.name | Name of the group. | keyword |
 | process.parent.thread.Ext | Object for all custom defined fields to live in. | object |
+| process.parent.thread.Ext.call_stack | Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame. | object |
+| process.parent.thread.Ext.call_stack.symbol_info | The nearest symbol for `instruction_pointer`. | keyword |
 | process.parent.thread.Ext.call_stack_contains_unbacked | Indicates whether the creating thread's stack contains frames pointing outside any known executable image. | boolean |
+| process.parent.thread.Ext.call_stack_summary | Concatentation of the non-repeated modules in the call stack. | keyword |
 | process.parent.thread.id | Thread ID. | long |
 | process.parent.thread.name | Thread name. | keyword |
 | process.parent.title | Process title. The proctitle, some times the same as process name. Can also be different: for example a browser setting its title to the web page currently opened. | keyword |

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1654,6 +1654,7 @@ sent by the endpoint.
 | process.ppid | Parent process' pid. | long |
 | process.session_leader.entity_id | Unique identifier for the process. The implementation of this is specified by the data source, but some examples of what could be used here are a process-generated UUID, Sysmon Process GUIDs, or a hash of some uniquely identifying components of a process. Constructing a globally unique identifier is a common practice to mitigate PID reuse as well as to identify a specific process over time, across multiple monitored hosts. | keyword |
 | process.thread.Ext | Object for all custom defined fields to live in. | object |
+| process.thread.Ext.call_stack | Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame. | object |
 | process.thread.Ext.call_stack.symbol_info | The nearest symbol for `instruction_pointer`. | keyword |
 | process.thread.Ext.call_stack_summary | Concatentation of the non-repeated modules in the call stack. | keyword |
 | process.thread.id | Thread ID. | long |
@@ -1836,6 +1837,10 @@ sent by the endpoint.
 | process.executable | Absolute path to the process executable. | keyword |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
 | process.pid | Process id. | long |
+| process.thread.Ext | Object for all custom defined fields to live in. | object |
+| process.thread.Ext.call_stack | Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame. | object |
+| process.thread.Ext.call_stack.symbol_info | The nearest symbol for `instruction_pointer`. | keyword |
+| process.thread.Ext.call_stack_summary | Concatentation of the non-repeated modules in the call stack. | keyword |
 | process.thread.id | Thread ID. | long |
 | source.geo.city_name | City name. | keyword |
 | source.geo.continent_code | Two-letter code representing continent's name. | keyword |
@@ -2523,6 +2528,10 @@ sent by the endpoint.
 | process.executable | Absolute path to the process executable. | keyword |
 | process.name | Process name. Sometimes called program name or similar. | keyword |
 | process.pid | Process id. | long |
+| process.thread.Ext | Object for all custom defined fields to live in. | object |
+| process.thread.Ext.call_stack | Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame. | object |
+| process.thread.Ext.call_stack.symbol_info | The nearest symbol for `instruction_pointer`. | keyword |
+| process.thread.Ext.call_stack_summary | Concatentation of the non-repeated modules in the call stack. | keyword |
 | process.thread.id | Thread ID. | long |
 | registry.data.bytes | Original bytes written with base64 encoding. For Windows registry operations, such as SetValueEx and RegQueryValueEx, this corresponds to the data pointed by `lp_data`. This is optional but provides better recoverability and should be populated for REG_BINARY encoded values. | keyword |
 | registry.data.strings | Content when writing string types. Populated as an array when writing string data to the registry. For single string registry types (REG_SZ, REG_EXPAND_SZ), this should be an array with one string. For sequences of string with REG_MULTI_SZ, this array will be variable length. For numeric data, such as REG_DWORD and REG_QWORD, this should be populated with the decimal representation (e.g `"1"`). | wildcard |

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -2498,6 +2498,18 @@ process.thread.Ext:
   normalize: []
   short: Object for all custom defined fields to live in.
   type: object
+process.thread.Ext.call_stack:
+  dashed_name: process-thread-Ext-call-stack
+  description: Fields describing a stack frame.  call_stack is expected to be an array
+    where each array element represents a stack frame.
+  enabled: true
+  flat_name: process.thread.Ext.call_stack
+  level: custom
+  name: call_stack
+  normalize: []
+  original_fieldset: call_stack
+  short: Fields describing a stack frame.
+  type: object
 process.thread.Ext.call_stack.symbol_info:
   dashed_name: process-thread-Ext-call-stack-symbol-info
   description: The nearest symbol for `instruction_pointer`.

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -2489,6 +2489,37 @@ process.session_leader.entity_id:
   original_fieldset: process
   short: Unique identifier for the process.
   type: keyword
+process.thread.Ext:
+  dashed_name: process-thread-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: process.thread.Ext
+  level: custom
+  name: thread.Ext
+  normalize: []
+  short: Object for all custom defined fields to live in.
+  type: object
+process.thread.Ext.call_stack.symbol_info:
+  dashed_name: process-thread-Ext-call-stack-symbol-info
+  description: The nearest symbol for `instruction_pointer`.
+  flat_name: process.thread.Ext.call_stack.symbol_info
+  ignore_above: 1024
+  level: custom
+  name: symbol_info
+  normalize: []
+  original_fieldset: call_stack
+  short: The nearest symbol for `instruction_pointer`.
+  type: keyword
+process.thread.Ext.call_stack_summary:
+  dashed_name: process-thread-Ext-call-stack-summary
+  description: Concatentation of the non-repeated modules in the call stack.
+  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  flat_name: process.thread.Ext.call_stack_summary
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_summary
+  normalize: []
+  short: Concatentation of the non-repeated modules in the call stack.
+  type: keyword
 process.thread.id:
   dashed_name: process-thread-id
   description: Thread ID.

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -2289,6 +2289,49 @@ process.pid:
   normalize: []
   short: Process id.
   type: long
+process.thread.Ext:
+  dashed_name: process-thread-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: process.thread.Ext
+  level: custom
+  name: thread.Ext
+  normalize: []
+  short: Object for all custom defined fields to live in.
+  type: object
+process.thread.Ext.call_stack:
+  dashed_name: process-thread-Ext-call-stack
+  description: Fields describing a stack frame.  call_stack is expected to be an array
+    where each array element represents a stack frame.
+  enabled: true
+  flat_name: process.thread.Ext.call_stack
+  level: custom
+  name: call_stack
+  normalize: []
+  original_fieldset: call_stack
+  short: Fields describing a stack frame.
+  type: object
+process.thread.Ext.call_stack.symbol_info:
+  dashed_name: process-thread-Ext-call-stack-symbol-info
+  description: The nearest symbol for `instruction_pointer`.
+  flat_name: process.thread.Ext.call_stack.symbol_info
+  ignore_above: 1024
+  level: custom
+  name: symbol_info
+  normalize: []
+  original_fieldset: call_stack
+  short: The nearest symbol for `instruction_pointer`.
+  type: keyword
+process.thread.Ext.call_stack_summary:
+  dashed_name: process-thread-Ext-call-stack-summary
+  description: Concatentation of the non-repeated modules in the call stack.
+  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  flat_name: process.thread.Ext.call_stack_summary
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_summary
+  normalize: []
+  short: Concatentation of the non-repeated modules in the call stack.
+  type: keyword
 process.thread.id:
   dashed_name: process-thread-id
   description: Thread ID.

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -2612,6 +2612,29 @@ process.parent.thread.Ext:
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
+process.parent.thread.Ext.call_stack:
+  dashed_name: process-parent-thread-Ext-call-stack
+  description: Fields describing a stack frame.  call_stack is expected to be an array
+    where each array element represents a stack frame.
+  enabled: true
+  flat_name: process.parent.thread.Ext.call_stack
+  level: custom
+  name: call_stack
+  normalize: []
+  original_fieldset: call_stack
+  short: Fields describing a stack frame.
+  type: object
+process.parent.thread.Ext.call_stack.symbol_info:
+  dashed_name: process-parent-thread-Ext-call-stack-symbol-info
+  description: The nearest symbol for `instruction_pointer`.
+  flat_name: process.parent.thread.Ext.call_stack.symbol_info
+  ignore_above: 1024
+  level: custom
+  name: symbol_info
+  normalize: []
+  original_fieldset: call_stack
+  short: The nearest symbol for `instruction_pointer`.
+  type: keyword
 process.parent.thread.Ext.call_stack_contains_unbacked:
   dashed_name: process-parent-thread-Ext-call-stack-contains-unbacked
   description: Indicates whether the creating thread's stack contains frames pointing
@@ -2624,6 +2647,18 @@ process.parent.thread.Ext.call_stack_contains_unbacked:
   short: Indicates whether the creating thread's stack contains frames pointing outside
     any known executable image.
   type: boolean
+process.parent.thread.Ext.call_stack_summary:
+  dashed_name: process-parent-thread-Ext-call-stack-summary
+  description: Concatentation of the non-repeated modules in the call stack.
+  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  flat_name: process.parent.thread.Ext.call_stack_summary
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_summary
+  normalize: []
+  original_fieldset: process
+  short: Concatentation of the non-repeated modules in the call stack.
+  type: keyword
 process.parent.thread.id:
   dashed_name: process-parent-thread-id
   description: Thread ID.

--- a/schemas/v1/registry/registry.yaml
+++ b/schemas/v1/registry/registry.yaml
@@ -1547,6 +1547,49 @@ process.pid:
   normalize: []
   short: Process id.
   type: long
+process.thread.Ext:
+  dashed_name: process-thread-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: process.thread.Ext
+  level: custom
+  name: thread.Ext
+  normalize: []
+  short: Object for all custom defined fields to live in.
+  type: object
+process.thread.Ext.call_stack:
+  dashed_name: process-thread-Ext-call-stack
+  description: Fields describing a stack frame.  call_stack is expected to be an array
+    where each array element represents a stack frame.
+  enabled: true
+  flat_name: process.thread.Ext.call_stack
+  level: custom
+  name: call_stack
+  normalize: []
+  original_fieldset: call_stack
+  short: Fields describing a stack frame.
+  type: object
+process.thread.Ext.call_stack.symbol_info:
+  dashed_name: process-thread-Ext-call-stack-symbol-info
+  description: The nearest symbol for `instruction_pointer`.
+  flat_name: process.thread.Ext.call_stack.symbol_info
+  ignore_above: 1024
+  level: custom
+  name: symbol_info
+  normalize: []
+  original_fieldset: call_stack
+  short: The nearest symbol for `instruction_pointer`.
+  type: keyword
+process.thread.Ext.call_stack_summary:
+  dashed_name: process-thread-Ext-call-stack-summary
+  description: Concatentation of the non-repeated modules in the call stack.
+  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  flat_name: process.thread.Ext.call_stack_summary
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_summary
+  normalize: []
+  short: Concatentation of the non-repeated modules in the call stack.
+  type: keyword
 process.thread.id:
   dashed_name: process-thread-id
   description: Thread ID.


### PR DESCRIPTION
# DRAFT - DO NOT REVIEW YET

## Change Summary
This PR adds thread call stacks to process, file, registry, and image/library load events.  Call stacks for process events are attributed to the parent at `process.parent.thread.Ext.call_stack`.  For the other listed events, they're attributed to the acting process at `process.thread.Ext.call_stack`.

### Sample values

See included sample docs.

## Release Target
8.8.0


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes