### PR TITLE
add all custom_documentation from main into 8.10

### DIFF
--- a/custom_documentation/endpoint/data_stream/alerts/windows/windows_malware_alert.yaml
+++ b/custom_documentation/endpoint/data_stream/alerts/windows/windows_malware_alert.yaml
@@ -30,6 +30,7 @@ fields:
   - Responses.action.key.path
   - Responses.action.key.values.actions
   - Responses.action.key.values.name
+  - Responses.action.process.path
   - Responses.action.source.attributes
   - Responses.action.source.path
   - Responses.message

--- a/custom_documentation/endpoint/data_stream/file/windows/windows_file_rename.yaml
+++ b/custom_documentation/endpoint/data_stream/file/windows/windows_file_rename.yaml
@@ -15,6 +15,10 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Effective_process.entity_id
+  - Effective_process.executable
+  - Effective_process.name
+  - Effective_process.pid
   - agent.id
   - agent.type
   - agent.version

--- a/custom_documentation/endpoint/data_stream/metadata/metadata.yaml
+++ b/custom_documentation/endpoint/data_stream/metadata/metadata.yaml
@@ -25,6 +25,7 @@ fields:
   - Endpoint.policy.applied.status
   - Endpoint.policy.applied.version
   - Endpoint.state.isolation
+  - Endpoint.state.tamper_protection
   - Endpoint.status
   - agent.build.original
   - agent.id

--- a/custom_documentation/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/endpoint/data_stream/metrics/metrics.yaml
@@ -40,6 +40,10 @@ fields:
   - Endpoint.metrics.documents_volume.api_events.sources.suppressed_count
   - Endpoint.metrics.documents_volume.api_events.suppressed_bytes
   - Endpoint.metrics.documents_volume.api_events.suppressed_count
+  - Endpoint.metrics.documents_volume.device_events.sent_bytes
+  - Endpoint.metrics.documents_volume.device_events.sent_count
+  - Endpoint.metrics.documents_volume.device_events.suppressed_bytes
+  - Endpoint.metrics.documents_volume.device_events.suppressed_count
   - Endpoint.metrics.documents_volume.diagnostic_alerts.sent_bytes
   - Endpoint.metrics.documents_volume.diagnostic_alerts.sent_count
   - Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_bytes
@@ -121,6 +125,8 @@ fields:
   - Endpoint.metrics.system_impact.registry_events.week_ms
   - Endpoint.metrics.system_impact.threat_intelligence_events.week_idle_ms
   - Endpoint.metrics.system_impact.threat_intelligence_events.week_ms
+  - Endpoint.metrics.system_impact.win32k_events.week_idle_ms
+  - Endpoint.metrics.system_impact.win32k_events.week_ms
   - Endpoint.metrics.threads.cpu.mean
   - Endpoint.metrics.threads.name
   - Endpoint.metrics.uptime.endpoint

--- a/custom_documentation/endpoint/data_stream/policy/policy_response.yaml
+++ b/custom_documentation/endpoint/data_stream/policy/policy_response.yaml
@@ -65,6 +65,7 @@ fields:
   - Endpoint.policy.applied.status
   - Endpoint.policy.applied.version
   - Endpoint.state.isolation
+  - Endpoint.state.tamper_protection
   - agent.build.original
   - agent.id
   - agent.type

--- a/custom_documentation/endpoint/data_stream/process/linux/linux_process_already_running.yaml
+++ b/custom_documentation/endpoint/data_stream/process/linux/linux_process_already_running.yaml
@@ -187,6 +187,8 @@ fields:
   - process.start
   - process.supplemental_groups.id
   - process.supplemental_groups.name
+  - process.thread.capabilities.permitted
+  - process.thread.capabilities.effective
   - process.tty.char_device.major
   - process.tty.char_device.minor
   - process.user.id

