### PR TITLE
Revert unattended transforms

### DIFF
--- a/package/endpoint/elasticsearch/transform/metadata_current/transform.yml
+++ b/package/endpoint/elasticsearch/transform/metadata_current/transform.yml
@@ -18,5 +18,3 @@ sync:
   time:
     field: event.ingested
     delay: 1s
-settings:
-  unattended: true

--- a/package/endpoint/elasticsearch/transform/metadata_united/transform.yml
+++ b/package/endpoint/elasticsearch/transform/metadata_united/transform.yml
@@ -21,8 +21,6 @@ pivot:
     agent.id:
       terms:
         field: agent.id
-settings:
-  unattended: true
 description: Merges latest Endpoint and Agent metadata documents
 _meta:
   managed: true


### PR DESCRIPTION
## Change Summary

This reverts https://github.com/elastic/endpoint-package/pull/401

(this change was previously introduced in #353 and reverted in #359. We are stuck in a time-loop)


## Release Target

8.10.1


