### PR TITLE
artifacts manifest update age, snapshot date

### DIFF
--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -341,6 +341,11 @@
       type: unsigned_long
       description: number of days since global artifacts were made up-to-date
 
+    - name: policy.applied.artifacts.global.snapshot
+      level: custom
+      type: keyword
+      description: the snapshot date of applied global artifacts or 'latest'
+
     - name: policy.applied.artifacts.global.version
       level: custom
       type: keyword

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -336,6 +336,11 @@
       type: object
       description: information about global protection artifacts applied.
 
+    - name: policy.applied.artifacts.global.update_age
+      level: custom
+      type: unsigned_long
+      description: number of days since global artifacts were made up-to-date
+
     - name: policy.applied.artifacts.global.version
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -70,6 +70,11 @@
       ignore_above: 1024
       description: the sha256 of global artifacts applied.
       default_field: false
+    - name: policy.applied.artifacts.global.update_age
+      level: custom
+      type: unsigned_long
+      description: number of days since global artifacts were made up-to-date
+      default_field: false
     - name: policy.applied.artifacts.global.version
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -70,6 +70,12 @@
       ignore_above: 1024
       description: the sha256 of global artifacts applied.
       default_field: false
+    - name: policy.applied.artifacts.global.snapshot
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: the snapshot date of applied global artifacts or 'latest'
+      default_field: false
     - name: policy.applied.artifacts.global.update_age
       level: custom
       type: unsigned_long

--- a/package/endpoint/data_stream/alerts/sample_event.json
+++ b/package/endpoint/data_stream/alerts/sample_event.json
@@ -474,6 +474,7 @@
                                 "name": "endpoint-trustlist-windows-v1"
                             }
                         ],
+                        "update_age": 0,
                         "version": "1.0.0"
                     }
                 }

--- a/package/endpoint/data_stream/alerts/sample_event.json
+++ b/package/endpoint/data_stream/alerts/sample_event.json
@@ -475,6 +475,7 @@
                             }
                         ],
                         "update_age": 0,
+                        "snapshot": "2023-09-26",
                         "version": "1.0.0"
                     }
                 }

--- a/package/endpoint/data_stream/alerts/sample_event.json
+++ b/package/endpoint/data_stream/alerts/sample_event.json
@@ -449,6 +449,8 @@
                                 "name": "production-rules-windows-v1"
                             }
                         ],
+                        "update_age": 0,
+                        "snapshot": "2023-09-26",
                         "version": "1.0.260"
                     },
                     "user": {
@@ -474,8 +476,6 @@
                                 "name": "endpoint-trustlist-windows-v1"
                             }
                         ],
-                        "update_age": 0,
-                        "snapshot": "2023-09-26",
                         "version": "1.0.0"
                     }
                 }

--- a/package/endpoint/data_stream/policy/fields/fields.yml
+++ b/package/endpoint/data_stream/policy/fields/fields.yml
@@ -100,6 +100,11 @@
       ignore_above: 1024
       description: the sha256 of global artifacts applied.
       default_field: false
+    - name: policy.applied.artifacts.global.update_age
+      level: custom
+      type: unsigned_long
+      description: number of days since global artifacts were made up-to-date
+      default_field: false
     - name: policy.applied.artifacts.global.version
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/policy/fields/fields.yml
+++ b/package/endpoint/data_stream/policy/fields/fields.yml
@@ -100,6 +100,12 @@
       ignore_above: 1024
       description: the sha256 of global artifacts applied.
       default_field: false
+    - name: policy.applied.artifacts.global.snapshot
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: the snapshot date of applied global artifacts or 'latest'
+      default_field: false
     - name: policy.applied.artifacts.global.update_age
       level: custom
       type: unsigned_long

--- a/package/endpoint/data_stream/policy/sample_event.json
+++ b/package/endpoint/data_stream/policy/sample_event.json
@@ -525,6 +525,7 @@
                                 "name": "production-rules-windows-v1"
                             }
                         ],
+                        "update_age": 0,
                         "version": "1.0.261"
                     },
                     "user": {

--- a/package/endpoint/data_stream/policy/sample_event.json
+++ b/package/endpoint/data_stream/policy/sample_event.json
@@ -526,6 +526,7 @@
                             }
                         ],
                         "update_age": 0,
