### PR TITLE
ETW Threat-Intelligence API Event metrics

### DIFF
--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -596,6 +596,56 @@
       type: long
       description: Total size of suppressed documents
 
+    - name: metrics.documents_volume.api_events.sent_count
+      level: custom
+      type: long
+      description: Number of sent API Event documents
+
+    - name: metrics.documents_volume.api_events.sent_bytes
+      level: custom
+      type: long
+      description: Total size of API Event sent documents
+
+    - name: metrics.documents_volume.api_events.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed API Event documents
+
+    - name: metrics.documents_volume.api_events.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed API Event documents
+
+    - name: metrics.documents_volume.api_events.sources
+      level: custom
+      type: object
+      description: An array of API Event document statistics per source
+
+    - name: metrics.documents_volume.api_events.sources.source
+      level: custom
+      type: string
+      description: API Event document source name
+
+    - name: metrics.documents_volume.api_events.sources.sent_count
+      level: custom
+      type: long
+      description: Number of sent API Event documents from source
+
+    - name: metrics.documents_volume.api_events.sources.sent_bytes
+      level: custom
+      type: long
+      description: Total size of API Event sent documents from source
+
+    - name: metrics.documents_volume.api_events.sources.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed API Event documents from source
+
+    - name: metrics.documents_volume.api_events.sources.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed API Event documents from source
+
     - name: metrics.uptime
       level: custom
       type: object
@@ -846,17 +896,17 @@
       index: false
       description: The total milliseconds spent queueing process events for the process over the last week
 
-    - name: metrics.system_impact.etw_events.week_ms
+    - name: metrics.system_impact.threat_intelligence_events.week_ms
       level: custom
       type: unsigned_long
       index: false
-      description: The total milliseconds spent on ETW-based events for the process over the last week
+      description: The total milliseconds spent on ETW Threat-Intelligence events for the process over the last week
 
-    - name: metrics.system_impact.etw_events.week_idle_ms
+    - name: metrics.system_impact.threat_intelligence_events.week_idle_ms
       level: custom
       type: unsigned_long
       index: false
-      description: The total milliseconds spent queueing ETW-based events for the process over the last week
+      description: The total milliseconds spent queueing ETW Threat-Intelligence events for the process over the last week
 
     - name: metrics.system_impact.process.executable
       level: custom

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -122,6 +122,56 @@
       type: long
       description: Number of suppressed documents
       default_field: false
+    - name: metrics.documents_volume.api_events.sent_bytes
+      level: custom
+      type: long
+      description: Total size of API Event sent documents
+      default_field: false
+    - name: metrics.documents_volume.api_events.sent_count
+      level: custom
+      type: long
+      description: Number of sent API Event documents
+      default_field: false
+    - name: metrics.documents_volume.api_events.sources
+      level: custom
+      type: object
+      description: An array of API Event document statistics per source
+      default_field: false
+    - name: metrics.documents_volume.api_events.sources.sent_bytes
+      level: custom
+      type: long
+      description: Total size of API Event sent documents from source
+      default_field: false
+    - name: metrics.documents_volume.api_events.sources.sent_count
+      level: custom
+      type: long
+      description: Number of sent API Event documents from source
+      default_field: false
+    - name: metrics.documents_volume.api_events.sources.source
+      level: custom
+      type: string
+      description: API Event document source name
+      default_field: false
+    - name: metrics.documents_volume.api_events.sources.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed API Event documents from source
+      default_field: false
+    - name: metrics.documents_volume.api_events.sources.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed API Event documents from source
+      default_field: false
+    - name: metrics.documents_volume.api_events.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed API Event documents
+      default_field: false
+    - name: metrics.documents_volume.api_events.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed API Event documents
+      default_field: false
     - name: metrics.documents_volume.diagnostic_alerts.sent_bytes
       level: custom
       type: long
@@ -397,20 +447,6 @@
       index: false
       doc_values: false
       default_field: false
-    - name: metrics.system_impact.etw_events.week_idle_ms
-      level: custom
-      type: unsigned_long
-      description: The total milliseconds spent queueing ETW-based events for the process over the last week
-      index: false
-      doc_values: false
-      default_field: false
-    - name: metrics.system_impact.etw_events.week_ms
-      level: custom
-      type: unsigned_long
-      description: The total milliseconds spent on ETW-based events for the process over the last week
-      index: false
-      doc_values: false
-      default_field: false
     - name: metrics.system_impact.file_events.week_idle_ms
       level: custom
       type: unsigned_long
@@ -586,6 +622,20 @@
       level: custom
       type: unsigned_long
       description: The total milliseconds spent on registry events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.threat_intelligence_events.week_idle_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent queueing ETW Threat-Intelligence events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.threat_intelligence_events.week_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent on ETW Threat-Intelligence events for the process over the last week
       index: false
       doc_values: false
       default_field: false

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2800,6 +2800,16 @@ Metrics documents contain performance information about the endpoint executable 
 | Endpoint.metrics.documents_volume.alerts.sent_count | Number of sent documents | long |
 | Endpoint.metrics.documents_volume.alerts.suppressed_bytes | Total size of suppressed documents | long |
 | Endpoint.metrics.documents_volume.alerts.suppressed_count | Number of suppressed documents | long |
+| Endpoint.metrics.documents_volume.api_events.sent_bytes | Total size of API Event sent documents | long |
+| Endpoint.metrics.documents_volume.api_events.sent_count | Number of sent API Event documents | long |
+| Endpoint.metrics.documents_volume.api_events.sources | An array of API Event document statistics per source | object |
+| Endpoint.metrics.documents_volume.api_events.sources.sent_bytes | Total size of API Event sent documents from source | long |
+| Endpoint.metrics.documents_volume.api_events.sources.sent_count | Number of sent API Event documents from source | long |
+| Endpoint.metrics.documents_volume.api_events.sources.source | API Event document source name | string |
+| Endpoint.metrics.documents_volume.api_events.sources.suppressed_bytes | Total size of suppressed API Event documents from source | long |
+| Endpoint.metrics.documents_volume.api_events.sources.suppressed_count | Number of suppressed API Event documents from source | long |
+| Endpoint.metrics.documents_volume.api_events.suppressed_bytes | Total size of suppressed API Event documents | long |
+| Endpoint.metrics.documents_volume.api_events.suppressed_count | Number of suppressed API Event documents | long |
 | Endpoint.metrics.documents_volume.diagnostic_alerts.sent_bytes | Total size of sent documents | long |
 | Endpoint.metrics.documents_volume.diagnostic_alerts.sent_count | Number of sent documents | long |
 | Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_bytes | Total size of suppressed documents | long |

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -188,6 +188,96 @@ Endpoint.metrics.documents_volume.alerts.suppressed_count:
   normalize: []
   short: Number of suppressed documents
   type: long
+Endpoint.metrics.documents_volume.api_events.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-api-events-sent-bytes
+  description: Total size of API Event sent documents
+  flat_name: Endpoint.metrics.documents_volume.api_events.sent_bytes
+  level: custom
+  name: metrics.documents_volume.api_events.sent_bytes
+  normalize: []
+  short: Total size of API Event sent documents
+  type: long
+Endpoint.metrics.documents_volume.api_events.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-api-events-sent-count
+  description: Number of sent API Event documents
+  flat_name: Endpoint.metrics.documents_volume.api_events.sent_count
+  level: custom
+  name: metrics.documents_volume.api_events.sent_count
+  normalize: []
+  short: Number of sent API Event documents
+  type: long
+Endpoint.metrics.documents_volume.api_events.sources:
+  dashed_name: Endpoint-metrics-documents-volume-api-events-sources
+  description: An array of API Event document statistics per source
+  flat_name: Endpoint.metrics.documents_volume.api_events.sources
+  level: custom
+  name: metrics.documents_volume.api_events.sources
+  normalize: []
+  short: An array of API Event document statistics per source
+  type: object
+Endpoint.metrics.documents_volume.api_events.sources.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-api-events-sources-sent-bytes
+  description: Total size of API Event sent documents from source
+  flat_name: Endpoint.metrics.documents_volume.api_events.sources.sent_bytes
+  level: custom
+  name: metrics.documents_volume.api_events.sources.sent_bytes
+  normalize: []
+  short: Total size of API Event sent documents from source
+  type: long
+Endpoint.metrics.documents_volume.api_events.sources.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-api-events-sources-sent-count
+  description: Number of sent API Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.api_events.sources.sent_count
+  level: custom
+  name: metrics.documents_volume.api_events.sources.sent_count
+  normalize: []
+  short: Number of sent API Event documents from source
+  type: long
+Endpoint.metrics.documents_volume.api_events.sources.source:
+  dashed_name: Endpoint-metrics-documents-volume-api-events-sources-source
+  description: API Event document source name
+  flat_name: Endpoint.metrics.documents_volume.api_events.sources.source
+  level: custom
+  name: metrics.documents_volume.api_events.sources.source
+  normalize: []
+  short: API Event document source name
+  type: string
+Endpoint.metrics.documents_volume.api_events.sources.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-api-events-sources-suppressed-bytes
+  description: Total size of suppressed API Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.api_events.sources.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.api_events.sources.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed API Event documents from source
+  type: long
+Endpoint.metrics.documents_volume.api_events.sources.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-api-events-sources-suppressed-count
+  description: Number of suppressed API Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.api_events.sources.suppressed_count
+  level: custom
+  name: metrics.documents_volume.api_events.sources.suppressed_count
+  normalize: []
+  short: Number of suppressed API Event documents from source
+  type: long
+Endpoint.metrics.documents_volume.api_events.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-api-events-suppressed-bytes
+  description: Total size of suppressed API Event documents
+  flat_name: Endpoint.metrics.documents_volume.api_events.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.api_events.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed API Event documents
+  type: long
+Endpoint.metrics.documents_volume.api_events.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-api-events-suppressed-count
+  description: Number of suppressed API Event documents
+  flat_name: Endpoint.metrics.documents_volume.api_events.suppressed_count
+  level: custom
+  name: metrics.documents_volume.api_events.suppressed_count
+  normalize: []
+  short: Number of suppressed API Event documents
+  type: long
 Endpoint.metrics.documents_volume.diagnostic_alerts.sent_bytes:
   dashed_name: Endpoint-metrics-documents-volume-diagnostic-alerts-sent-bytes
   description: Total size of sent documents