--- a/custom_documentation/endpoint/data_stream/process/linux/linux_process_exec.yaml
+++ b/custom_documentation/endpoint/data_stream/process/linux/linux_process_exec.yaml
@@ -191,6 +191,8 @@ fields:
   - process.start
   - process.supplemental_groups.id
   - process.supplemental_groups.name
+  - process.thread.capabilities.permitted
+  - process.thread.capabilities.effective
   - process.tty.char_device.major
   - process.tty.char_device.minor
   - process.user.id

--- a/custom_documentation/endpoint/data_stream/process/linux/linux_process_exit.yaml
+++ b/custom_documentation/endpoint/data_stream/process/linux/linux_process_exit.yaml
@@ -99,6 +99,8 @@ fields:
   - process.entry_leader.start
   - process.entry_leader.supplemental_groups.id
   - process.entry_leader.supplemental_groups.name
+  - process.thread.capabilities.permitted
+  - process.thread.capabilities.effective
   - process.entry_leader.tty.char_device.major
   - process.entry_leader.tty.char_device.minor
   - process.entry_leader.user.id

--- a/custom_documentation/endpoint/data_stream/process/linux/linux_process_fork.yaml
+++ b/custom_documentation/endpoint/data_stream/process/linux/linux_process_fork.yaml
@@ -188,6 +188,8 @@ fields:
   - process.start
   - process.supplemental_groups.id
   - process.supplemental_groups.name
+  - process.thread.capabilities.permitted
+  - process.thread.capabilities.effective
   - process.tty.char_device.major
   - process.tty.char_device.minor
   - process.user.id

--- a/custom_documentation/endpoint/data_stream/process/linux/linux_process_gid_change.yaml
+++ b/custom_documentation/endpoint/data_stream/process/linux/linux_process_gid_change.yaml
@@ -189,6 +189,8 @@ fields:
   - process.start
   - process.supplemental_groups.id
   - process.supplemental_groups.name
+  - process.thread.capabilities.permitted
+  - process.thread.capabilities.effective
   - process.tty.char_device.major
   - process.tty.char_device.minor
   - process.user.id

--- a/custom_documentation/endpoint/data_stream/process/linux/linux_process_session_id_change.yaml
+++ b/custom_documentation/endpoint/data_stream/process/linux/linux_process_session_id_change.yaml
@@ -186,6 +186,8 @@ fields:
   - process.start
   - process.supplemental_groups.id
   - process.supplemental_groups.name
+  - process.thread.capabilities.permitted
+  - process.thread.capabilities.effective
   - process.tty.char_device.major
   - process.tty.char_device.minor
   - process.user.id

--- a/custom_documentation/endpoint/data_stream/process/linux/linux_process_text_output.yaml
+++ b/custom_documentation/endpoint/data_stream/process/linux/linux_process_text_output.yaml
@@ -187,6 +187,8 @@ fields:
   - process.start
   - process.supplemental_groups.id
   - process.supplemental_groups.name
+  - process.thread.capabilities.permitted
+  - process.thread.capabilities.effective
   - process.tty.char_device.major
   - process.tty.char_device.minor
   - process.tty.columns

--- a/custom_documentation/endpoint/data_stream/process/linux/linux_process_uid_change.yaml
+++ b/custom_documentation/endpoint/data_stream/process/linux/linux_process_uid_change.yaml
@@ -190,6 +190,8 @@ fields:
   - process.start
   - process.supplemental_groups.id
   - process.supplemental_groups.name
+  - process.thread.capabilities.permitted
+  - process.thread.capabilities.effective
   - process.tty.char_device.major
   - process.tty.char_device.minor
   - process.user.id

--- a/package/endpoint/docs/custom_documentation/alerts/windows/windows_malware_alert.md
+++ b/package/endpoint/docs/custom_documentation/alerts/windows/windows_malware_alert.md
@@ -25,6 +25,7 @@ This alert is generated when a Malware alert occurs.
 | Responses.action.key.path |
 | Responses.action.key.values.actions |
 | Responses.action.key.values.name |
+| Responses.action.process.path |
 | Responses.action.source.attributes |
 | Responses.action.source.path |
 | Responses.message |

