### PR TITLE
File system type

### DIFF
--- a/custom_schemas/custom_dll.yml
+++ b/custom_schemas/custom_dll.yml
@@ -182,6 +182,17 @@
         Disk File System
         CD-ROM File System
 
+    - name: Ext.device.file_system_type
+      level: custom
+      type: keyword
+      short: Volume device file system type.
+      description: >
+        Volume device file system type.
+
+        Following are examples of the most frequently seen volume device file system types:
+        NTFS
+        UDF
+
     - name: code_signature.exists
       level: core
       type: boolean

--- a/custom_schemas/custom_file.yml
+++ b/custom_schemas/custom_file.yml
@@ -343,6 +343,17 @@
         Disk File System
         CD-ROM File System
 
+    - name: Ext.device.file_system_type
+      level: custom
+      type: keyword
+      short: Volume device file system type.
+      description: >
+        Volume device file system type.
+
+        Following are examples of the most frequently seen volume device file system types:
+        NTFS
+        UDF
+
     - name: code_signature.exists
       level: core
       type: boolean

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -482,6 +482,17 @@
         Disk File System
         CD-ROM File System
 
+    - name: Ext.device.file_system_type
+      level: custom
+      type: keyword
+      short: Volume device file system type.
+      description: >
+        Volume device file system type.
+
+        Following are examples of the most frequently seen volume device file system types:
+        NTFS
+        UDF
+
     - name: Ext.trusted
       level: custom
       type: boolean

--- a/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/malware_event.yaml
@@ -202,6 +202,8 @@ fields:
                           product_id: {}
                           serial_number: {}
                           vendor_id: {}
+                          file_system_type: {}
+                          volume_device_type: {}
                       entropy: {}
                       entry_modified: {}
                       header_bytes: {}
@@ -350,6 +352,8 @@ fields:
                       product_id: {}
                       serial_number: {}
                       vendor_id: {}
+                      file_system_type: {}
+                      volume_device_type: {}
                   entropy: {}
                   entry_modified: {}
                   header_bytes: {}

--- a/custom_subsets/elastic_endpoint/file/file.yaml
+++ b/custom_subsets/elastic_endpoint/file/file.yaml
@@ -235,4 +235,5 @@ fields:
              serial_number: {}
              vendor_id: {}
              volume_device_type: {}
+             file_system_type: {}
 

--- a/custom_subsets/elastic_endpoint/library/library.yaml
+++ b/custom_subsets/elastic_endpoint/library/library.yaml
@@ -211,5 +211,6 @@ fields:
              serial_number: {}
              vendor_id: {}
              volume_device_type: {}
+             file_system_type: {}
           relative_file_creation_time: {}
           relative_file_name_modify_time: {}

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -205,6 +205,7 @@ fields:
              serial_number: {}
              vendor_id: {}
              volume_device_type: {}
+             file_system_type: {}
       parent:
         fields:
           args: {}

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -7708,6 +7708,14 @@
       ignore_above: 1024
       description: DOS name of the device. DOS device name is in the format of driver letters such as C:, D:,...
       default_field: false
+    - name: enrichments.indicator.file.Ext.device.file_system_type
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: 'Volume device file system type.
+
+        Following are examples of the most frequently seen volume device file system types: NTFS UDF'
+      default_field: false
     - name: enrichments.indicator.file.Ext.device.nt_name
       level: custom
       type: keyword
@@ -7731,6 +7739,14 @@
       type: keyword
       ignore_above: 1024
       description: VendorID of the device. It is provided by the vendor of the device.
+      default_field: false
+    - name: enrichments.indicator.file.Ext.device.volume_device_type
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: 'Volume device type.
+
+        Following are examples of the most frequently seen volume device types: Disk File System CD-ROM File System'
       default_field: false
     - name: enrichments.indicator.file.Ext.entropy
       level: custom
@@ -9089,6 +9105,14 @@
       ignore_above: 1024
       description: DOS name of the device. DOS device name is in the format of driver letters such as C:, D:,...
       default_field: false
+    - name: indicator.file.Ext.device.file_system_type
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: 'Volume device file system type.
+
+        Following are examples of the most frequently seen volume device file system types: NTFS UDF'
+      default_field: false
     - name: indicator.file.Ext.device.nt_name
       level: custom
       type: keyword
@@ -9112,6 +9136,14 @@
       type: keyword
       ignore_above: 1024
       description: VendorID of the device. It is provided by the vendor of the device.
+      default_field: false
+    - name: indicator.file.Ext.device.volume_device_type
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: 'Volume device type.
+
+        Following are examples of the most frequently seen volume device types: Disk File System CD-ROM File System'
       default_field: false
     - name: indicator.file.Ext.entropy
       level: custom

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -403,6 +403,14 @@
       ignore_above: 1024
       description: DOS name of the device. DOS device name is in the format of driver letters such as C:, D:,...
       default_field: false
