### PR TITLE
Backport `custom_documentation` #435 to 8.10.3 

### DIFF
--- a/custom_documentation/endpoint/data_stream/process/windows/windows_process_create.yaml
+++ b/custom_documentation/endpoint/data_stream/process/windows/windows_process_create.yaml
@@ -112,6 +112,9 @@ fields:
   - process.parent.name
   - process.parent.pid
   - process.parent.thread.Ext.call_stack.symbol_info
+  - process.parent.thread.Ext.call_stack.protection
+  - process.parent.thread.Ext.call_stack.callsite_leading_bytes
+  - process.parent.thread.Ext.call_stack.callsite_trailing_bytes
   - process.parent.thread.Ext.call_stack_contains_unbacked
   - process.parent.thread.Ext.call_stack_summary
   - process.pe.imphash

--- a/package/endpoint/docs/custom_documentation/process/windows/windows_process_create.md
+++ b/package/endpoint/docs/custom_documentation/process/windows/windows_process_create.md
@@ -107,6 +107,9 @@ This event is generated when a process is created.
 | process.parent.name |
 | process.parent.pid |
 | process.parent.thread.Ext.call_stack.symbol_info |
+| process.parent.thread.Ext.call_stack.protection |
+| process.parent.thread.Ext.call_stack.callsite_leading_bytes |
+| process.parent.thread.Ext.call_stack.callsite_trailing_bytes |
 | process.parent.thread.Ext.call_stack_contains_unbacked |
 | process.parent.thread.Ext.call_stack_summary |
 | process.pe.imphash |

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -14,7 +14,7 @@ policy_templates:
     description: Interact with the endpoint.
     multiple: false
 conditions:
-  kibana.version: "^8.10.0"
+  kibana.version: "^8.10.2"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
   # >= <the version> && < 8.0.0
 icons:


### PR DESCRIPTION
Backport https://github.com/elastic/endpoint-package/pull/435 to 8.10.3.