+                        "snapshot": "2023-09-26",
                         "version": "1.0.261"
                     },
                     "user": {

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -83,6 +83,15 @@ Endpoint.policy.applied.artifacts.global.identifiers.sha256:
   normalize: []
   short: the sha256 of global artifacts applied.
   type: keyword
+Endpoint.policy.applied.artifacts.global.update_age:
+  dashed_name: Endpoint-policy-applied-artifacts-global-update-age
+  description: number of days since global artifacts were made up-to-date
+  flat_name: Endpoint.policy.applied.artifacts.global.update_age
+  level: custom
+  name: policy.applied.artifacts.global.update_age
+  normalize: []
+  short: number of days since global artifacts were made up-to-date
+  type: unsigned_long
 Endpoint.policy.applied.artifacts.global.version:
   dashed_name: Endpoint-policy-applied-artifacts-global-version
   description: the version of global artifacts applied.

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -83,6 +83,16 @@ Endpoint.policy.applied.artifacts.global.identifiers.sha256:
   normalize: []
   short: the sha256 of global artifacts applied.
   type: keyword
+Endpoint.policy.applied.artifacts.global.snapshot:
+  dashed_name: Endpoint-policy-applied-artifacts-global-snapshot
+  description: the snapshot date of applied global artifacts or 'latest'
+  flat_name: Endpoint.policy.applied.artifacts.global.snapshot
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.artifacts.global.snapshot
+  normalize: []
+  short: the snapshot date of applied global artifacts or 'latest'
+  type: keyword
 Endpoint.policy.applied.artifacts.global.update_age:
   dashed_name: Endpoint-policy-applied-artifacts-global-update-age
   description: number of days since global artifacts were made up-to-date

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -83,6 +83,15 @@ Endpoint.policy.applied.artifacts.global.identifiers.sha256:
   normalize: []
   short: the sha256 of global artifacts applied.
   type: keyword
+Endpoint.policy.applied.artifacts.global.update_age:
+  dashed_name: Endpoint-policy-applied-artifacts-global-update-age
+  description: number of days since global artifacts were made up-to-date
+  flat_name: Endpoint.policy.applied.artifacts.global.update_age
+  level: custom
+  name: policy.applied.artifacts.global.update_age
+  normalize: []
+  short: number of days since global artifacts were made up-to-date
+  type: unsigned_long
 Endpoint.policy.applied.artifacts.global.version:
   dashed_name: Endpoint-policy-applied-artifacts-global-version
   description: the version of global artifacts applied.

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -83,6 +83,16 @@ Endpoint.policy.applied.artifacts.global.identifiers.sha256:
   normalize: []
   short: the sha256 of global artifacts applied.
   type: keyword
+Endpoint.policy.applied.artifacts.global.snapshot:
+  dashed_name: Endpoint-policy-applied-artifacts-global-snapshot
+  description: the snapshot date of applied global artifacts or 'latest'
+  flat_name: Endpoint.policy.applied.artifacts.global.snapshot
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.artifacts.global.snapshot
+  normalize: []
+  short: the snapshot date of applied global artifacts or 'latest'
+  type: keyword
 Endpoint.policy.applied.artifacts.global.update_age:
   dashed_name: Endpoint-policy-applied-artifacts-global-update-age
   description: number of days since global artifacts were made up-to-date

--- a/schemas/v1/alerts/ransomware_event.yaml
+++ b/schemas/v1/alerts/ransomware_event.yaml
@@ -83,6 +83,15 @@ Endpoint.policy.applied.artifacts.global.identifiers.sha256:
   normalize: []
   short: the sha256 of global artifacts applied.
   type: keyword
+Endpoint.policy.applied.artifacts.global.update_age:
+  dashed_name: Endpoint-policy-applied-artifacts-global-update-age
+  description: number of days since global artifacts were made up-to-date
+  flat_name: Endpoint.policy.applied.artifacts.global.update_age
+  level: custom
+  name: policy.applied.artifacts.global.update_age
+  normalize: []
+  short: number of days since global artifacts were made up-to-date
+  type: unsigned_long
 Endpoint.policy.applied.artifacts.global.version:
   dashed_name: Endpoint-policy-applied-artifacts-global-version
   description: the version of global artifacts applied.

--- a/schemas/v1/alerts/ransomware_event.yaml
+++ b/schemas/v1/alerts/ransomware_event.yaml
@@ -83,6 +83,16 @@ Endpoint.policy.applied.artifacts.global.identifiers.sha256:
   normalize: []
   short: the sha256 of global artifacts applied.
   type: keyword
+Endpoint.policy.applied.artifacts.global.snapshot:
+  dashed_name: Endpoint-policy-applied-artifacts-global-snapshot
+  description: the snapshot date of applied global artifacts or 'latest'
+  flat_name: Endpoint.policy.applied.artifacts.global.snapshot
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.artifacts.global.snapshot
+  normalize: []
+  short: the snapshot date of applied global artifacts or 'latest'
+  type: keyword
 Endpoint.policy.applied.artifacts.global.update_age:
   dashed_name: Endpoint-policy-applied-artifacts-global-update-age
   description: number of days since global artifacts were made up-to-date

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -147,6 +147,16 @@ Endpoint.policy.applied.artifacts.global.identifiers.sha256:
   normalize: []
   short: the sha256 of global artifacts applied.
   type: keyword
+Endpoint.policy.applied.artifacts.global.snapshot:
+  dashed_name: Endpoint-policy-applied-artifacts-global-snapshot
+  description: the snapshot date of applied global artifacts or 'latest'
+  flat_name: Endpoint.policy.applied.artifacts.global.snapshot
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.artifacts.global.snapshot
+  normalize: []
+  short: the snapshot date of applied global artifacts or 'latest'
+  type: keyword
 Endpoint.policy.applied.artifacts.global.update_age:
   dashed_name: Endpoint-policy-applied-artifacts-global-update-age
   description: number of days since global artifacts were made up-to-date

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -147,6 +147,15 @@ Endpoint.policy.applied.artifacts.global.identifiers.sha256:
   normalize: []
   short: the sha256 of global artifacts applied.
   type: keyword
+Endpoint.policy.applied.artifacts.global.update_age:
+  dashed_name: Endpoint-policy-applied-artifacts-global-update-age
+  description: number of days since global artifacts were made up-to-date
+  flat_name: Endpoint.policy.applied.artifacts.global.update_age
+  level: custom
+  name: policy.applied.artifacts.global.update_age
+  normalize: []
+  short: number of days since global artifacts were made up-to-date
+  type: unsigned_long
 Endpoint.policy.applied.artifacts.global.version:
   dashed_name: Endpoint-policy-applied-artifacts-global-version
   description: the version of global artifacts applied.


### PR DESCRIPTION
## Change Summary

Add artifact snapshot date indicator. When artifacts are not pinned to any specific snapshot date the keyword 'latest' is used.

Add artifact up-to-date age indicator. It's equal to number of days since the local artifacts copy at Endpoint side was last time deemed up-to-date (the date when either Endpoint updated the artifacts or verified that it's artifacts are up-to-date with Elastic CDN).

Note, when artifacts are pinned to a specific snapshot date, the age always equal to the numbers of days since that date. In addition the initial artifacts shipped with the installation package age is equal to the number of days since the package creation date (endpoint build date).

### Sample values

Artifacts made or verified to be up-to-date today:
`"Endpoint.policy.applied.artifacts.global.update_age": 0`
Artifacts 50 days old
`"Endpoint.policy.applied.artifacts.global.update_age": 50`

Artifacts pinned to `2023-09-26` snapshot date:
`"Endpoint.policy.applied.artifacts.global.snapshot": "2023-09-26"`

Artifacts not pinned to any snapshot date:
`"Endpoint.policy.applied.artifacts.global.snapshot": "latest"`

Sample document:

Endpoint altert and Endpoint policy response:

```json
{
    "Endpoint": {
        "policy": {
            "applied": {
                "artifacts": {
                    "global": {
                        "update_age": 0,
                        "snapshot": "latest",
                    },
}

```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