--- a/package/endpoint/docs/custom_documentation/file/windows/windows_file_rename.md
+++ b/package/endpoint/docs/custom_documentation/file/windows/windows_file_rename.md
@@ -10,6 +10,10 @@ This event is generated when a file is renamed.
 | Field |
 |---|
 | @timestamp |
+| Effective_process.entity_id |
+| Effective_process.executable |
+| Effective_process.name |
+| Effective_process.pid |
 | agent.id |
 | agent.type |
 | agent.version |

--- a/package/endpoint/docs/custom_documentation/metadata/metadata.md
+++ b/package/endpoint/docs/custom_documentation/metadata/metadata.md
@@ -18,6 +18,7 @@ This is a relatively small state management document that includes details about
 | Endpoint.policy.applied.status |
 | Endpoint.policy.applied.version |
 | Endpoint.state.isolation |
+| Endpoint.state.tamper_protection |
 | Endpoint.status |
 | agent.build.original |
 | agent.id |

--- a/package/endpoint/docs/custom_documentation/metrics/metrics.md
+++ b/package/endpoint/docs/custom_documentation/metrics/metrics.md
@@ -33,6 +33,10 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.documents_volume.api_events.sources.suppressed_count |
 | Endpoint.metrics.documents_volume.api_events.suppressed_bytes |
 | Endpoint.metrics.documents_volume.api_events.suppressed_count |
+| Endpoint.metrics.documents_volume.device_events.sent_bytes |
+| Endpoint.metrics.documents_volume.device_events.sent_count |
+| Endpoint.metrics.documents_volume.device_events.suppressed_bytes |
+| Endpoint.metrics.documents_volume.device_events.suppressed_count |
 | Endpoint.metrics.documents_volume.diagnostic_alerts.sent_bytes |
 | Endpoint.metrics.documents_volume.diagnostic_alerts.sent_count |
 | Endpoint.metrics.documents_volume.diagnostic_alerts.suppressed_bytes |
@@ -114,6 +118,8 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.system_impact.registry_events.week_ms |
 | Endpoint.metrics.system_impact.threat_intelligence_events.week_idle_ms |
 | Endpoint.metrics.system_impact.threat_intelligence_events.week_ms |
+| Endpoint.metrics.system_impact.win32k_events.week_idle_ms |
+| Endpoint.metrics.system_impact.win32k_events.week_ms |
 | Endpoint.metrics.threads.cpu.mean |
 | Endpoint.metrics.threads.name |
 | Endpoint.metrics.uptime.endpoint |

--- a/package/endpoint/docs/custom_documentation/policy/policy_response.md
+++ b/package/endpoint/docs/custom_documentation/policy/policy_response.md
@@ -57,6 +57,7 @@ This is a state management document that is generated every time Endpoint refres
 | Endpoint.policy.applied.status |
 | Endpoint.policy.applied.version |
 | Endpoint.state.isolation |
+| Endpoint.state.tamper_protection |
 | agent.build.original |
 | agent.id |
 | agent.type |

--- a/package/endpoint/docs/custom_documentation/process/linux/linux_process_already_running.md
+++ b/package/endpoint/docs/custom_documentation/process/linux/linux_process_already_running.md
@@ -181,6 +181,8 @@ This event is generated for a process that was already running before Endpoint's
 | process.start |
 | process.supplemental_groups.id |
 | process.supplemental_groups.name |
+| process.thread.capabilities.permitted |
+| process.thread.capabilities.effective |
 | process.tty.char_device.major |
 | process.tty.char_device.minor |
 | process.user.id |

--- a/package/endpoint/docs/custom_documentation/process/linux/linux_process_exec.md
+++ b/package/endpoint/docs/custom_documentation/process/linux/linux_process_exec.md
@@ -186,6 +186,8 @@ This event is generated when a process calls `exec()`.
 | process.start |
 | process.supplemental_groups.id |
 | process.supplemental_groups.name |
