### PR TITLE
Reformat metadata yaml, removed dotted-keys

### DIFF
--- a/package/endpoint/data_stream/metadata/manifest.yml
+++ b/package/endpoint/data_stream/metadata/manifest.yml
@@ -6,9 +6,10 @@ elasticsearch:
       dynamic: false
     settings:
       index:
-        sort.field:
-          - "@timestamp"
-          - agent.id
-        sort.order:
-          - desc
-          - asc
+        sort:
+          field:
+            - "@timestamp"
+            - agent.id
+          order:
+            - desc
+            - asc


### PR DESCRIPTION
## Change Summary

A change in yaml formatting, removing `key1.key2` dotted-key style, and changing to the verbose version

this is a required formatting enforced by package-spec 3.0


## Release Target

8.12


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [x] If this is a `metadata` change, I also updated both transform destination schemas to match


