### PR TITLE
set up 8.9 dev cycle

### DIFF
--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,3 +1,8 @@
+- version: "8.9.0-next"
+  changes:
+    - description: TBD
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/364
 - version: "8.8.0"
   changes:
     - description: change action.key.values to object in alerts

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.8.0
+version: 8.9.0-dev.0
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 # The default type is integration and will be set if empty.
@@ -14,7 +14,7 @@ policy_templates:
     description: Interact with the endpoint.
     multiple: false
 conditions:
-  kibana.version: "^8.8.0"
+  kibana.version: "^8.9.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
   # >= <the version> && < 8.0.0
 icons:


### PR DESCRIPTION
## Change Summary

Setup the 8.9 development cycle



`-next` convention is now reserved for use in the `changelog` file, as its intention is to relax the linter:

to allow the top-line `changelog` version to differ from the `manifest` version during development, where the `manifest` file version will likely change with each prerelease. Now the changelog version does not have to constantly change to match.

However, the manifest version _does_ need to continually change to actually perform releases. We cannot overwrite a previous release (even prerelease) with the same version name. So we are going back to the `-dev.N` convention for now, incrementing periodically. This will likely be automated in the future