@@ -675,32 +765,6 @@ Endpoint.metrics.system_impact.dns_events.week_ms:
   short: The total milliseconds spent on DNS events for the process over the last
     week
   type: unsigned_long
-Endpoint.metrics.system_impact.etw_events.week_idle_ms:
-  dashed_name: Endpoint-metrics-system-impact-etw-events-week-idle-ms
-  description: The total milliseconds spent queueing ETW-based events for the process
-    over the last week
-  doc_values: false
-  flat_name: Endpoint.metrics.system_impact.etw_events.week_idle_ms
-  index: false
-  level: custom
-  name: metrics.system_impact.etw_events.week_idle_ms
-  normalize: []
-  short: The total milliseconds spent queueing ETW-based events for the process over
-    the last week
-  type: unsigned_long
-Endpoint.metrics.system_impact.etw_events.week_ms:
-  dashed_name: Endpoint-metrics-system-impact-etw-events-week-ms
-  description: The total milliseconds spent on ETW-based events for the process over
-    the last week
-  doc_values: false
-  flat_name: Endpoint.metrics.system_impact.etw_events.week_ms
-  index: false
-  level: custom
-  name: metrics.system_impact.etw_events.week_ms
-  normalize: []
-  short: The total milliseconds spent on ETW-based events for the process over the
-    last week
-  type: unsigned_long
 Endpoint.metrics.system_impact.file_events.week_idle_ms:
   dashed_name: Endpoint-metrics-system-impact-file-events-week-idle-ms
   description: The total milliseconds spent queueing file events for the process over
@@ -1003,6 +1067,32 @@ Endpoint.metrics.system_impact.registry_events.week_ms:
   normalize: []
   short: The total milliseconds spent on registry events for the process over the
     last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.threat_intelligence_events.week_idle_ms:
+  dashed_name: Endpoint-metrics-system-impact-threat-intelligence-events-week-idle-ms
+  description: The total milliseconds spent queueing ETW Threat-Intelligence events
+    for the process over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.threat_intelligence_events.week_idle_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.threat_intelligence_events.week_idle_ms
+  normalize: []
+  short: The total milliseconds spent queueing ETW Threat-Intelligence events for
+    the process over the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.threat_intelligence_events.week_ms:
+  dashed_name: Endpoint-metrics-system-impact-threat-intelligence-events-week-ms
+  description: The total milliseconds spent on ETW Threat-Intelligence events for
+    the process over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.threat_intelligence_events.week_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.threat_intelligence_events.week_ms
+  normalize: []
+  short: The total milliseconds spent on ETW Threat-Intelligence events for the process
+    over the last week
   type: unsigned_long
 Endpoint.metrics.threads:
   dashed_name: Endpoint-metrics-threads


### PR DESCRIPTION
## Change Summary

Adds new metrics fields for the API Event type and the ETW Threat-Intelligence API Event provider.

```
Endpoint.metrics.documents_volume.api_events.sent_bytes
Endpoint.metrics.documents_volume.api_events.sent_count
Endpoint.metrics.documents_volume.api_events.suppressed_bytes
Endpoint.metrics.documents_volume.api_events.suppressed_count
Endpoint.metrics.documents_volume.api_events.sources[].source
Endpoint.metrics.documents_volume.api_events.sources[].sent_bytes
Endpoint.metrics.documents_volume.api_events.sources[].sent_count
Endpoint.metrics.documents_volume.api_events.sources[].suppressed_bytes
Endpoint.metrics.documents_volume.api_events.sources[].suppressed_count
Endpoint.metrics.system_impact.threat_intelligence_events.week_idle_ms
Endpoint.metrics.system_impact.threat_intelligence_events.week_ms
```

## Release Target

These events are diagnostic in 8.8 and will be released in a future version.

# For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match