+    - name: Ext.device.file_system_type
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: 'Volume device file system type.
+
+        Following are examples of the most frequently seen volume device file system types: NTFS UDF'
+      default_field: false
     - name: Ext.device.nt_name
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/library/fields/fields.yml
+++ b/package/endpoint/data_stream/library/fields/fields.yml
@@ -243,6 +243,14 @@
       ignore_above: 1024
       description: DOS name of the device. DOS device name is in the format of driver letters such as C:, D:,...
       default_field: false
+    - name: Ext.device.file_system_type
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: 'Volume device file system type.
+
+        Following are examples of the most frequently seen volume device file system types: NTFS UDF'
+      default_field: false
     - name: Ext.device.nt_name
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -785,6 +785,14 @@
       ignore_above: 1024
       description: DOS name of the device. DOS device name is in the format of driver letters such as C:, D:,...
       default_field: false
+    - name: Ext.device.file_system_type
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: 'Volume device file system type.
+
+        Following are examples of the most frequently seen volume device file system types: NTFS UDF'
+      default_field: false
     - name: Ext.device.nt_name
       level: custom
       type: keyword

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1021,10 +1021,12 @@ sent by the endpoint.
 | threat.enrichments.indicator.file.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | threat.enrichments.indicator.file.Ext.device.bus_type | Bus type of the device, such as Nvme, Usb, FileBackedVirtual,... etc. | keyword |
 | threat.enrichments.indicator.file.Ext.device.dos_name | DOS name of the device. DOS device name is in the format of driver letters such as C:, D:,... | keyword |
+| threat.enrichments.indicator.file.Ext.device.file_system_type | Volume device file system type. Following are examples of the most frequently seen volume device file system types: NTFS UDF | keyword |
 | threat.enrichments.indicator.file.Ext.device.nt_name | NT name of the device. NT device name is in the format such as: \Device\HarddiskVolume2 | keyword |
 | threat.enrichments.indicator.file.Ext.device.product_id | ProductID of the device. It is provided by the vendor of the device if any. | keyword |
 | threat.enrichments.indicator.file.Ext.device.serial_number | Serial Number of the device. It is provided by the vendor of the device if any. | keyword |
 | threat.enrichments.indicator.file.Ext.device.vendor_id | VendorID of the device. It is provided by the vendor of the device. | keyword |
+| threat.enrichments.indicator.file.Ext.device.volume_device_type | Volume device type. Following are examples of the most frequently seen volume device types: Disk File System CD-ROM File System | keyword |
 | threat.enrichments.indicator.file.Ext.entropy | Entropy calculation of file's header and footer used to check file integrity. | double |
 | threat.enrichments.indicator.file.Ext.entry_modified | Time of last status change.  See `st_ctim` member of `struct stat`. | double |
 | threat.enrichments.indicator.file.Ext.header_bytes | First 16 bytes of file used to check file integrity. | keyword |
@@ -1224,10 +1226,12 @@ sent by the endpoint.
 | threat.indicator.file.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | threat.indicator.file.Ext.device.bus_type | Bus type of the device, such as Nvme, Usb, FileBackedVirtual,... etc. | keyword |
 | threat.indicator.file.Ext.device.dos_name | DOS name of the device. DOS device name is in the format of driver letters such as C:, D:,... | keyword |
+| threat.indicator.file.Ext.device.file_system_type | Volume device file system type. Following are examples of the most frequently seen volume device file system types: NTFS UDF | keyword |
 | threat.indicator.file.Ext.device.nt_name | NT name of the device. NT device name is in the format such as: \Device\HarddiskVolume2 | keyword |
 | threat.indicator.file.Ext.device.product_id | ProductID of the device. It is provided by the vendor of the device if any. | keyword |
 | threat.indicator.file.Ext.device.serial_number | Serial Number of the device. It is provided by the vendor of the device if any. | keyword |
 | threat.indicator.file.Ext.device.vendor_id | VendorID of the device. It is provided by the vendor of the device. | keyword |
+| threat.indicator.file.Ext.device.volume_device_type | Volume device type. Following are examples of the most frequently seen volume device types: Disk File System CD-ROM File System | keyword |
 | threat.indicator.file.Ext.entropy | Entropy calculation of file's header and footer used to check file integrity. | double |
 | threat.indicator.file.Ext.entry_modified | Time of last status change.  See `st_ctim` member of `struct stat`. | double |
 | threat.indicator.file.Ext.header_bytes | First 16 bytes of file used to check file integrity. | keyword |
