### PR TITLE
change action.key.values to object in alerts

### DIFF
--- a/custom_schemas/custom_responses.yml
+++ b/custom_schemas/custom_responses.yml
@@ -78,7 +78,7 @@
 
     - name: action.key.values
       level: custom
-      type: nested
+      type: object
       description: Values modified
 
     - name: action.key.values.name

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -419,7 +419,7 @@
       default_field: false
     - name: action.key.values
       level: custom
-      type: nested
+      type: object
       description: Values modified
       default_field: false
     - name: action.key.values.actions

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -80,7 +80,7 @@ sent by the endpoint.
 | Responses.action.file.reason | Combined USN file modification reason | long |
 | Responses.action.key.actions | Actions taken by Registry Rollback for key | keyword |
 | Responses.action.key.path | NT path of registry key recovered by Rollback | keyword |
-| Responses.action.key.values | Values modified | nested |
+| Responses.action.key.values | Values modified | object |
 | Responses.action.key.values.actions | Actions taken by Registry Rollback for value | keyword |
 | Responses.action.key.values.name | Value name recovered by Rollback | keyword |
 | Responses.action.source.attributes | Source file attributes | keyword |

--- a/schemas/v1/alerts/rule_detection_event.yaml
+++ b/schemas/v1/alerts/rule_detection_event.yaml
@@ -122,7 +122,7 @@ Responses.action.key.values:
   name: action.key.values
   normalize: []
   short: Values modified
-  type: nested
+  type: object
 Responses.action.key.values.actions:
   dashed_name: Responses-action-key-values-actions
   description: Actions taken by Registry Rollback for value


### PR DESCRIPTION
## Change Summary

change `action.key.values` (added in #362) from nested type to object in the alerts index.

alerts index reached maximum (50) nested fields


### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes


