### PR TITLE
Added registry rollback fields associated with recovered values

### DIFF
--- a/custom_schemas/custom_responses.yml
+++ b/custom_schemas/custom_responses.yml
@@ -76,6 +76,21 @@
       type: keyword
       description: NT path of registry key recovered by Rollback 
 
+    - name: action.key.values
+      level: custom
+      type: nested
+      description: Values modified
+
+    - name: action.key.values.name
+      level: custom
+      type: keyword
+      description: Value name recovered by Rollback 
+
+    - name: action.key.values.actions
+      level: custom
+      type: keyword
+      description: Actions taken by Registry Rollback for value 
+
     - name: message
       level: custom
       type: text

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -417,6 +417,23 @@
       ignore_above: 1024
       description: NT path of registry key recovered by Rollback
       default_field: false
+    - name: action.key.values
+      level: custom
+      type: nested
+      description: Values modified
+      default_field: false
+    - name: action.key.values.actions
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Actions taken by Registry Rollback for value
+      default_field: false
+    - name: action.key.values.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Value name recovered by Rollback
+      default_field: false
     - name: action.source.attributes
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/alerts/sample_event.json
+++ b/package/endpoint/data_stream/alerts/sample_event.json
@@ -549,7 +549,7 @@
         "domain": "NT AUTHORITY",
         "name": "SYSTEM"
     },
-        "Responses": [
+    "Responses": [
         {
             "@timestamp": "2023-04-13T16:15:16.0Z",
             "action": {

--- a/package/endpoint/data_stream/alerts/sample_event.json
+++ b/package/endpoint/data_stream/alerts/sample_event.json
@@ -548,5 +548,62 @@
     "user": {
         "domain": "NT AUTHORITY",
         "name": "SYSTEM"
-    }
+    },
+        "Responses": [
+        {
+            "@timestamp": "2023-04-13T16:15:16.0Z",
+            "action": {
+                "action": "file_rollback",
+                "file": {
+                    "attributes": [
+                        "invalid"
+                    ],
+                    "path": "",
+                    "reason": 2147484160
+                },
+                "source": {
+                    "attributes": [
+                        "archive"
+                    ],
+                    "path": "\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy55\\git\\endpoint-dev\\Python\\runtime\\failed_test_logs\\20230413_181248\\EndpointRollbackTestCase\\test_rollback_trigger_malware_1_prevent\\tmp\\TRA14KA5Z2\\ExceptionlistTester-Windows.1d1phoq97d"
+                }
+            },
+            "message": "Successful production rollback",
+            "result": 0
+        },
+        {
+            "@timestamp": "2023-04-13T16:15:16.0Z",
+            "action": {
+                "action": "registry_rollback",
+                "key": {
+                    "actions": [
+                        "Deleted"
+                    ],
+                    "path": "\\REGISTRY\\MACHINE\\SOFTWARE\\WOW6432Node\\TestRollback\\1"
+                }
+            },
+            "message": "Successful production registry rollback",
+            "result": 0
+        },
+        {
+            "@timestamp": "2023-04-13T16:15:16.0Z",
+            "action": {
+                "action": "registry_rollback",
+                "key": {
+                    "actions": [
+                        "Modified"
+                    ],
+                    "path": "\\REGISTRY\\MACHINE\\SOFTWARE\\WOW6432Node\\TestRollback.valuetest",
+                    "values": [
+                        {
+                            "actions": [
+                                "Deleted"
+                            ],
+                            "name": "SomeValue"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
 }

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -80,6 +80,9 @@ sent by the endpoint.
 | Responses.action.file.reason | Combined USN file modification reason | long |
 | Responses.action.key.actions | Actions taken by Registry Rollback for key | keyword |
 | Responses.action.key.path | NT path of registry key recovered by Rollback | keyword |
+| Responses.action.key.values | Values modified | nested |
+| Responses.action.key.values.actions | Actions taken by Registry Rollback for value | keyword |
+| Responses.action.key.values.name | Value name recovered by Rollback | keyword |
 | Responses.action.source.attributes | Source file attributes | keyword |
 | Responses.action.source.path | Source file path | keyword |
 | Responses.action.state | Index of event in events array to use for field lookup | long |

--- a/schemas/v1/alerts/rule_detection_event.yaml
+++ b/schemas/v1/alerts/rule_detection_event.yaml
@@ -114,6 +114,35 @@ Responses.action.key.path:
   normalize: []
   short: NT path of registry key recovered by Rollback
   type: keyword
+Responses.action.key.values:
+  dashed_name: Responses-action-key-values
+  description: Values modified
+  flat_name: Responses.action.key.values
+  level: custom
+  name: action.key.values
+  normalize: []
+  short: Values modified
+  type: nested
+Responses.action.key.values.actions:
+  dashed_name: Responses-action-key-values-actions
+  description: Actions taken by Registry Rollback for value
+  flat_name: Responses.action.key.values.actions
+  ignore_above: 1024
+  level: custom
+  name: action.key.values.actions
+  normalize: []
+  short: Actions taken by Registry Rollback for value
+  type: keyword
+Responses.action.key.values.name:
+  dashed_name: Responses-action-key-values-name
+  description: Value name recovered by Rollback
+  flat_name: Responses.action.key.values.name
+  ignore_above: 1024
+  level: custom
+  name: action.key.values.name
+  normalize: []
+  short: Value name recovered by Rollback
+  type: keyword
 Responses.action.source.attributes:
   dashed_name: Responses-action-source-attributes
   description: Source file attributes


### PR DESCRIPTION
## Change Summary

Sample document:

```json
        {
            "@timestamp": "2023-04-13T16:15:16.0Z",
            "action": {
                "action": "registry_rollback",
                "key": {
                    "actions": [
                        "Modified"
                    ],
                    "path": "\\REGISTRY\\MACHINE\\SOFTWARE\\WOW6432Node\\TestRollback.valuetest",
                    "values": [
                        {
                            "actions": [
                                "Deleted"
                            ],
                            "name": "SomeValue"
                        }
                    ]
                }
            },
            "message": "Successful production registry rollback",
            "result": 0
        }
```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [x] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [x] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
