### PR TITLE
revert adding Endpoint.state.enabled_features

### DIFF
--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -1050,11 +1050,6 @@
       type: boolean
       description: Current network isolation state of the host
 
-    - name: state.enabled_features
-      level: custom
-      type: keyword
-      description: High level summary of policy features actively in use
-
     - name: capabilities
       level: custom
       type: keyword

--- a/custom_subsets/elastic_endpoint/heartbeat/heartbeat.yaml
+++ b/custom_subsets/elastic_endpoint/heartbeat/heartbeat.yaml
@@ -13,8 +13,3 @@ fields:
   event:
     fields:
       ingested: {}
-  Endpoint:
-    fields:
-      state:
-        fields:
-          enabled_features: {}

--- a/package/endpoint/data_stream/heartbeat/fields/fields.yml
+++ b/package/endpoint/data_stream/heartbeat/fields/fields.yml
@@ -21,24 +21,6 @@
     If multiple messages exist, they can be combined into one message.'
   example: Hello World
   default_field: true
-- name: Endpoint
-  title: Endpoint
-  group: 2
-  description: Fields describing the state of the Elastic Endpoint when an event occurs.
-  type: group
-  default_field: true
-  fields:
-    - name: state
-      level: custom
-      type: object
-      description: Represents the current state of a non-policy setting These fields reflect the current status of a field, which may differ from what it is configured to be (see Endpoint.configuration)
-      default_field: false
-    - name: state.enabled_features
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: High level summary of policy features actively in use
-      default_field: false
 - name: agent
   title: Agent
   group: 2

--- a/package/endpoint/data_stream/heartbeat/sample_event.json
+++ b/package/endpoint/data_stream/heartbeat/sample_event.json
@@ -11,17 +11,5 @@
     "message": "Endpoint heartbeat",
     "event": {
         "ingested": "2023-07-18T20:40:09.279939Z"
-    },
-    "Endpoint": {
-        "state": {
-            "enabled_features": [
-                "malware",
-                "ransomware",
-                "attack_surface_reduction",
-                "memory_threat",
-                "malicious_behavior",
-                "events"
-            ]
-        }
     }
 }

--- a/schemas/v1/heartbeat/heartbeat.yaml
+++ b/schemas/v1/heartbeat/heartbeat.yaml
@@ -17,29 +17,6 @@
   required: true
   short: Date/time when the event originated.
   type: date
-Endpoint.state:
-  dashed_name: Endpoint-state
-  description: Represents the current state of a non-policy setting These fields reflect
-    the current status of a field, which may differ from what it is configured to
-    be (see Endpoint.configuration)
-  flat_name: Endpoint.state
-  level: custom
-  name: state
-  normalize: []
-  short: Represents the current state of a non-policy setting These fields reflect
-    the current status of a field, which may differ from what it is configured to
-    be (see Endpoint.configuration)
-  type: object
-Endpoint.state.enabled_features:
-  dashed_name: Endpoint-state-enabled-features
-  description: High level summary of policy features actively in use
-  flat_name: Endpoint.state.enabled_features
-  ignore_above: 1024
-  level: custom
-  name: state.enabled_features
-  normalize: []
-  short: High level summary of policy features actively in use
-  type: keyword
 agent.id:
   dashed_name: agent-id
   description: 'Unique identifier of this agent (if one exists).


### PR DESCRIPTION
## Change Summary

This reverts most of https://github.com/elastic/endpoint-package/pull/399
* `Endpoint.state.enabled_features` is removed
* The `custom_documentation/` removal in the original PR is left removed since the data is still now going to a `.logs` index.


### Sample values

See PR

## Release Target

8.10

## Q/A

- [x] I ran `make` after making the schema changes, and committed all changes