@@ -1486,6 +1490,7 @@ sent by the endpoint.
 | file.Ext | Object for all custom defined fields to live in. | object |
 | file.Ext.device.bus_type | Bus type of the device, such as Nvme, Usb, FileBackedVirtual,... etc. | keyword |
 | file.Ext.device.dos_name | DOS name of the device. DOS device name is in the format of driver letters such as C:, D:,... | keyword |
+| file.Ext.device.file_system_type | Volume device file system type. Following are examples of the most frequently seen volume device file system types: NTFS UDF | keyword |
 | file.Ext.device.nt_name | NT name of the device. NT device name is in the format such as: \Device\HarddiskVolume2 | keyword |
 | file.Ext.device.product_id | ProductID of the device. It is provided by the vendor of the device if any. | keyword |
 | file.Ext.device.serial_number | Serial Number of the device. It is provided by the vendor of the device if any. | keyword |
@@ -1667,6 +1672,7 @@ sent by the endpoint.
 | dll.Ext.defense_evasions | List of defense evasions found for this DLL. These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior. Examples tools that can cause defense evasions include KnownDlls hijacking and PPLDump. | keyword |
 | dll.Ext.device.bus_type | Bus type of the device, such as Nvme, Usb, FileBackedVirtual,... etc. | keyword |
 | dll.Ext.device.dos_name | DOS name of the device. DOS device name is in the format of driver letters such as C:, D:,... | keyword |
+| dll.Ext.device.file_system_type | Volume device file system type. Following are examples of the most frequently seen volume device file system types: NTFS UDF | keyword |
 | dll.Ext.device.nt_name | NT name of the device. NT device name is in the format such as: \Device\HarddiskVolume2 | keyword |
 | dll.Ext.device.product_id | ProductID of the device. It is provided by the vendor of the device if any. | keyword |
 | dll.Ext.device.serial_number | Serial Number of the device. It is provided by the vendor of the device if any. | keyword |
@@ -2081,6 +2087,7 @@ sent by the endpoint.
 | process.Ext.defense_evasions | List of defense evasions found in this process. These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior. Examples tools that can cause defense evasions include Process Doppelganging and Process Herpaderping. | keyword |
 | process.Ext.device.bus_type | Bus type of the device, such as Nvme, Usb, FileBackedVirtual,... etc. | keyword |
 | process.Ext.device.dos_name | DOS name of the device. DOS device name is in the format of driver letters such as C:, D:,... | keyword |
+| process.Ext.device.file_system_type | Volume device file system type. Following are examples of the most frequently seen volume device file system types: NTFS UDF | keyword |
 | process.Ext.device.nt_name | NT name of the device. NT device name is in the format such as: \Device\HarddiskVolume2 | keyword |
 | process.Ext.device.product_id | ProductID of the device. It is provided by the vendor of the device if any. | keyword |
 | process.Ext.device.serial_number | Serial Number of the device. It is provided by the vendor of the device if any. | keyword |

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -7707,6 +7707,20 @@ threat.enrichments.indicator.file.Ext.device.dos_name:
   original_fieldset: file
   short: DOS name of the device.
   type: keyword
+threat.enrichments.indicator.file.Ext.device.file_system_type:
+  dashed_name: threat-enrichments-indicator-file-Ext-device-file-system-type
+  description: 'Volume device file system type.
+
+    Following are examples of the most frequently seen volume device file system types:
+    NTFS UDF'
+  flat_name: threat.enrichments.indicator.file.Ext.device.file_system_type
+  ignore_above: 1024
+  level: custom
+  name: Ext.device.file_system_type
+  normalize: []
+  original_fieldset: file
+  short: Volume device file system type.
+  type: keyword
 threat.enrichments.indicator.file.Ext.device.nt_name:
   dashed_name: threat-enrichments-indicator-file-Ext-device-nt-name
   description: 'NT name of the device. NT device name is in the format such as: \Device\HarddiskVolume2'
@@ -7752,6 +7766,20 @@ threat.enrichments.indicator.file.Ext.device.vendor_id:
   normalize: []
   original_fieldset: file
   short: VendorID of the device.
+  type: keyword
+threat.enrichments.indicator.file.Ext.device.volume_device_type:
+  dashed_name: threat-enrichments-indicator-file-Ext-device-volume-device-type
+  description: 'Volume device type.
+
+    Following are examples of the most frequently seen volume device types: Disk File
+    System CD-ROM File System'
+  flat_name: threat.enrichments.indicator.file.Ext.device.volume_device_type
+  ignore_above: 1024
+  level: custom
+  name: Ext.device.volume_device_type
+  normalize: []
+  original_fieldset: file
+  short: Volume device type.
   type: keyword
 threat.enrichments.indicator.file.Ext.entropy:
   dashed_name: threat-enrichments-indicator-file-Ext-entropy
