### PR TITLE
Fix mapping error by replacing string with keyword

### DIFF
--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -623,7 +623,7 @@
 
     - name: metrics.documents_volume.api_events.sources.source
       level: custom
-      type: string
+      type: keyword
       description: API Event document source name
 
     - name: metrics.documents_volume.api_events.sources.sent_count

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -149,7 +149,8 @@
       default_field: false
     - name: metrics.documents_volume.api_events.sources.source
       level: custom
-      type: string
+      type: keyword
+      ignore_above: 1024
       description: API Event document source name
       default_field: false
     - name: metrics.documents_volume.api_events.sources.suppressed_bytes

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2805,7 +2805,7 @@ Metrics documents contain performance information about the endpoint executable 
 | Endpoint.metrics.documents_volume.api_events.sources | An array of API Event document statistics per source | object |
 | Endpoint.metrics.documents_volume.api_events.sources.sent_bytes | Total size of API Event sent documents from source | long |
 | Endpoint.metrics.documents_volume.api_events.sources.sent_count | Number of sent API Event documents from source | long |
-| Endpoint.metrics.documents_volume.api_events.sources.source | API Event document source name | string |
+| Endpoint.metrics.documents_volume.api_events.sources.source | API Event document source name | keyword |
 | Endpoint.metrics.documents_volume.api_events.sources.suppressed_bytes | Total size of suppressed API Event documents from source | long |
 | Endpoint.metrics.documents_volume.api_events.sources.suppressed_count | Number of suppressed API Event documents from source | long |
 | Endpoint.metrics.documents_volume.api_events.suppressed_bytes | Total size of suppressed API Event documents | long |

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.9.0-dev.0
+version: 8.9.0-dev.1
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 # The default type is integration and will be set if empty.

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -237,11 +237,12 @@ Endpoint.metrics.documents_volume.api_events.sources.source:
   dashed_name: Endpoint-metrics-documents-volume-api-events-sources-source
   description: API Event document source name
   flat_name: Endpoint.metrics.documents_volume.api_events.sources.source
+  ignore_above: 1024
   level: custom
   name: metrics.documents_volume.api_events.sources.source
   normalize: []
   short: API Event document source name
-  type: string
+  type: keyword
 Endpoint.metrics.documents_volume.api_events.sources.suppressed_bytes:
   dashed_name: Endpoint-metrics-documents-volume-api-events-sources-suppressed-bytes
   description: Total size of suppressed API Event documents from source


### PR DESCRIPTION
## Change Summary

Fixes a mapping error due to the inclusion of `type: string` in a recent change.  The proposed change is to use `type: keyword` in place.

Failing test where this was caught: https://github.com/elastic/kibana/issues/147640

## Release Target

8.9

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

