### PR TITLE
additional process callstack custom_documentation fields

### DIFF
--- a/custom_documentation/doc/endpoint/process/windows/windows_process_create.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_create.md
@@ -107,6 +107,9 @@ This event is generated when a process is created.
 | process.parent.name |
 | process.parent.pid |
 | process.parent.thread.Ext.call_stack.symbol_info |
+| process.parent.thread.Ext.call_stack.protection |
+| process.parent.thread.Ext.call_stack.callsite_leading_bytes |
+| process.parent.thread.Ext.call_stack.callsite_trailing_bytes |
 | process.parent.thread.Ext.call_stack_contains_unbacked |
 | process.parent.thread.Ext.call_stack_summary |
 | process.pe.imphash |

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create.yaml
@@ -112,6 +112,9 @@ fields:
   - process.parent.name
   - process.parent.pid
   - process.parent.thread.Ext.call_stack.symbol_info
+  - process.parent.thread.Ext.call_stack.protection
+  - process.parent.thread.Ext.call_stack.callsite_leading_bytes
+  - process.parent.thread.Ext.call_stack.callsite_trailing_bytes
   - process.parent.thread.Ext.call_stack_contains_unbacked
   - process.parent.thread.Ext.call_stack_summary
   - process.pe.imphash


### PR DESCRIPTION
## Change Summary

Add missing `process.parent.thread.Ext.call_stack` fields to custom_documentation.
These optional fields have existed since 8.8.0

