### PR TITLE
setup 8.10.1 dev cycle

### DIFF
--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,3 +1,8 @@
+- version: "8.10.1-preview"
+  changes:
+    - description: TBD
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/TBD
 - version: "8.10.0"
   changes:
     - description: set transforms to be unattended

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.10.0
+version: 8.10.1-preview
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 # The default type is integration and will be set if empty.


### PR DESCRIPTION
## Change Summary

Set up the 8.10.x branch for any dev work on patch releases

`-preview` was used as the manifest version instead of `-dev` because of this lint error:

```
   6. prerelease tag (dev) should be one of [next, SNAPSHOT], or one of [beta, rc, preview] followed by numbers
```

we used `-next` in the past, but then special handling was added for that one specifically. 


The same postfix was added to the changelog because of this ensuing lint message:

```
   4. current manifest version doesn't have changelog entry
```


Both messages went away with this changeset


## Release Target

none