### PR TITLE
Added Process Rollback fields

### DIFF
--- a/custom_schemas/custom_responses.yml
+++ b/custom_schemas/custom_responses.yml
@@ -91,6 +91,21 @@
       type: keyword
       description: Actions taken by Registry Rollback for value 
 
+    - name: action.process.path
+      level: custom
+      type: keyword
+      description: Path of process killed by Process Rollback
+
+    - name: action.process.message
+      level: custom
+      type: keyword
+      description: Status message for Process Rollback
+
+    - name: action.process.result
+      level: custom
+      type: long
+      description: Result code for Process Rollback
+
     - name: message
       level: custom
       type: text

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -434,6 +434,23 @@
       ignore_above: 1024
       description: Value name recovered by Rollback
       default_field: false
+    - name: action.process.message
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Status message for Process Rollback
+      default_field: false
+    - name: action.process.path
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Path of process killed by Process Rollback
+      default_field: false
+    - name: action.process.result
+      level: custom
+      type: long
+      description: Result code for Process Rollback
+      default_field: false
     - name: action.source.attributes
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/alerts/sample_event.json
+++ b/package/endpoint/data_stream/alerts/sample_event.json
@@ -605,7 +605,7 @@
                 }
             }
         },
-	{
+        {
             "@timestamp": "2023-07-19T14:21:05.0Z",
             "action": {
                 "action": "process_rollback",
@@ -615,6 +615,6 @@
             },
             "message": "Successful production process rollback",
             "result": 0
-	}
+        }
     ]
 }

--- a/package/endpoint/data_stream/alerts/sample_event.json
+++ b/package/endpoint/data_stream/alerts/sample_event.json
@@ -604,6 +604,17 @@
                     ]
                 }
             }
-        }
+        },
+	{
+            "@timestamp": "2023-07-19T14:21:05.0Z",
+            "action": {
+                "action": "process_rollback",
+                "process": {
+                    "path": "C:\\Users\\Pawel Mirski\\AppData\\Local\\Programs\\Python\\Python38-32\\python.exe"
+                }
+            },
+            "message": "Successful production process rollback",
+            "result": 0
+	}
     ]
 }

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -83,6 +83,9 @@ sent by the endpoint.
 | Responses.action.key.values | Values modified | object |
 | Responses.action.key.values.actions | Actions taken by Registry Rollback for value | keyword |
 | Responses.action.key.values.name | Value name recovered by Rollback | keyword |
+| Responses.action.process.message | Status message for Process Rollback | keyword |
+| Responses.action.process.path | Path of process killed by Process Rollback | keyword |
+| Responses.action.process.result | Result code for Process Rollback | long |
 | Responses.action.source.attributes | Source file attributes | keyword |
 | Responses.action.source.path | Source file path | keyword |
 | Responses.action.state | Index of event in events array to use for field lookup | long |

--- a/schemas/v1/alerts/rule_detection_event.yaml
+++ b/schemas/v1/alerts/rule_detection_event.yaml
@@ -143,6 +143,35 @@ Responses.action.key.values.name:
   normalize: []
   short: Value name recovered by Rollback
   type: keyword
+Responses.action.process.message:
+  dashed_name: Responses-action-process-message
+  description: Status message for Process Rollback
+  flat_name: Responses.action.process.message
+  ignore_above: 1024
+  level: custom
+  name: action.process.message
+  normalize: []
+  short: Status message for Process Rollback
+  type: keyword
+Responses.action.process.path:
+  dashed_name: Responses-action-process-path
+  description: Path of process killed by Process Rollback
+  flat_name: Responses.action.process.path
+  ignore_above: 1024
+  level: custom
+  name: action.process.path
+  normalize: []
+  short: Path of process killed by Process Rollback
+  type: keyword
+Responses.action.process.result:
+  dashed_name: Responses-action-process-result
+  description: Result code for Process Rollback
+  flat_name: Responses.action.process.result
+  level: custom
+  name: action.process.result
+  normalize: []
+  short: Result code for Process Rollback
+  type: long
 Responses.action.source.attributes:
   dashed_name: Responses-action-source-attributes
   description: Source file attributes


### PR DESCRIPTION
## Change Summary

Added response fields related to Process Rollback

### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json
    "Responses": [
        {
            "@timestamp": "2023-07-19T14:21:05.0Z",
            "action": {
                "action": "process_rollback",
                "process": {
                    "path": "C:\\Users\\Pawel Mirski\\AppData\\Local\\Programs\\Python\\Python38-32\\python.exe"
                }
            },
            "message": "Successful production process rollback",
            "result": 0
        }
    ]
```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [x] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [x] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
