### PR TITLE
[8.10 BACKPORT] add more missing custom_documentation fields (#430)

### DIFF
--- a/custom_documentation/endpoint/data_stream/alerts/macos/macos_malicious_behavior_alert.yaml
+++ b/custom_documentation/endpoint/data_stream/alerts/macos/macos_malicious_behavior_alert.yaml
@@ -15,6 +15,10 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Effective_process.entity_id
+  - Effective_process.executable
+  - Effective_process.name
+  - Effective_process.pid
   - Endpoint.policy.applied.artifacts.global.identifiers.name
   - Endpoint.policy.applied.artifacts.global.identifiers.sha256
   - Endpoint.policy.applied.artifacts.global.version

--- a/custom_documentation/endpoint/data_stream/file/macos/macos_file_delete.yaml
+++ b/custom_documentation/endpoint/data_stream/file/macos/macos_file_delete.yaml
@@ -15,6 +15,10 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Effective_process.entity_id
+  - Effective_process.executable
+  - Effective_process.name
+  - Effective_process.pid
   - agent.id
   - agent.type
   - agent.version

--- a/custom_documentation/endpoint/data_stream/file/macos/macos_file_extended_attributes_delete.yaml
+++ b/custom_documentation/endpoint/data_stream/file/macos/macos_file_extended_attributes_delete.yaml
@@ -15,6 +15,10 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Effective_process.entity_id
+  - Effective_process.executable
+  - Effective_process.name
+  - Effective_process.pid
   - agent.id
   - agent.type
   - agent.version

--- a/custom_documentation/endpoint/data_stream/file/macos/macos_file_launch_daemon.yaml
+++ b/custom_documentation/endpoint/data_stream/file/macos/macos_file_launch_daemon.yaml
@@ -15,6 +15,10 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Effective_process.entity_id
+  - Effective_process.executable
+  - Effective_process.name
+  - Effective_process.pid
   - Persistence.args
   - Persistence.keepalive
   - Persistence.name

--- a/custom_documentation/endpoint/data_stream/file/macos/macos_file_modification.yaml
+++ b/custom_documentation/endpoint/data_stream/file/macos/macos_file_modification.yaml
@@ -15,6 +15,10 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Effective_process.entity_id
+  - Effective_process.executable
+  - Effective_process.name
+  - Effective_process.pid
   - agent.id
   - agent.type
   - agent.version

--- a/custom_documentation/endpoint/data_stream/file/macos/macos_file_mount.yaml
+++ b/custom_documentation/endpoint/data_stream/file/macos/macos_file_mount.yaml
@@ -15,6 +15,10 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Effective_process.entity_id
+  - Effective_process.executable
+  - Effective_process.name
+  - Effective_process.pid
   - agent.id
   - agent.type
   - agent.version

--- a/custom_documentation/endpoint/data_stream/file/macos/macos_file_rename.yaml
+++ b/custom_documentation/endpoint/data_stream/file/macos/macos_file_rename.yaml
@@ -15,6 +15,10 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Effective_process.entity_id
+  - Effective_process.executable
+  - Effective_process.name
+  - Effective_process.pid
   - agent.id
   - agent.type
   - agent.version

--- a/custom_documentation/endpoint/data_stream/process/linux/linux_process_fork.yaml
+++ b/custom_documentation/endpoint/data_stream/process/linux/linux_process_fork.yaml
@@ -75,6 +75,7 @@ fields:
   - process.args
   - process.args_count
   - process.command_line
+  - process.end
   - process.entity_id
   - process.entry_leader.args
   - process.entry_leader.args_count
@@ -105,6 +106,7 @@ fields:
   - process.entry_leader.working_directory
   - process.env_vars
   - process.executable
+  - process.exit_code
   - process.group.id
   - process.group.name
   - process.group_leader.args

--- a/package/endpoint/docs/custom_documentation/alerts/macos/macos_malicious_behavior_alert.md
+++ b/package/endpoint/docs/custom_documentation/alerts/macos/macos_malicious_behavior_alert.md
@@ -10,6 +10,10 @@ This alert is generated when a Malicious Behavior alert occurs.
 | Field |
 |---|
 | @timestamp |
+| Effective_process.entity_id |
+| Effective_process.executable |
+| Effective_process.name |
+| Effective_process.pid |
 | Endpoint.policy.applied.artifacts.global.identifiers.name |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.global.version |

--- a/package/endpoint/docs/custom_documentation/file/macos/macos_file_delete.md
+++ b/package/endpoint/docs/custom_documentation/file/macos/macos_file_delete.md
@@ -10,6 +10,10 @@ This event is generated when a file is deleted.
 | Field |
 |---|
 | @timestamp |
+| Effective_process.entity_id |
+| Effective_process.executable |
+| Effective_process.name |
+| Effective_process.pid |
 | agent.id |
 | agent.type |
 | agent.version |

--- a/package/endpoint/docs/custom_documentation/file/macos/macos_file_extended_attributes_delete.md
+++ b/package/endpoint/docs/custom_documentation/file/macos/macos_file_extended_attributes_delete.md
@@ -10,6 +10,10 @@ This event is generated when extended file attributes are deleted.
 | Field |
 |---|
 | @timestamp |
+| Effective_process.entity_id |
+| Effective_process.executable |
+| Effective_process.name |
+| Effective_process.pid |
 | agent.id |
 | agent.type |
 | agent.version |

--- a/package/endpoint/docs/custom_documentation/file/macos/macos_file_launch_daemon.md
+++ b/package/endpoint/docs/custom_documentation/file/macos/macos_file_launch_daemon.md
@@ -10,6 +10,10 @@ This event includes information about a macOS Launch Daemon.
 | Field |
 |---|
 | @timestamp |
+| Effective_process.entity_id |
+| Effective_process.executable |
+| Effective_process.name |
+| Effective_process.pid |
 | Persistence.args |
 | Persistence.keepalive |
 | Persistence.name |

--- a/package/endpoint/docs/custom_documentation/file/macos/macos_file_modification.md
+++ b/package/endpoint/docs/custom_documentation/file/macos/macos_file_modification.md
@@ -10,6 +10,10 @@ This event is generated when a file is modified.
 | Field |
 |---|
 | @timestamp |
+| Effective_process.entity_id |
+| Effective_process.executable |
+| Effective_process.name |
+| Effective_process.pid |
 | agent.id |
 | agent.type |
 | agent.version |

--- a/package/endpoint/docs/custom_documentation/file/macos/macos_file_mount.md
+++ b/package/endpoint/docs/custom_documentation/file/macos/macos_file_mount.md
@@ -10,6 +10,10 @@ This event is generated when a file system is mounted.
 | Field |
 |---|
 | @timestamp |
+| Effective_process.entity_id |
+| Effective_process.executable |
+| Effective_process.name |
+| Effective_process.pid |
 | agent.id |
 | agent.type |
 | agent.version |

--- a/package/endpoint/docs/custom_documentation/file/macos/macos_file_rename.md
+++ b/package/endpoint/docs/custom_documentation/file/macos/macos_file_rename.md
@@ -10,6 +10,10 @@ This event is generated when a file is renamed.
 | Field |
 |---|
 | @timestamp |
+| Effective_process.entity_id |
+| Effective_process.executable |
+| Effective_process.name |
+| Effective_process.pid |
 | agent.id |
 | agent.type |
 | agent.version |

--- a/package/endpoint/docs/custom_documentation/process/linux/linux_process_fork.md
+++ b/package/endpoint/docs/custom_documentation/process/linux/linux_process_fork.md
@@ -70,6 +70,7 @@ This event is generated when a new process is created using `fork()`.
 | process.args |
 | process.args_count |
 | process.command_line |
+| process.end |
 | process.entity_id |
 | process.entry_leader.args |
 | process.entry_leader.args_count |
@@ -100,6 +101,7 @@ This event is generated when a new process is created using `fork()`.
 | process.entry_leader.working_directory |
 | process.env_vars |
 | process.executable |
+| process.exit_code |
 | process.group.id |
 | process.group.name |
 | process.group_leader.args |


### PR DESCRIPTION
```
git cherry-pick 8c8621b
```

Backport https://github.com/elastic/endpoint-package/pull/430 to 8.10.