### PR TITLE
set up 8.11 release cycle

### DIFF
--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,3 +1,8 @@
+- version: "8.11.0-preview"
+  changes:
+    - description: TBD
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/9999
 - version: "8.10.0"
   changes:
     - description: set transforms to be unattended

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 1.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.10.0
+version: 8.11.0-preview
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 # The default type is integration and will be set if empty.
@@ -14,7 +14,7 @@ policy_templates:
     description: Interact with the endpoint.
     multiple: false
 conditions:
-  kibana.version: "^8.10.0"
+  kibana.version: "^8.11.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
   # >= <the version> && < 8.0.0
 icons:


### PR DESCRIPTION
## Change Summary

- updates min. kibana to `^8.11` (this will cause CI to fail as 8.11 docker images don't exist, which is OK)
- updates package to `8.11.0-preview`. The package linter doesn't accept `-dev` as a valid suffix
- adds matching TBD changelog line, which also quiets the linter

