### PR TITLE
Set transforms to be unattended

### DIFF
--- a/package/endpoint/elasticsearch/transform/metadata_current/transform.yml
+++ b/package/endpoint/elasticsearch/transform/metadata_current/transform.yml
@@ -18,3 +18,5 @@ sync:
   time:
     field: event.ingested
     delay: 1s
+settings:
+  unattended: true

--- a/package/endpoint/elasticsearch/transform/metadata_united/transform.yml
+++ b/package/endpoint/elasticsearch/transform/metadata_united/transform.yml
@@ -21,6 +21,8 @@ pivot:
     agent.id:
       terms:
         field: agent.id
+settings:
+  unattended: true
 description: Merges latest Endpoint and Agent metadata documents
 _meta:
   managed: true


### PR DESCRIPTION
## Change Summary

This changes both transforms to use the `unattended` setting, allowing for increased stack oversight about their continual running.

This was previously introduced in https://github.com/elastic/endpoint-package/pull/353 and reverted in https://github.com/elastic/endpoint-package/pull/359



## Release Target

next / TBD -- kibana changes to the watchdog tasks should be in sync

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For Transform changes:

- [x] The new transform successfully starts in Kibana
- [x] The corresponding transform destination schema was updated if necessary
