### PR TITLE
global artifact update age

### DIFF
--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -336,6 +336,11 @@
       type: object
       description: information about global protection artifacts applied.
 
+    - name: policy.applied.artifacts.global.update_age
+      level: custom
+      type: unsigned_long
+      description: number of days since global artifacts were made up-to-date
+
     - name: policy.applied.artifacts.global.version
       level: custom
       type: keyword


### PR DESCRIPTION
## Change Summary

Add artifact up-to-date age indicator. It's equal to number of days since the local artifacts copy at Endpoint side was last time deemed up-to-date (the date when either Endpoint updated the artifacts or verified that it's artifacts are up-to-date with Elastic CDN).

Note, when artifacts are pinned to a specific snapshot date, the age always equal to the numbers of days since that date. In addition the initial artifacts shipped with the installation package age is equal to the number of days since the package creation date (endpoint build date).

### Sample values

Artifacts made or verified to be up-to-date today:
`"Endpoint.policy.applied.artifacts.global.update_age": 0`
Artifacts 50 days old
`"Endpoint.policy.applied.artifacts.global.update_age": 50`

Sample document:

Endpoint altert and Endpoint policy response:

```json
{
    "Endpoint": {
        "policy": {
            "applied": {
                "artifacts": {
                    "global": {
                        "update_age": 0,
                    },
}

```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