@@ -10234,6 +10262,20 @@ threat.indicator.file.Ext.device.dos_name:
   original_fieldset: file
   short: DOS name of the device.
   type: keyword
+threat.indicator.file.Ext.device.file_system_type:
+  dashed_name: threat-indicator-file-Ext-device-file-system-type
+  description: 'Volume device file system type.
+
+    Following are examples of the most frequently seen volume device file system types:
+    NTFS UDF'
+  flat_name: threat.indicator.file.Ext.device.file_system_type
+  ignore_above: 1024
+  level: custom
+  name: Ext.device.file_system_type
+  normalize: []
+  original_fieldset: file
+  short: Volume device file system type.
+  type: keyword
 threat.indicator.file.Ext.device.nt_name:
   dashed_name: threat-indicator-file-Ext-device-nt-name
   description: 'NT name of the device. NT device name is in the format such as: \Device\HarddiskVolume2'
@@ -10279,6 +10321,20 @@ threat.indicator.file.Ext.device.vendor_id:
   normalize: []
   original_fieldset: file
   short: VendorID of the device.
+  type: keyword
+threat.indicator.file.Ext.device.volume_device_type:
+  dashed_name: threat-indicator-file-Ext-device-volume-device-type
+  description: 'Volume device type.
+
+    Following are examples of the most frequently seen volume device types: Disk File
+    System CD-ROM File System'
+  flat_name: threat.indicator.file.Ext.device.volume_device_type
+  ignore_above: 1024
+  level: custom
+  name: Ext.device.volume_device_type
+  normalize: []
+  original_fieldset: file
+  short: Volume device type.
   type: keyword
 threat.indicator.file.Ext.entropy:
   dashed_name: threat-indicator-file-Ext-entropy

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -948,6 +948,19 @@ file.Ext.device.dos_name:
   normalize: []
   short: DOS name of the device.
   type: keyword
+file.Ext.device.file_system_type:
+  dashed_name: file-Ext-device-file-system-type
+  description: 'Volume device file system type.
+
+    Following are examples of the most frequently seen volume device file system types:
+    NTFS UDF'
+  flat_name: file.Ext.device.file_system_type
+  ignore_above: 1024
+  level: custom
+  name: Ext.device.file_system_type
+  normalize: []
+  short: Volume device file system type.
+  type: keyword
 file.Ext.device.nt_name:
   dashed_name: file-Ext-device-nt-name
   description: 'NT name of the device. NT device name is in the format such as: \Device\HarddiskVolume2'

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -341,6 +341,19 @@ dll.Ext.device.dos_name:
   normalize: []
   short: DOS name of the device.
   type: keyword
+dll.Ext.device.file_system_type:
+  dashed_name: dll-Ext-device-file-system-type
+  description: 'Volume device file system type.
+
+    Following are examples of the most frequently seen volume device file system types:
+    NTFS UDF'
+  flat_name: dll.Ext.device.file_system_type
+  ignore_above: 1024
+  level: custom
+  name: Ext.device.file_system_type
+  normalize: []
+  short: Volume device file system type.
+  type: keyword
 dll.Ext.device.nt_name:
   dashed_name: dll-Ext-device-nt-name
   description: 'NT name of the device. NT device name is in the format such as: \Device\HarddiskVolume2'

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1367,6 +1367,19 @@ process.Ext.device.dos_name:
   normalize: []
   short: DOS name of the device.
   type: keyword
+process.Ext.device.file_system_type:
+  dashed_name: process-Ext-device-file-system-type
+  description: 'Volume device file system type.
+
+    Following are examples of the most frequently seen volume device file system types:
+    NTFS UDF'
+  flat_name: process.Ext.device.file_system_type
+  ignore_above: 1024
+  level: custom
+  name: Ext.device.file_system_type
+  normalize: []
+  short: Volume device file system type.
+  type: keyword
 process.Ext.device.nt_name:
   dashed_name: process-Ext-device-nt-name
   description: 'NT name of the device. NT device name is in the format such as: \Device\HarddiskVolume2'


### PR DESCRIPTION
## Change Summary

This adds `device.file_system_type` field to file/dll/process events and malware alerts. A process event example is [here](https://gist.github.com/Trinity2019/ce9e34e69a9a106694fc0fefa8931261#file-process_event_from_eaf_test_iso_process_strings64-exe_has_device_info-txt-L85-L92). also adding `device.volume_device_type` to malware alerts as it shows up in malware alert, example is [here](https://gist.github.com/Trinity2019/f3b36fabbd38419d63f4231f3e3d1da6#file-malware_alert_process_from_mounted_iso_eaf_test-txt-L169-L176).

Sample document shown in above links.

## Release Target

8.8.0

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