+| process.thread.capabilities.permitted |
+| process.thread.capabilities.effective |
 | process.tty.char_device.major |
 | process.tty.char_device.minor |
 | process.user.id |

--- a/package/endpoint/docs/custom_documentation/process/linux/linux_process_exit.md
+++ b/package/endpoint/docs/custom_documentation/process/linux/linux_process_exit.md
@@ -94,6 +94,8 @@ This event is generated when a process exits.
 | process.entry_leader.start |
 | process.entry_leader.supplemental_groups.id |
 | process.entry_leader.supplemental_groups.name |
+| process.thread.capabilities.permitted |
+| process.thread.capabilities.effective |
 | process.entry_leader.tty.char_device.major |
 | process.entry_leader.tty.char_device.minor |
 | process.entry_leader.user.id |

--- a/package/endpoint/docs/custom_documentation/process/linux/linux_process_fork.md
+++ b/package/endpoint/docs/custom_documentation/process/linux/linux_process_fork.md
@@ -183,6 +183,8 @@ This event is generated when a new process is created using `fork()`.
 | process.start |
 | process.supplemental_groups.id |
 | process.supplemental_groups.name |
+| process.thread.capabilities.permitted |
+| process.thread.capabilities.effective |
 | process.tty.char_device.major |
 | process.tty.char_device.minor |
 | process.user.id |

--- a/package/endpoint/docs/custom_documentation/process/linux/linux_process_gid_change.md
+++ b/package/endpoint/docs/custom_documentation/process/linux/linux_process_gid_change.md
@@ -184,6 +184,8 @@ This event is generated when the group id changes for a process.
 | process.start |
 | process.supplemental_groups.id |
 | process.supplemental_groups.name |
+| process.thread.capabilities.permitted |
+| process.thread.capabilities.effective |
 | process.tty.char_device.major |
 | process.tty.char_device.minor |
 | process.user.id |

--- a/package/endpoint/docs/custom_documentation/process/linux/linux_process_session_id_change.md
+++ b/package/endpoint/docs/custom_documentation/process/linux/linux_process_session_id_change.md
@@ -181,6 +181,8 @@ This event is generated when a process's session id changes.
 | process.start |
 | process.supplemental_groups.id |
 | process.supplemental_groups.name |
+| process.thread.capabilities.permitted |
+| process.thread.capabilities.effective |
 | process.tty.char_device.major |
 | process.tty.char_device.minor |
 | process.user.id |

--- a/package/endpoint/docs/custom_documentation/process/linux/linux_process_text_output.md
+++ b/package/endpoint/docs/custom_documentation/process/linux/linux_process_text_output.md
@@ -182,6 +182,8 @@ This event is generated when a process generates text output.
 | process.start |
 | process.supplemental_groups.id |
 | process.supplemental_groups.name |
+| process.thread.capabilities.permitted |
+| process.thread.capabilities.effective |
 | process.tty.char_device.major |
 | process.tty.char_device.minor |
 | process.tty.columns |

--- a/package/endpoint/docs/custom_documentation/process/linux/linux_process_uid_change.md
+++ b/package/endpoint/docs/custom_documentation/process/linux/linux_process_uid_change.md
@@ -185,6 +185,8 @@ This event is generated when the user id changes for a process.
 | process.start |
 | process.supplemental_groups.id |
 | process.supplemental_groups.name |
+| process.thread.capabilities.permitted |
+| process.thread.capabilities.effective |
 | process.tty.char_device.major |
 | process.tty.char_device.minor |
 | process.user.id |


### PR DESCRIPTION
This pulls all `custom_documentation/` from `main` into `8.10`. I did the below steps

```
git checkout main
cp -r custom_documentation/src /tmp/backup
git checkout 8.10
git checkout -b add-all-custom-doc-from-main-to-8.10
rm -rf custom_documentation/endpoint
cp -r /tmp/backup/endpoint custom_documentation/endpoint
make clean all
git add custom_documentation package
git commit
```