### PR TITLE
object_type: keyword

### DIFF
--- a/custom_schemas/custom_api.yml
+++ b/custom_schemas/custom_api.yml
@@ -4,6 +4,7 @@
   group: 2
   short: Fields describing an API call.
   type: object
+  object_type: keyword
   description: >
     These fields describe an API call (function, or system call).
 
@@ -61,6 +62,7 @@
     - name: metadata
       level: custom
       type: object
+      object_type: keyword
       description: >
         Information related to the API call.
 
@@ -81,6 +83,7 @@
     - name: parameters
       level: custom
       type: object
+      object_type: keyword
       description: >
         Parameter values passed to the API call.
 

--- a/custom_schemas/custom_base.yml
+++ b/custom_schemas/custom_base.yml
@@ -11,6 +11,7 @@
   fields:
     - name: Events
       type: object
+      object_type: keyword
       level: custom
       short: events array
       description: >

--- a/custom_schemas/custom_call_stack.yml
+++ b/custom_schemas/custom_call_stack.yml
@@ -4,6 +4,7 @@
   group: 3
   short: Fields describing a stack frame.
   type: object
+  object_type: keyword
   description: >
     Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame.
   reusable:

--- a/custom_schemas/custom_dll.yml
+++ b/custom_schemas/custom_dll.yml
@@ -20,6 +20,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
 
     - name: Ext.mapped_address

--- a/custom_schemas/custom_dns.yml
+++ b/custom_schemas/custom_dns.yml
@@ -15,6 +15,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
 
     - name: Ext.status

--- a/custom_schemas/custom_elastic.yml
+++ b/custom_schemas/custom_elastic.yml
@@ -11,6 +11,7 @@
     - name: agent
       level: custom
       type: object
+      object_type: keyword
       description: >
         The agent fields contain data about the Elastic Agent. The Elastic Agent is the management agent
         that manages other agents or process on the host.

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -15,11 +15,13 @@
     - name: policy
       level: custom
       type: object
+      object_type: keyword
       description: The policy fields are used to hold information about applied policy.
 
     - name: policy.applied
       level: custom
       type: object
+      object_type: keyword
       description: information about the policy that is applied
 
     - name: policy.applied.actions
@@ -71,18 +73,21 @@
     - name: policy.applied.response
       level: custom
       type: object
+      object_type: keyword
       enabled: false
       description: the response of actions that failed in the applied policy
 
     - name: policy.applied.response.configurations
       level: custom
       type: object
+      object_type: keyword
       enabled: false
       description: the configurations of the applied policy
 
     - name: policy.applied.response.configurations.events
       level: custom
       type: object
+      object_type: keyword
       description: overall event collection configuration and status of the applied policy
 
     - name: policy.applied.response.configurations.events.concerned_actions
@@ -101,6 +106,7 @@
     - name: policy.applied.response.configurations.logging
       level: custom
       type: object
+      object_type: keyword
       description: overall logging configuration and status of the applied policy
 
     - name: policy.applied.response.configurations.logging.concerned_actions
@@ -119,6 +125,7 @@
     - name: policy.applied.response.configurations.antivirus_registration
       level: custom
       type: object
+      object_type: keyword
       enabled: false
       description: overall antivirus registration configuration and status of the applied policy
 
@@ -138,6 +145,7 @@
     - name: policy.applied.response.configurations.malware
       level: custom
       type: object
+      object_type: keyword
       description: overall malware configuration and status of the applied policy
 
     - name: policy.applied.response.configurations.malware.concerned_actions
@@ -156,6 +164,7 @@
     - name: policy.applied.response.configurations.memory_protection
       level: custom
       type: object
+      object_type: keyword
       description: overall memory_protection configuration and status of the applied policy
 
     - name: policy.applied.response.configurations.memory_protection.concerned_actions
@@ -174,6 +183,7 @@
     - name: policy.applied.response.configurations.streaming
       level: custom
       type: object
+      object_type: keyword
       description: overall data streaming configuration and status of the applied policy
 
     - name: policy.applied.response.configurations.streaming.concerned_actions
@@ -244,6 +254,7 @@
     - name: policy.applied.response.diagnostic
       level: custom
       type: object
+      object_type: keyword
       enabled: false
       description: the diagnostic configurations of the applied policy
 
@@ -328,12 +339,14 @@
     - name: policy.applied.artifacts
       level: custom
       type: object
+      object_type: keyword
       enabled: false
       description: information about protection artifacts applied.
 
     - name: policy.applied.artifacts.global
       level: custom
       type: object
+      object_type: keyword
       description: information about global protection artifacts applied.
 
     - name: policy.applied.artifacts.global.version
@@ -359,6 +372,7 @@
     - name: policy.applied.artifacts.user
       level: custom
       type: object
+      object_type: keyword
       description: information about user protection artifacts applied.
 
     - name: policy.applied.artifacts.user.version
@@ -384,11 +398,13 @@
     - name: metrics
       level: custom
       type: object
+      object_type: keyword
       description: Metrics fields hold the endpoint and system's performance metrics
 
     - name: metrics.documents_volume
       level: custom
       type: object
+      object_type: keyword
       description: Statistics about sent documents
 
     - name: metrics.documents_volume.overall
@@ -619,6 +635,7 @@
     - name: metrics.documents_volume.api_events.sources
       level: custom
       type: object
+      object_type: keyword
       description: An array of API Event document statistics per source
 
     - name: metrics.documents_volume.api_events.sources.source
@@ -649,6 +666,7 @@
     - name: metrics.uptime
       level: custom
       type: object
+      object_type: keyword
       description: Number of seconds since boot
 
     - name: metrics.uptime.endpoint
@@ -664,11 +682,13 @@
     - name: metrics.cpu
       level: custom
       type: object
+      object_type: keyword
       description: CPU statistics
 
     - name: metrics.cpu.endpoint
       level: custom
       type: object
+      object_type: keyword
       description: CPU metrics for the endpoint
 
     - name: metrics.cpu.endpoint.mean
@@ -693,16 +713,19 @@
     - name: metrics.memory
       level: custom
       type: object
+      object_type: keyword
       description: Memory statistics
 
     - name: metrics.memory.endpoint
       level: custom
       type: object
+      object_type: keyword
       description: Endpoint memory utilization
 
     - name: metrics.memory.endpoint.private
       level: custom
       type: object
+      object_type: keyword
       description: The memory private to the endpoint
 
     - name: metrics.memory.endpoint.private.mean
@@ -718,6 +741,7 @@
     - name: metrics.disks
       level: custom
       type: object
+      object_type: keyword
       enabled: false
       description: An array of disk information for the host
 
@@ -766,6 +790,7 @@
     - name: metrics.malicious_behavior_rules
       level: custom
       type: object
+      object_type: keyword
       enabled: false
       description: An array of performance information about each malicious behavior rule
 
@@ -784,6 +809,7 @@
     - name: metrics.system_impact
       level: custom
       type: object
+      object_type: keyword
       enabled: false
       index: false
       description: An array of system impact information
@@ -1011,6 +1037,7 @@
       # using an object here even though it is actually an array because you can only have a limited number
       # of nested fields
       type: object
+      object_type: keyword
       enabled: false
       description: Statistics about the individual Endpoint threads (array)
 
@@ -1029,6 +1056,7 @@
     - name: configuration
       level: custom
       type: object
+      object_type: keyword
       description:
         Configuration fields represent the intended and applied setting for fields not part of a Policy setting
         This reflects what a given field is configured to do. The actual state of that same field is found in Endpoint.state
@@ -1041,6 +1069,7 @@
     - name: state
       level: custom
       type: object
+      object_type: keyword
       description:
         Represents the current state of a non-policy setting
         These fields reflect the current status of a field, which may differ from what it is configured to be (see Endpoint.configuration)

--- a/custom_schemas/custom_endpoint_actions.yml
+++ b/custom_schemas/custom_endpoint_actions.yml
@@ -33,6 +33,7 @@
       type: object
       level: custom
       short: data
+      object_type: keyword
       description: >
         The action request information
 

--- a/custom_schemas/custom_event.yml
+++ b/custom_schemas/custom_event.yml
@@ -21,11 +21,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
 
     - name: Ext.correlation
       level: custom
       type: object
+      object_type: keyword
       description: Information about event this should be correlated with.
     
     - name: Ext.correlation.id

--- a/custom_schemas/custom_file.yml
+++ b/custom_schemas/custom_file.yml
@@ -30,6 +30,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
 
     - name: Ext.entry_modified
@@ -65,6 +66,7 @@
     - name: Ext.windows
       level: custom
       type: object
+      object_type: keyword
       description: Platform-specific Windows fields
 
     - name: Ext.windows.zone_identifier
@@ -76,6 +78,7 @@
     - name: Ext.original
       level: custom
       type: object
+      object_type: keyword
       description: Original file information during a modification event.
 
     - name: Ext.original.name
@@ -423,4 +426,5 @@
     - name: pe
       level: custom
       type: object
+      object_type: keyword
       description: PE fields

--- a/custom_schemas/custom_group.yml
+++ b/custom_schemas/custom_group.yml
@@ -39,11 +39,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
 
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
 
     - name: Ext.real.id

--- a/custom_schemas/custom_http.yml
+++ b/custom_schemas/custom_http.yml
@@ -10,6 +10,7 @@
     - name: response.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
 
     - name: response.Ext.version

--- a/custom_schemas/custom_macro.yml
+++ b/custom_schemas/custom_macro.yml
@@ -32,12 +32,14 @@
     - name: collection
       level: custom
       type: object
+      object_type: keyword
       description: >
         Object containing hashes for the macro collection.
 
     - name: project_file
       level: custom
       type: object
+      object_type: keyword
       description: >
         Metadata about the corresponding VBA project file
 

--- a/custom_schemas/custom_malware_classification.yml
+++ b/custom_schemas/custom_malware_classification.yml
@@ -38,6 +38,14 @@
       description: >
         The version of the model used.
 
+    - name: features
+      level: custom
+      type: object
+      object_type: keyword
+      enabled: false
+      description: >
+        The features extracted from this file and evaluated by the model.
+
     - name: features.data.buffer
       level: custom
       type: keyword

--- a/custom_schemas/custom_malware_signature.yml
+++ b/custom_schemas/custom_malware_signature.yml
@@ -32,6 +32,7 @@
     - name: primary
       level: custom
       type: object
+      object_type: keyword
       description: The first matching details.
 
     - name: primary.matches

--- a/custom_schemas/custom_os.yml
+++ b/custom_schemas/custom_os.yml
@@ -30,6 +30,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
 
     # this is temporary until variant is included in ecs core https://github.com/elastic/ecs/issues/744

--- a/custom_schemas/custom_pe.yml
+++ b/custom_schemas/custom_pe.yml
@@ -21,6 +21,7 @@
     - name: Ext.sections
       level: custom
       type: object
+      object_type: keyword
       short: The file's sections, if it is a PE
       description: >
         The file's relevant sections, if it is a PE
@@ -35,12 +36,14 @@
     - name: Ext.sections.hash
       level: custom
       type: object
+      object_type: keyword
       description: >
         Hashes
         
     - name: Ext.streams
       level: custom
       type: object
+      object_type: keyword
       short: The file's streams, if it is a PE
       description: >
         The file's streams, if it is a PE
@@ -55,5 +58,6 @@
     - name: Ext.streams.hash
       level: custom
       type: object
+      object_type: keyword
       description: >
         Hashes

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -58,11 +58,13 @@
     - name: parent.thread
       level: custom
       type: object
+      object_type: keyword
       description: The parent thread
 
     - name: parent.thread.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields for the parent thread to live in.
 
     - name: parent.ppid
@@ -76,6 +78,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
 
     - name: Ext.ancestry
@@ -104,6 +107,7 @@
     - name: thread.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
 
     - name: thread.Ext.call_stack_contains_unbacked
@@ -121,6 +125,7 @@
     - name: thread.Ext.call_stack
       level: custom
       type: object
+      object_type: keyword
       description: The thread's call stack
 
     - name: thread.Ext.call_stack_final_user_module
@@ -202,6 +207,7 @@
     - name: thread.Ext.call_stack_final_user_module.hash
       level: custom
       type: object
+      object_type: keyword
       description: Hashes of the call_stack_final_user_module.
 
     - name: thread.Ext.call_stack_final_user_module.hash.sha256
@@ -271,6 +277,7 @@
     - name: thread.Ext.start_address_details
       level: custom
       type: object
+      object_type: keyword
       description: >
         Additional information about the memory containing the thread start address.
 
@@ -319,6 +326,7 @@
     - name: thread.Ext.start_address_details
       level: custom
       type: object
+      object_type: keyword
       description: >
         Additional information about the memory containing the thread start address.
 
@@ -426,6 +434,7 @@
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: >
         The field set containing process info in case of any pid spoofing. This is mainly useful for process.parent.
 
@@ -663,6 +672,7 @@
     - name: tty
       level: extended
       type: object
+      object_type: keyword
       short: Information about the controlling TTY device.
       description: >
         Information about the controlling TTY device. If set, the process belongs to an interactive session.
@@ -708,6 +718,7 @@
     - name: io
       level: extended
       type: object
+      object_type: keyword
       beta: This field is beta and subject to change.
       short: A chunk of input or output (IO) from a single process.
       description: >
@@ -760,6 +771,7 @@
     - name: io.bytes_skipped
       level: extended
       type: object
+      object_type: keyword
       beta: This field is beta and subject to change.
       description: >
         An array of byte offsets and lengths denoting where IO data has been skipped.

--- a/custom_schemas/custom_responses.yml
+++ b/custom_schemas/custom_responses.yml
@@ -79,6 +79,7 @@
     - name: action.key.values
       level: custom
       type: object
+      object_type: keyword
       description: Values modified
 
     - name: action.key.values.name

--- a/custom_schemas/custom_target.yml
+++ b/custom_schemas/custom_target.yml
@@ -15,11 +15,13 @@
     - name: process
       level: custom
       type: object
+      object_type: keyword
       description: >
         Process.
 
     - name: dll
       level: custom
       type: object
+      object_type: keyword
       description: >
         Dll core fieldset reused here.

--- a/custom_schemas/custom_user.yml
+++ b/custom_schemas/custom_user.yml
@@ -24,17 +24,20 @@
     - name: group
       level: extended
       type: object
+      object_type: keyword
       description: 'The group fields are meant to represent groups that are
         relevant to the event.'
 
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
 
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: User info prior to any setuid operations.
 
     - name: Ext.real.id

--- a/package/endpoint/data_stream/action_responses/fields/fields.yml
+++ b/package/endpoint/data_stream/action_responses/fields/fields.yml
@@ -72,6 +72,7 @@
     - name: data
       level: custom
       type: object
+      object_type: keyword
       description: The action request information
       default_field: false
     - name: data.alert_id

--- a/package/endpoint/data_stream/actions/fields/fields.yml
+++ b/package/endpoint/data_stream/actions/fields/fields.yml
@@ -72,6 +72,7 @@
     - name: data
       level: custom
       type: object
+      object_type: keyword
       description: The action request information
       default_field: false
     - name: data.alert_id

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -14,6 +14,7 @@
 - name: Events
   level: custom
   type: object
+  object_type: keyword
   description: events array
 - name: message
   level: core
@@ -35,22 +36,26 @@
     - name: policy
       level: custom
       type: object
+      object_type: keyword
       description: The policy fields are used to hold information about applied policy.
       default_field: false
     - name: policy.applied
       level: custom
       type: object
+      object_type: keyword
       description: information about the policy that is applied
       default_field: false
     - name: policy.applied.artifacts
       level: custom
       type: object
+      object_type: keyword
       description: information about protection artifacts applied.
       enabled: false
       default_field: false
     - name: policy.applied.artifacts.global
       level: custom
       type: object
+      object_type: keyword
       description: information about global protection artifacts applied.
       default_field: false
     - name: policy.applied.artifacts.global.identifiers
@@ -79,6 +84,7 @@
     - name: policy.applied.artifacts.user
       level: custom
       type: object
+      object_type: keyword
       description: information about user protection artifacts applied.
       default_field: false
     - name: policy.applied.artifacts.user.identifiers
@@ -420,6 +426,7 @@
     - name: action.key.values
       level: custom
       type: object
+      object_type: keyword
       description: Values modified
       default_field: false
     - name: action.key.values.actions
@@ -516,6 +523,7 @@
     - name: dll.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: dll.Ext.code_signature
@@ -769,6 +777,7 @@
     - name: process.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: process.Ext.ancestry
@@ -836,6 +845,7 @@
     - name: process.Ext.dll.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: process.Ext.dll.Ext.code_signature
@@ -1154,6 +1164,7 @@
     - name: process.Ext.memory_region.malware_signature.primary
       level: custom
       type: object
+      object_type: keyword
       description: The first matching details.
       default_field: false
     - name: process.Ext.memory_region.malware_signature.primary.matches
@@ -1604,6 +1615,7 @@
     - name: process.parent.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: process.parent.Ext.architecture
@@ -1659,6 +1671,7 @@
     - name: process.parent.Ext.dll.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: process.parent.Ext.dll.Ext.code_signature
@@ -1868,6 +1881,7 @@
     - name: process.parent.Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: The field set containing process info in case of any pid spoofing. This is mainly useful for process.parent.
       default_field: false
     - name: process.parent.Ext.real.pid
@@ -2319,11 +2333,13 @@
     - name: process.thread.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: process.thread.Ext.call_stack
       level: custom
       type: object
+      object_type: keyword
       description: Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame.
       enabled: false
       default_field: false
@@ -2429,6 +2445,7 @@
     - name: process.thread.Ext.call_stack_final_user_module.hash
       level: custom
       type: object
+      object_type: keyword
       description: Hashes of the call_stack_final_user_module.
       default_field: false
     - name: process.thread.Ext.call_stack_final_user_module.hash.sha256
@@ -2959,6 +2976,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.code_signature
@@ -3258,6 +3276,7 @@
     - name: agent
       level: custom
       type: object
+      object_type: keyword
       description: The agent fields contain data about the Elastic Agent. The Elastic Agent is the management agent that manages other agents or process on the host.
       default_field: false
     - name: agent.id
@@ -3427,6 +3446,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.code_signature
@@ -3485,6 +3505,7 @@
     - name: Ext.macro.collection
       level: custom
       type: object
+      object_type: keyword
       description: Object containing hashes for the macro collection.
       default_field: false
     - name: Ext.macro.collection.hash.md5
@@ -3536,6 +3557,7 @@
     - name: Ext.macro.project_file
       level: custom
       type: object
+      object_type: keyword
       description: Metadata about the corresponding VBA project file
       default_field: false
     - name: Ext.macro.project_file.hash.md5
@@ -3662,6 +3684,7 @@
     - name: Ext.original
       level: custom
       type: object
+      object_type: keyword
       description: Original file information during a modification event.
       default_field: false
     - name: Ext.original.gid
@@ -3736,6 +3759,7 @@
     - name: Ext.windows
       level: custom
       type: object
+      object_type: keyword
       description: Platform-specific Windows fields
       default_field: false
     - name: Ext.windows.zone_identifier
@@ -3947,6 +3971,7 @@
     - name: pe.Ext.sections
       level: custom
       type: object
+      object_type: keyword
       description: The file's relevant sections, if it is a PE
       default_field: false
     - name: pe.Ext.sections.hash.md5
@@ -3971,6 +3996,7 @@
     - name: pe.Ext.streams
       level: custom
       type: object
+      object_type: keyword
       description: The file's streams, if it is a PE
       default_field: false
     - name: pe.Ext.streams.hash.md5
@@ -4080,11 +4106,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: Ext.real.id
@@ -4258,6 +4286,7 @@
     - name: os.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: os.Ext.variant
@@ -4354,11 +4383,13 @@
     - name: user.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: user.Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: User info prior to any setuid operations.
       default_field: false
     - name: user.Ext.real.id
@@ -4398,11 +4429,13 @@
     - name: user.group.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: user.group.Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: user.group.Ext.real.id
@@ -4501,6 +4534,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.ancestry
@@ -4568,6 +4602,7 @@
     - name: Ext.dll.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.dll.Ext.code_signature
@@ -4886,6 +4921,7 @@
     - name: Ext.memory_region.malware_signature.primary
       level: custom
       type: object
+      object_type: keyword
       description: The first matching details.
       default_field: false
     - name: Ext.memory_region.malware_signature.primary.matches
@@ -5527,6 +5563,7 @@
     - name: entry_leader.tty
       level: extended
       type: object
+      object_type: keyword
       description: Information about the controlling TTY device. If set, the process belongs to an interactive session.
       default_field: false
     - name: entry_leader.tty.char_device.major
@@ -5804,6 +5841,7 @@
     - name: group_leader.tty
       level: extended
       type: object
+      object_type: keyword
       description: Information about the controlling TTY device. If set, the process belongs to an interactive session.
       default_field: false
     - name: group_leader.tty.char_device.major
@@ -5901,6 +5939,7 @@
     - name: parent.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: parent.Ext.architecture
@@ -5956,6 +5995,7 @@
     - name: parent.Ext.dll.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: parent.Ext.dll.Ext.code_signature
@@ -6165,6 +6205,7 @@
     - name: parent.Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: The field set containing process info in case of any pid spoofing. This is mainly useful for process.parent.
       default_field: false
     - name: parent.Ext.real.pid
@@ -6639,6 +6680,7 @@
     - name: parent.tty
       level: extended
       type: object
+      object_type: keyword
       description: Information about the controlling TTY device. If set, the process belongs to an interactive session.
       default_field: false
     - name: parent.tty.char_device.major
@@ -7090,6 +7132,7 @@
     - name: session_leader.tty
       level: extended
       type: object
+      object_type: keyword
       description: Information about the controlling TTY device. If set, the process belongs to an interactive session.
       default_field: false
     - name: session_leader.tty.char_device.major
@@ -7156,11 +7199,13 @@
     - name: thread.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: thread.Ext.call_stack
       level: custom
       type: object
+      object_type: keyword
       description: Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame.
       enabled: false
       default_field: false
@@ -7266,6 +7311,7 @@
     - name: thread.Ext.call_stack_final_user_module.hash
       level: custom
       type: object
+      object_type: keyword
       description: Hashes of the call_stack_final_user_module.
       default_field: false
     - name: thread.Ext.call_stack_final_user_module.hash.sha256
@@ -7524,6 +7570,7 @@
     - name: tty
       level: extended
       type: object
+      object_type: keyword
       description: Information about the controlling TTY device. If set, the process belongs to an interactive session.
       default_field: false
     - name: tty.char_device.major
@@ -7793,6 +7840,7 @@
     - name: enrichments.indicator.file.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: enrichments.indicator.file.Ext.code_signature
@@ -8027,6 +8075,7 @@
     - name: enrichments.indicator.file.Ext.original
       level: custom
       type: object
+      object_type: keyword
       description: Original file information during a modification event.
       default_field: false
     - name: enrichments.indicator.file.Ext.original.gid
@@ -8101,6 +8150,7 @@
     - name: enrichments.indicator.file.Ext.windows
       level: custom
       type: object
+      object_type: keyword
       description: Platform-specific Windows fields
       default_field: false
     - name: enrichments.indicator.file.Ext.windows.zone_identifier
@@ -9248,6 +9298,7 @@
     - name: indicator.file.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: indicator.file.Ext.code_signature
@@ -9482,6 +9533,7 @@
     - name: indicator.file.Ext.original
       level: custom
       type: object
+      object_type: keyword
       description: Original file information during a modification event.
       default_field: false
     - name: indicator.file.Ext.original.gid
@@ -9556,6 +9608,7 @@
     - name: indicator.file.Ext.windows
       level: custom
       type: object
+      object_type: keyword
       description: Platform-specific Windows fields
       default_field: false
     - name: indicator.file.Ext.windows.zone_identifier
@@ -10705,11 +10758,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: User info prior to any setuid operations.
       default_field: false
     - name: Ext.real.id
@@ -10749,11 +10804,13 @@
     - name: group.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: group.Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: group.Ext.real.id

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -577,7 +577,8 @@
     - name: dll.Ext.malware_classification.features
       level: custom
       type: object
-      description: Intermediate field included by adding option with subset
+      object_type: keyword
+      description: The features extracted from this file and evaluated by the model.
       enabled: false
       default_field: false
     - name: dll.Ext.malware_classification.features.data.buffer
@@ -1049,7 +1050,8 @@
     - name: process.Ext.malware_classification.features
       level: custom
       type: object
-      description: Intermediate field included by adding option with subset
+      object_type: keyword
+      description: The features extracted from this file and evaluated by the model.
       enabled: false
       default_field: false
     - name: process.Ext.malware_classification.features.data.buffer
@@ -3030,7 +3032,8 @@
     - name: Ext.malware_classification.features
       level: custom
       type: object
-      description: Intermediate field included by adding option with subset
+      object_type: keyword
+      description: The features extracted from this file and evaluated by the model.
       enabled: false
       default_field: false
     - name: Ext.malware_classification.features.data.buffer
@@ -3634,7 +3637,8 @@
     - name: Ext.malware_classification.features
       level: custom
       type: object
-      description: Intermediate field included by adding option with subset
+      object_type: keyword
+      description: The features extracted from this file and evaluated by the model.
       enabled: false
       default_field: false
     - name: Ext.malware_classification.features.data.buffer
@@ -4806,7 +4810,8 @@
     - name: Ext.malware_classification.features
       level: custom
       type: object
-      description: Intermediate field included by adding option with subset
+      object_type: keyword
+      description: The features extracted from this file and evaluated by the model.
       enabled: false
       default_field: false
     - name: Ext.malware_classification.features.data.buffer
@@ -7959,6 +7964,13 @@
       type: text
       description: First 16 bytes of file used to check file integrity.
       default_field: false
+    - name: enrichments.indicator.file.Ext.malware_classification.features
+      level: custom
+      type: object
+      object_type: keyword
+      description: The features extracted from this file and evaluated by the model.
+      enabled: false
+      default_field: false
     - name: enrichments.indicator.file.Ext.malware_classification.features.data.buffer
       level: custom
       type: keyword
@@ -9416,6 +9428,13 @@
       level: custom
       type: text
       description: First 16 bytes of file used to check file integrity.
+      default_field: false
+    - name: indicator.file.Ext.malware_classification.features
+      level: custom
+      type: object
+      object_type: keyword
+      description: The features extracted from this file and evaluated by the model.
+      enabled: false
       default_field: false
     - name: indicator.file.Ext.malware_classification.features.data.buffer
       level: custom

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -33,6 +33,7 @@
     - name: process.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: process.Ext.token.integrity_level_name
@@ -287,6 +288,7 @@
     - name: os.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: os.Ext.variant
@@ -385,6 +387,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.ancestry
@@ -406,6 +409,7 @@
     - name: Ext.api.metadata
       level: custom
       type: object
+      object_type: keyword
       description: Information related to the API call.
       default_field: false
     - name: Ext.api.metadata.target_address_name
@@ -432,6 +436,7 @@
     - name: Ext.api.parameters
       level: custom
       type: object
+      object_type: keyword
       description: Parameter values passed to the API call.
       default_field: false
     - name: Ext.api.parameters.address
@@ -806,11 +811,13 @@
     - name: thread.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: thread.Ext.call_stack
       level: custom
       type: object
+      object_type: keyword
       description: Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame.
       enabled: false
       default_field: false
@@ -917,6 +924,7 @@
     - name: thread.Ext.call_stack_final_user_module.hash
       level: custom
       type: object
+      object_type: keyword
       description: Hashes of the call_stack_final_user_module.
       default_field: false
     - name: thread.Ext.call_stack_final_user_module.hash.sha256

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -270,11 +270,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.correlation
       level: custom
       type: object
+      object_type: keyword
       description: Information about event this should be correlated with.
       default_field: false
     - name: Ext.correlation.id
@@ -430,6 +432,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.device.bus_type
@@ -572,6 +575,7 @@
     - name: Ext.original
       level: custom
       type: object
+      object_type: keyword
       description: Original file information during a modification event.
       default_field: false
     - name: Ext.original.gid
@@ -623,6 +627,7 @@
     - name: Ext.windows
       level: custom
       type: object
+      object_type: keyword
       description: Platform-specific Windows fields
       default_field: false
     - name: Ext.windows.zone_identifier
@@ -857,11 +862,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: Ext.real.id
@@ -954,6 +961,7 @@
     - name: os.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: os.Ext.variant
@@ -1052,6 +1060,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.ancestry
@@ -1300,11 +1309,13 @@
     - name: thread.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: thread.Ext.call_stack
       level: custom
       type: object
+      object_type: keyword
       description: Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame.
       enabled: true
       default_field: false
@@ -1445,11 +1456,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: User info prior to any setuid operations.
       default_field: false
     - name: Ext.real.id
@@ -1489,11 +1502,13 @@
     - name: group.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: group.Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: group.Ext.real.id

--- a/package/endpoint/data_stream/library/fields/fields.yml
+++ b/package/endpoint/data_stream/library/fields/fields.yml
@@ -220,6 +220,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.code_signature
@@ -657,6 +658,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.code_signature
@@ -854,11 +856,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: Ext.real.id
@@ -951,6 +955,7 @@
     - name: os.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: os.Ext.variant
@@ -1049,6 +1054,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.ancestry
@@ -1210,11 +1216,13 @@
     - name: thread.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: thread.Ext.call_stack
       level: custom
       type: object
+      object_type: keyword
       description: Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame.
       enabled: true
       default_field: false
@@ -1355,11 +1363,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: User info prior to any setuid operations.
       default_field: false
     - name: Ext.real.id
@@ -1399,11 +1409,13 @@
     - name: group.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: group.Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: group.Ext.real.id

--- a/package/endpoint/data_stream/metadata/fields/fields.yml
+++ b/package/endpoint/data_stream/metadata/fields/fields.yml
@@ -28,6 +28,7 @@
     - name: configuration
       level: custom
       type: object
+      object_type: keyword
       description: Configuration fields represent the intended and applied setting for fields not part of a Policy setting This reflects what a given field is configured to do. The actual state of that same field is found in Endpoint.state
       default_field: false
     - name: configuration.isolation
@@ -38,11 +39,13 @@
     - name: policy
       level: custom
       type: object
+      object_type: keyword
       description: The policy fields are used to hold information about applied policy.
       default_field: false
     - name: policy.applied
       level: custom
       type: object
+      object_type: keyword
       description: information about the policy that is applied
       default_field: false
     - name: policy.applied.id
@@ -66,6 +69,7 @@
     - name: state
       level: custom
       type: object
+      object_type: keyword
       description: Represents the current state of a non-policy setting These fields reflect the current status of a field, which may differ from what it is configured to be (see Endpoint.configuration)
       default_field: false
     - name: state.isolation
@@ -170,6 +174,7 @@
     - name: agent
       level: custom
       type: object
+      object_type: keyword
       description: The agent fields contain data about the Elastic Agent. The Elastic Agent is the management agent that manages other agents or process on the host.
       default_field: false
     - name: agent.id
@@ -386,6 +391,7 @@
     - name: os.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: os.Ext.variant

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -31,16 +31,19 @@
     - name: metrics
       level: custom
       type: object
+      object_type: keyword
       description: Metrics fields hold the endpoint and system's performance metrics
       default_field: false
     - name: metrics.cpu
       level: custom
       type: object
+      object_type: keyword
       description: CPU statistics
       default_field: false
     - name: metrics.cpu.endpoint
       level: custom
       type: object
+      object_type: keyword
       description: CPU metrics for the endpoint
       default_field: false
     - name: metrics.cpu.endpoint.histogram
@@ -61,6 +64,7 @@
     - name: metrics.disks
       level: custom
       type: object
+      object_type: keyword
       description: An array of disk information for the host
       enabled: false
       default_field: false
@@ -100,6 +104,7 @@
     - name: metrics.documents_volume
       level: custom
       type: object
+      object_type: keyword
       description: Statistics about sent documents
       default_field: false
     - name: metrics.documents_volume.alerts.sent_bytes
@@ -135,6 +140,7 @@
     - name: metrics.documents_volume.api_events.sources
       level: custom
       type: object
+      object_type: keyword
       description: An array of API Event document statistics per source
       default_field: false
     - name: metrics.documents_volume.api_events.sources.sent_bytes
@@ -370,6 +376,7 @@
     - name: metrics.malicious_behavior_rules
       level: custom
       type: object
+      object_type: keyword
       description: An array of performance information about each malicious behavior rule
       enabled: false
       default_field: false
@@ -390,16 +397,19 @@
     - name: metrics.memory
       level: custom
       type: object
+      object_type: keyword
       description: Memory statistics
       default_field: false
     - name: metrics.memory.endpoint
       level: custom
       type: object
+      object_type: keyword
       description: Endpoint memory utilization
       default_field: false
     - name: metrics.memory.endpoint.private
       level: custom
       type: object
+      object_type: keyword
       description: The memory private to the endpoint
       default_field: false
     - name: metrics.memory.endpoint.private.latest
@@ -415,6 +425,7 @@
     - name: metrics.system_impact
       level: custom
       type: object
+      object_type: keyword
       description: An array of system impact information
       enabled: false
       index: false
@@ -657,6 +668,7 @@
     - name: metrics.threads
       level: custom
       type: object
+      object_type: keyword
       description: Statistics about the individual Endpoint threads (array)
       enabled: false
       default_field: false
@@ -677,6 +689,7 @@
     - name: metrics.uptime
       level: custom
       type: object
+      object_type: keyword
       description: Number of seconds since boot
       default_field: false
     - name: metrics.uptime.endpoint
@@ -977,6 +990,7 @@
     - name: os.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: os.Ext.variant

--- a/package/endpoint/data_stream/network/fields/fields.yml
+++ b/package/endpoint/data_stream/network/fields/fields.yml
@@ -241,6 +241,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.options
@@ -471,11 +472,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: Ext.real.id
@@ -568,6 +571,7 @@
     - name: os.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: os.Ext.variant
@@ -685,6 +689,7 @@
     - name: response.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: response.Ext.version
@@ -806,6 +811,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.ancestry
@@ -1199,11 +1205,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: User info prior to any setuid operations.
       default_field: false
     - name: Ext.real.id
@@ -1243,11 +1251,13 @@
     - name: group.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: group.Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: group.Ext.real.id

--- a/package/endpoint/data_stream/policy/fields/fields.yml
+++ b/package/endpoint/data_stream/policy/fields/fields.yml
@@ -31,6 +31,7 @@
     - name: configuration
       level: custom
       type: object
+      object_type: keyword
       description: Configuration fields represent the intended and applied setting for fields not part of a Policy setting This reflects what a given field is configured to do. The actual state of that same field is found in Endpoint.state
       default_field: false
     - name: configuration.isolation
@@ -41,11 +42,13 @@
     - name: policy
       level: custom
       type: object
+      object_type: keyword
       description: The policy fields are used to hold information about applied policy.
       default_field: false
     - name: policy.applied
       level: custom
       type: object
+      object_type: keyword
       description: information about the policy that is applied
       default_field: false
     - name: policy.applied.actions
@@ -75,12 +78,14 @@
     - name: policy.applied.artifacts
       level: custom
       type: object
+      object_type: keyword
       description: information about protection artifacts applied.
       enabled: false
       default_field: false
     - name: policy.applied.artifacts.global
       level: custom
       type: object
+      object_type: keyword
       description: information about global protection artifacts applied.
       default_field: false
     - name: policy.applied.artifacts.global.identifiers
@@ -109,6 +114,7 @@
     - name: policy.applied.artifacts.user
       level: custom
       type: object
+      object_type: keyword
       description: information about user protection artifacts applied.
       default_field: false
     - name: policy.applied.artifacts.user.identifiers
@@ -155,18 +161,21 @@
     - name: policy.applied.response
       level: custom
       type: object
+      object_type: keyword
       description: the response of actions that failed in the applied policy
       enabled: false
       default_field: false
     - name: policy.applied.response.configurations
       level: custom
       type: object
+      object_type: keyword
       description: the configurations of the applied policy
       enabled: false
       default_field: false
     - name: policy.applied.response.configurations.antivirus_registration
       level: custom
       type: object
+      object_type: keyword
       description: overall antivirus registration configuration and status of the applied policy
       enabled: false
       default_field: false
@@ -209,6 +218,7 @@
     - name: policy.applied.response.configurations.events
       level: custom
       type: object
+      object_type: keyword
       description: overall event collection configuration and status of the applied policy
       default_field: false
     - name: policy.applied.response.configurations.events.concerned_actions
@@ -238,6 +248,7 @@
     - name: policy.applied.response.configurations.logging
       level: custom
       type: object
+      object_type: keyword
       description: overall logging configuration and status of the applied policy
       default_field: false
     - name: policy.applied.response.configurations.logging.concerned_actions
@@ -255,6 +266,7 @@
     - name: policy.applied.response.configurations.malware
       level: custom
       type: object
+      object_type: keyword
       description: overall malware configuration and status of the applied policy
       default_field: false
     - name: policy.applied.response.configurations.malware.concerned_actions
@@ -272,6 +284,7 @@
     - name: policy.applied.response.configurations.memory_protection
       level: custom
       type: object
+      object_type: keyword
       description: overall memory_protection configuration and status of the applied policy
       default_field: false
     - name: policy.applied.response.configurations.memory_protection.concerned_actions
@@ -301,6 +314,7 @@
     - name: policy.applied.response.configurations.streaming
       level: custom
       type: object
+      object_type: keyword
       description: overall data streaming configuration and status of the applied policy
       default_field: false
     - name: policy.applied.response.configurations.streaming.concerned_actions
@@ -318,6 +332,7 @@
     - name: policy.applied.response.diagnostic
       level: custom
       type: object
+      object_type: keyword
       description: the diagnostic configurations of the applied policy
       enabled: false
       default_field: false
@@ -408,6 +423,7 @@
     - name: state
       level: custom
       type: object
+      object_type: keyword
       description: Represents the current state of a non-policy setting These fields reflect the current status of a field, which may differ from what it is configured to be (see Endpoint.configuration)
       default_field: false
     - name: state.isolation
@@ -695,6 +711,7 @@
     - name: os.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: os.Ext.variant

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -427,11 +427,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: Ext.real.id
@@ -531,6 +533,7 @@
     - name: os.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: os.Ext.variant
@@ -701,6 +704,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.ancestry
@@ -826,6 +830,7 @@
     - name: Ext.dll.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.dll.Ext.mapped_address
@@ -1378,6 +1383,7 @@
     - name: entry_leader.tty
       level: extended
       type: object
+      object_type: keyword
       description: Information about the controlling TTY device. If set, the process belongs to an interactive session.
       default_field: false
     - name: entry_leader.tty.char_device.major
@@ -1667,6 +1673,7 @@
     - name: group_leader.tty
       level: extended
       type: object
+      object_type: keyword
       description: Information about the controlling TTY device. If set, the process belongs to an interactive session.
       default_field: false
     - name: group_leader.tty.char_device.major
@@ -1746,6 +1753,7 @@
     - name: io
       level: extended
       type: object
+      object_type: keyword
       description: 'A chunk of input or output (IO) from a single process.
 
         This field only appears on the top level process object, which is the process that wrote the output or read the input.'
@@ -1793,6 +1801,7 @@
     - name: parent.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: parent.Ext.architecture
@@ -1854,6 +1863,7 @@
     - name: parent.Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: The field set containing process info in case of any pid spoofing. This is mainly useful for process.parent.
       default_field: false
     - name: parent.Ext.real.pid
@@ -2222,11 +2232,13 @@
     - name: parent.thread.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: parent.thread.Ext.call_stack
       level: custom
       type: object
+      object_type: keyword
       description: Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame.
       enabled: true
       default_field: false
@@ -2299,6 +2311,7 @@
     - name: parent.tty
       level: extended
       type: object
+      object_type: keyword
       description: Information about the controlling TTY device. If set, the process belongs to an interactive session.
       default_field: false
     - name: parent.tty.char_device.major
@@ -2750,6 +2763,7 @@
     - name: session_leader.tty
       level: extended
       type: object
+      object_type: keyword
       description: Information about the controlling TTY device. If set, the process belongs to an interactive session.
       default_field: false
     - name: session_leader.tty.char_device.major
@@ -2855,6 +2869,7 @@
     - name: tty
       level: extended
       type: object
+      object_type: keyword
       description: Information about the controlling TTY device. If set, the process belongs to an interactive session.
       default_field: false
     - name: tty.char_device.major
@@ -3018,11 +3033,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: User info prior to any setuid operations.
       default_field: false
     - name: Ext.real.id
@@ -3062,11 +3079,13 @@
     - name: group.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: group.Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: group.Ext.real.id

--- a/package/endpoint/data_stream/registry/fields/fields.yml
+++ b/package/endpoint/data_stream/registry/fields/fields.yml
@@ -371,11 +371,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: Ext.real.id
@@ -468,6 +470,7 @@
     - name: os.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: os.Ext.variant
@@ -566,6 +569,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.ancestry
@@ -727,11 +731,13 @@
     - name: thread.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: thread.Ext.call_stack
       level: custom
       type: object
+      object_type: keyword
       description: Fields describing a stack frame.  call_stack is expected to be an array where each array element represents a stack frame.
       enabled: true
       default_field: false
@@ -931,11 +937,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: User info prior to any setuid operations.
       default_field: false
     - name: Ext.real.id
@@ -975,11 +983,13 @@
     - name: group.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: group.Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: group.Ext.real.id

--- a/package/endpoint/data_stream/security/fields/fields.yml
+++ b/package/endpoint/data_stream/security/fields/fields.yml
@@ -331,11 +331,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: Ext.real.id
@@ -428,6 +430,7 @@
     - name: os.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: os.Ext.variant
@@ -526,6 +529,7 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.ancestry
@@ -785,11 +789,13 @@
     - name: Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: User info prior to any setuid operations.
       default_field: false
     - name: Ext.real.id
@@ -829,11 +835,13 @@
     - name: group.Ext
       level: custom
       type: object
+      object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
     - name: group.Ext.real
       level: custom
       type: object
+      object_type: keyword
       description: Group info prior to any setgid operations.
       default_field: false
     - name: group.Ext.real.id

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1064,9 +1064,6 @@ sent by the endpoint.
 | threat.enrichments.indicator.file.Ext.entry_modified | Time of last status change.  See `st_ctim` member of `struct stat`. | double |
 | threat.enrichments.indicator.file.Ext.header_bytes | First 16 bytes of file used to check file integrity. | keyword |
 | threat.enrichments.indicator.file.Ext.header_data | First 16 bytes of file used to check file integrity. | text |
-| threat.enrichments.indicator.file.Ext.malware_classification.features.data.buffer | The features extracted from this file and evaluated by the model.  Usually an array of floats.  Likely zlib-encoded. | keyword |
-| threat.enrichments.indicator.file.Ext.malware_classification.features.data.decompressed_size | The decompressed size of buffer. | integer |
-| threat.enrichments.indicator.file.Ext.malware_classification.features.data.encoding | The encoding of buffer (e.g. zlib). | keyword |
 | threat.enrichments.indicator.file.Ext.malware_classification.identifier | The model's unique identifier. | keyword |
 | threat.enrichments.indicator.file.Ext.malware_classification.score | The score produced by the classification model. | double |
 | threat.enrichments.indicator.file.Ext.malware_classification.threshold | The score threshold for the model.  Files that score above this threshold are considered malicious. | double |
@@ -1278,9 +1275,6 @@ sent by the endpoint.
 | threat.indicator.file.Ext.entry_modified | Time of last status change.  See `st_ctim` member of `struct stat`. | double |
 | threat.indicator.file.Ext.header_bytes | First 16 bytes of file used to check file integrity. | keyword |
 | threat.indicator.file.Ext.header_data | First 16 bytes of file used to check file integrity. | text |
-| threat.indicator.file.Ext.malware_classification.features.data.buffer | The features extracted from this file and evaluated by the model.  Usually an array of floats.  Likely zlib-encoded. | keyword |
-| threat.indicator.file.Ext.malware_classification.features.data.decompressed_size | The decompressed size of buffer. | integer |
-| threat.indicator.file.Ext.malware_classification.features.data.encoding | The encoding of buffer (e.g. zlib). | keyword |
 | threat.indicator.file.Ext.malware_classification.identifier | The model's unique identifier. | keyword |
 | threat.indicator.file.Ext.malware_classification.score | The score produced by the classification model. | double |
 | threat.indicator.file.Ext.malware_classification.threshold | The score threshold for the model.  Files that score above this threshold are considered malicious. | double |

--- a/schemas/v1/action_responses/action_responses.yaml
+++ b/schemas/v1/action_responses/action_responses.yaml
@@ -44,6 +44,7 @@ EndpointActions.data:
   level: custom
   name: data
   normalize: []
+  object_type: keyword
   short: data
   type: object
 EndpointActions.data.alert_id:

--- a/schemas/v1/actions/actions.yaml
+++ b/schemas/v1/actions/actions.yaml
@@ -34,6 +34,7 @@ EndpointActions.data:
   level: custom
   name: data
   normalize: []
+  object_type: keyword
   short: data
   type: object
 EndpointActions.data.alert_id:

--- a/schemas/v1/alerts/linux_event_model_event.yaml
+++ b/schemas/v1/alerts/linux_event_model_event.yaml
@@ -851,6 +851,7 @@ process.entry_leader.tty:
   level: extended
   name: tty
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Information about the controlling TTY device.
   type: object
@@ -1316,6 +1317,7 @@ process.group_leader.tty:
   level: extended
   name: tty
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Information about the controlling TTY device.
   type: object
@@ -1800,6 +1802,7 @@ process.parent.tty:
   level: extended
   name: tty
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Information about the controlling TTY device.
   type: object
@@ -2478,6 +2481,7 @@ process.session_leader.tty:
   level: extended
   name: tty
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Information about the controlling TTY device.
   type: object
@@ -2599,6 +2603,7 @@ process.tty:
   level: extended
   name: tty
   normalize: []
+  object_type: keyword
   short: Information about the controlling TTY device.
   type: object
 process.tty.char_device.major:

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -287,14 +287,15 @@ Target.dll.Ext.compile_time:
   type: date
 Target.dll.Ext.malware_classification.features:
   dashed_name: Target-dll-Ext-malware-classification-features
-  description: Intermediate field included by adding option with subset
+  description: The features extracted from this file and evaluated by the model.
   enabled: false
   flat_name: Target.dll.Ext.malware_classification.features
   level: custom
   name: features
   normalize: []
+  object_type: keyword
   original_fieldset: malware_classification
-  short: Intermediate field included by adding option with subset
+  short: The features extracted from this file and evaluated by the model.
   type: object
 Target.dll.Ext.malware_classification.features.data.buffer:
   dashed_name: Target-dll-Ext-malware-classification-features-data-buffer
@@ -761,14 +762,15 @@ Target.process.Ext.code_signature.valid:
   type: boolean
 Target.process.Ext.malware_classification.features:
   dashed_name: Target-process-Ext-malware-classification-features
-  description: Intermediate field included by adding option with subset
+  description: The features extracted from this file and evaluated by the model.
   enabled: false
   flat_name: Target.process.Ext.malware_classification.features
   level: custom
   name: features
   normalize: []
+  object_type: keyword
   original_fieldset: malware_classification
-  short: Intermediate field included by adding option with subset
+  short: The features extracted from this file and evaluated by the model.
   type: object
 Target.process.Ext.malware_classification.features.data.buffer:
   dashed_name: Target-process-Ext-malware-classification-features-data-buffer
@@ -2687,14 +2689,15 @@ dll.Ext.compile_time:
   type: date
 dll.Ext.malware_classification.features:
   dashed_name: dll-Ext-malware-classification-features
-  description: Intermediate field included by adding option with subset
+  description: The features extracted from this file and evaluated by the model.
   enabled: false
   flat_name: dll.Ext.malware_classification.features
   level: custom
   name: features
   normalize: []
+  object_type: keyword
   original_fieldset: malware_classification
-  short: Intermediate field included by adding option with subset
+  short: The features extracted from this file and evaluated by the model.
   type: object
 dll.Ext.malware_classification.features.data.buffer:
   dashed_name: dll-Ext-malware-classification-features-data-buffer
@@ -4145,14 +4148,15 @@ file.Ext.macro.stream.raw_code_size:
   type: keyword
 file.Ext.malware_classification.features:
   dashed_name: file-Ext-malware-classification-features
-  description: Intermediate field included by adding option with subset
+  description: The features extracted from this file and evaluated by the model.
   enabled: false
   flat_name: file.Ext.malware_classification.features
   level: custom
   name: features
   normalize: []
+  object_type: keyword
   original_fieldset: malware_classification
-  short: Intermediate field included by adding option with subset
+  short: The features extracted from this file and evaluated by the model.
   type: object
 file.Ext.malware_classification.features.data.buffer:
   dashed_name: file-Ext-malware-classification-features-data-buffer
@@ -5765,14 +5769,15 @@ process.Ext.code_signature.valid:
   type: boolean
 process.Ext.malware_classification.features:
   dashed_name: process-Ext-malware-classification-features
-  description: Intermediate field included by adding option with subset
+  description: The features extracted from this file and evaluated by the model.
   enabled: false
   flat_name: process.Ext.malware_classification.features
   level: custom
   name: features
   normalize: []
+  object_type: keyword
   original_fieldset: malware_classification
-  short: Intermediate field included by adding option with subset
+  short: The features extracted from this file and evaluated by the model.
   type: object
 process.Ext.malware_classification.features.data.buffer:
   dashed_name: process-Ext-malware-classification-features-data-buffer
@@ -7911,6 +7916,18 @@ threat.enrichments.indicator.file.Ext.header_data:
   original_fieldset: file
   short: Header data
   type: text
+threat.enrichments.indicator.file.Ext.malware_classification.features:
+  dashed_name: threat-enrichments-indicator-file-Ext-malware-classification-features
+  description: The features extracted from this file and evaluated by the model.
+  enabled: false
+  flat_name: threat.enrichments.indicator.file.Ext.malware_classification.features
+  level: custom
+  name: features
+  normalize: []
+  object_type: keyword
+  original_fieldset: malware_classification
+  short: The features extracted from this file and evaluated by the model.
+  type: object
 threat.enrichments.indicator.file.Ext.malware_classification.features.data.buffer:
   dashed_name: threat-enrichments-indicator-file-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -10591,6 +10608,18 @@ threat.indicator.file.Ext.header_data:
   original_fieldset: file
   short: Header data
   type: text
+threat.indicator.file.Ext.malware_classification.features:
+  dashed_name: threat-indicator-file-Ext-malware-classification-features
+  description: The features extracted from this file and evaluated by the model.
+  enabled: false
+  flat_name: threat.indicator.file.Ext.malware_classification.features
+  level: custom
+  name: features
+  normalize: []
+  object_type: keyword
+  original_fieldset: malware_classification
+  short: The features extracted from this file and evaluated by the model.
+  type: object
 threat.indicator.file.Ext.malware_classification.features.data.buffer:
   dashed_name: threat-indicator-file-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -24,6 +24,7 @@ Endpoint.policy:
   level: custom
   name: policy
   normalize: []
+  object_type: keyword
   short: The policy fields are used to hold information about applied policy.
   type: object
 Endpoint.policy.applied:
@@ -33,6 +34,7 @@ Endpoint.policy.applied:
   level: custom
   name: policy.applied
   normalize: []
+  object_type: keyword
   short: information about the policy that is applied
   type: object
 Endpoint.policy.applied.artifacts:
@@ -43,6 +45,7 @@ Endpoint.policy.applied.artifacts:
   level: custom
   name: policy.applied.artifacts
   normalize: []
+  object_type: keyword
   short: information about protection artifacts applied.
   type: object
 Endpoint.policy.applied.artifacts.global:
@@ -52,6 +55,7 @@ Endpoint.policy.applied.artifacts.global:
   level: custom
   name: policy.applied.artifacts.global
   normalize: []
+  object_type: keyword
   short: information about global protection artifacts applied.
   type: object
 Endpoint.policy.applied.artifacts.global.identifiers:
@@ -100,6 +104,7 @@ Endpoint.policy.applied.artifacts.user:
   level: custom
   name: policy.applied.artifacts.user
   normalize: []
+  object_type: keyword
   short: information about user protection artifacts applied.
   type: object
 Endpoint.policy.applied.artifacts.user.identifiers:
@@ -188,6 +193,7 @@ Target.dll.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: dll
   short: Object for all custom defined fields to live in.
   type: object
@@ -649,6 +655,7 @@ Target.process.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
@@ -1319,6 +1326,7 @@ Target.process.parent.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
@@ -1408,6 +1416,7 @@ Target.process.parent.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: The field set containing process info in case of any pid spoofing. This is
     mainly useful for process.parent.
@@ -1956,6 +1965,7 @@ Target.process.thread.Ext:
   level: custom
   name: thread.Ext
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
@@ -1968,6 +1978,7 @@ Target.process.thread.Ext.call_stack:
   level: custom
   name: call_stack
   normalize: []
+  object_type: keyword
   original_fieldset: call_stack
   short: Fields describing a stack frame.
   type: object
@@ -2590,6 +2601,7 @@ dll.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 dll.Ext.code_signature:
@@ -3084,6 +3096,7 @@ elastic.agent:
   level: custom
   name: agent
   normalize: []
+  object_type: keyword
   short: The agent fields contain data about the Elastic Agent.
   type: object
 elastic.agent.id:
@@ -3795,6 +3808,7 @@ file.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 file.Ext.code_signature:
@@ -3895,6 +3909,7 @@ file.Ext.macro.collection:
   level: custom
   name: collection
   normalize: []
+  object_type: keyword
   original_fieldset: macro
   short: Object containing hashes for the macro collection.
   type: object
@@ -3991,6 +4006,7 @@ file.Ext.macro.project_file:
   level: custom
   name: project_file
   normalize: []
+  object_type: keyword
   original_fieldset: macro
   short: Metadata about the corresponding VBA project file
   type: object
@@ -4233,6 +4249,7 @@ file.Ext.original:
   level: custom
   name: Ext.original
   normalize: []
+  object_type: keyword
   short: Original file information during a modification event.
   type: object
 file.Ext.original.gid:
@@ -4357,6 +4374,7 @@ file.Ext.windows:
   level: custom
   name: Ext.windows
   normalize: []
+  object_type: keyword
   short: Platform-specific Windows fields
   type: object
 file.Ext.windows.zone_identifier:
@@ -4740,6 +4758,7 @@ file.pe.Ext.sections:
   level: custom
   name: Ext.sections
   normalize: []
+  object_type: keyword
   original_fieldset: pe
   short: The file's sections, if it is a PE
   type: object
@@ -4784,6 +4803,7 @@ file.pe.Ext.streams:
   level: custom
   name: Ext.streams
   normalize: []
+  object_type: keyword
   original_fieldset: pe
   short: The file's streams, if it is a PE
   type: object
@@ -4958,6 +4978,7 @@ group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 group.Ext.real:
@@ -4967,6 +4988,7 @@ group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: Group info prior to any setgid operations.
   type: object
 group.Ext.real.id:
@@ -5259,6 +5281,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object
@@ -5424,6 +5447,7 @@ host.user.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: user
   short: Object for all custom defined fields to live in.
   type: object
@@ -5434,6 +5458,7 @@ host.user.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: user
   short: User info prior to any setuid operations.
   type: object
@@ -5506,6 +5531,7 @@ host.user.group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Object for all custom defined fields to live in.
   type: object
@@ -5516,6 +5542,7 @@ host.user.group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Group info prior to any setgid operations.
   type: object
@@ -5641,6 +5668,7 @@ process.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.Ext.ancestry:
@@ -6304,6 +6332,7 @@ process.parent.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
@@ -6406,6 +6435,7 @@ process.parent.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: The field set containing process info in case of any pid spoofing. This is
     mainly useful for process.parent.
@@ -6950,6 +6980,7 @@ process.thread.Ext:
   level: custom
   name: thread.Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.thread.Ext.call_stack:
@@ -6961,6 +6992,7 @@ process.thread.Ext.call_stack:
   level: custom
   name: call_stack
   normalize: []
+  object_type: keyword
   original_fieldset: call_stack
   short: Fields describing a stack frame.
   type: object
@@ -7657,6 +7689,7 @@ threat.enrichments.indicator.file.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Object for all custom defined fields to live in.
   type: object
@@ -8111,6 +8144,7 @@ threat.enrichments.indicator.file.Ext.original:
   level: custom
   name: Ext.original
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Original file information during a modification event.
   type: object
@@ -8247,6 +8281,7 @@ threat.enrichments.indicator.file.Ext.windows:
   level: custom
   name: Ext.windows
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Platform-specific Windows fields
   type: object
@@ -10334,6 +10369,7 @@ threat.indicator.file.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Object for all custom defined fields to live in.
   type: object
@@ -10788,6 +10824,7 @@ threat.indicator.file.Ext.original:
   level: custom
   name: Ext.original
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Original file information during a modification event.
   type: object
@@ -10924,6 +10961,7 @@ threat.indicator.file.Ext.windows:
   level: custom
   name: Ext.windows
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Platform-specific Windows fields
   type: object
@@ -13022,6 +13060,7 @@ user.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 user.Ext.real:
@@ -13031,6 +13070,7 @@ user.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: User info prior to any setuid operations.
   type: object
 user.Ext.real.id:
@@ -13097,6 +13137,7 @@ user.group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Object for all custom defined fields to live in.
   type: object
@@ -13107,6 +13148,7 @@ user.group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Group info prior to any setgid operations.
   type: object

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -24,6 +24,7 @@ Endpoint.policy:
   level: custom
   name: policy
   normalize: []
+  object_type: keyword
   short: The policy fields are used to hold information about applied policy.
   type: object
 Endpoint.policy.applied:
@@ -33,6 +34,7 @@ Endpoint.policy.applied:
   level: custom
   name: policy.applied
   normalize: []
+  object_type: keyword
   short: information about the policy that is applied
   type: object
 Endpoint.policy.applied.artifacts:
@@ -43,6 +45,7 @@ Endpoint.policy.applied.artifacts:
   level: custom
   name: policy.applied.artifacts
   normalize: []
+  object_type: keyword
   short: information about protection artifacts applied.
   type: object
 Endpoint.policy.applied.artifacts.global:
@@ -52,6 +55,7 @@ Endpoint.policy.applied.artifacts.global:
   level: custom
   name: policy.applied.artifacts.global
   normalize: []
+  object_type: keyword
   short: information about global protection artifacts applied.
   type: object
 Endpoint.policy.applied.artifacts.global.identifiers:
@@ -100,6 +104,7 @@ Endpoint.policy.applied.artifacts.user:
   level: custom
   name: policy.applied.artifacts.user
   normalize: []
+  object_type: keyword
   short: information about user protection artifacts applied.
   type: object
 Endpoint.policy.applied.artifacts.user.identifiers:
@@ -249,6 +254,7 @@ Target.process.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
@@ -371,6 +377,7 @@ Target.process.Ext.dll.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: dll
   short: Object for all custom defined fields to live in.
   type: object
@@ -855,6 +862,7 @@ Target.process.Ext.memory_region.malware_signature.primary:
   level: custom
   name: primary
   normalize: []
+  object_type: keyword
   original_fieldset: malware_signature
   short: The first matching details.
   type: object
@@ -1653,6 +1661,7 @@ Target.process.parent.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
@@ -1753,6 +1762,7 @@ Target.process.parent.Ext.dll.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: dll
   short: Object for all custom defined fields to live in.
   type: object
@@ -2129,6 +2139,7 @@ Target.process.parent.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: The field set containing process info in case of any pid spoofing. This is
     mainly useful for process.parent.
@@ -2915,6 +2926,7 @@ Target.process.thread.Ext:
   level: custom
   name: thread.Ext
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
@@ -2927,6 +2939,7 @@ Target.process.thread.Ext.call_stack:
   level: custom
   name: call_stack
   normalize: []
+  object_type: keyword
   original_fieldset: call_stack
   short: Fields describing a stack frame.
   type: object
@@ -3120,6 +3133,7 @@ Target.process.thread.Ext.call_stack_final_user_module.hash:
   level: custom
   name: thread.Ext.call_stack_final_user_module.hash
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Hashes of the call_stack_final_user_module.
   type: object
@@ -3884,6 +3898,7 @@ dll.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 dll.Ext.code_signature:
@@ -4252,6 +4267,7 @@ elastic.agent:
   level: custom
   name: agent
   normalize: []
+  object_type: keyword
   short: The agent fields contain data about the Elastic Agent.
   type: object
 elastic.agent.id:
@@ -4952,6 +4968,7 @@ group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 group.Ext.real:
@@ -4961,6 +4978,7 @@ group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: Group info prior to any setgid operations.
   type: object
 group.Ext.real.id:
@@ -5253,6 +5271,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object
@@ -5418,6 +5437,7 @@ host.user.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: user
   short: Object for all custom defined fields to live in.
   type: object
@@ -5428,6 +5448,7 @@ host.user.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: user
   short: User info prior to any setuid operations.
   type: object
@@ -5500,6 +5521,7 @@ host.user.group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Object for all custom defined fields to live in.
   type: object
@@ -5510,6 +5532,7 @@ host.user.group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Group info prior to any setgid operations.
   type: object
@@ -5635,6 +5658,7 @@ process.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.Ext.ancestry:
@@ -5747,6 +5771,7 @@ process.Ext.dll.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: dll
   short: Object for all custom defined fields to live in.
   type: object
@@ -6231,6 +6256,7 @@ process.Ext.memory_region.malware_signature.primary:
   level: custom
   name: primary
   normalize: []
+  object_type: keyword
   original_fieldset: malware_signature
   short: The first matching details.
   type: object
@@ -7018,6 +7044,7 @@ process.parent.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
@@ -7118,6 +7145,7 @@ process.parent.Ext.dll.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: dll
   short: Object for all custom defined fields to live in.
   type: object
@@ -7494,6 +7522,7 @@ process.parent.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: The field set containing process info in case of any pid spoofing. This is
     mainly useful for process.parent.
@@ -8276,6 +8305,7 @@ process.thread.Ext:
   level: custom
   name: thread.Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.thread.Ext.call_stack:
@@ -8287,6 +8317,7 @@ process.thread.Ext.call_stack:
   level: custom
   name: call_stack
   normalize: []
+  object_type: keyword
   original_fieldset: call_stack
   short: Fields describing a stack frame.
   type: object
@@ -8473,6 +8504,7 @@ process.thread.Ext.call_stack_final_user_module.hash:
   level: custom
   name: thread.Ext.call_stack_final_user_module.hash
   normalize: []
+  object_type: keyword
   short: Hashes of the call_stack_final_user_module.
   type: object
 process.thread.Ext.call_stack_final_user_module.hash.sha256:
@@ -9252,6 +9284,7 @@ threat.enrichments.indicator.file.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Object for all custom defined fields to live in.
   type: object
@@ -9678,6 +9711,7 @@ threat.enrichments.indicator.file.Ext.original:
   level: custom
   name: Ext.original
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Original file information during a modification event.
   type: object
@@ -9814,6 +9848,7 @@ threat.enrichments.indicator.file.Ext.windows:
   level: custom
   name: Ext.windows
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Platform-specific Windows fields
   type: object
@@ -11901,6 +11936,7 @@ threat.indicator.file.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Object for all custom defined fields to live in.
   type: object
@@ -12327,6 +12363,7 @@ threat.indicator.file.Ext.original:
   level: custom
   name: Ext.original
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Original file information during a modification event.
   type: object
@@ -12463,6 +12500,7 @@ threat.indicator.file.Ext.windows:
   level: custom
   name: Ext.windows
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Platform-specific Windows fields
   type: object
@@ -14561,6 +14599,7 @@ user.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 user.Ext.real:
@@ -14570,6 +14609,7 @@ user.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: User info prior to any setuid operations.
   type: object
 user.Ext.real.id:
@@ -14636,6 +14676,7 @@ user.group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Object for all custom defined fields to live in.
   type: object
@@ -14646,6 +14687,7 @@ user.group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Group info prior to any setgid operations.
   type: object

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -9478,6 +9478,18 @@ threat.enrichments.indicator.file.Ext.header_data:
   original_fieldset: file
   short: Header data
   type: text
+threat.enrichments.indicator.file.Ext.malware_classification.features:
+  dashed_name: threat-enrichments-indicator-file-Ext-malware-classification-features
+  description: The features extracted from this file and evaluated by the model.
+  enabled: false
+  flat_name: threat.enrichments.indicator.file.Ext.malware_classification.features
+  level: custom
+  name: features
+  normalize: []
+  object_type: keyword
+  original_fieldset: malware_classification
+  short: The features extracted from this file and evaluated by the model.
+  type: object
 threat.enrichments.indicator.file.Ext.malware_classification.features.data.buffer:
   dashed_name: threat-enrichments-indicator-file-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -12130,6 +12142,18 @@ threat.indicator.file.Ext.header_data:
   original_fieldset: file
   short: Header data
   type: text
+threat.indicator.file.Ext.malware_classification.features:
+  dashed_name: threat-indicator-file-Ext-malware-classification-features
+  description: The features extracted from this file and evaluated by the model.
+  enabled: false
+  flat_name: threat.indicator.file.Ext.malware_classification.features
+  level: custom
+  name: features
+  normalize: []
+  object_type: keyword
+  original_fieldset: malware_classification
+  short: The features extracted from this file and evaluated by the model.
+  type: object
 threat.indicator.file.Ext.malware_classification.features.data.buffer:
   dashed_name: threat-indicator-file-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually

--- a/schemas/v1/alerts/ransomware_event.yaml
+++ b/schemas/v1/alerts/ransomware_event.yaml
@@ -24,6 +24,7 @@ Endpoint.policy:
   level: custom
   name: policy
   normalize: []
+  object_type: keyword
   short: The policy fields are used to hold information about applied policy.
   type: object
 Endpoint.policy.applied:
@@ -33,6 +34,7 @@ Endpoint.policy.applied:
   level: custom
   name: policy.applied
   normalize: []
+  object_type: keyword
   short: information about the policy that is applied
   type: object
 Endpoint.policy.applied.artifacts:
@@ -43,6 +45,7 @@ Endpoint.policy.applied.artifacts:
   level: custom
   name: policy.applied.artifacts
   normalize: []
+  object_type: keyword
   short: information about protection artifacts applied.
   type: object
 Endpoint.policy.applied.artifacts.global:
@@ -52,6 +55,7 @@ Endpoint.policy.applied.artifacts.global:
   level: custom
   name: policy.applied.artifacts.global
   normalize: []
+  object_type: keyword
   short: information about global protection artifacts applied.
   type: object
 Endpoint.policy.applied.artifacts.global.identifiers:
@@ -100,6 +104,7 @@ Endpoint.policy.applied.artifacts.user:
   level: custom
   name: policy.applied.artifacts.user
   normalize: []
+  object_type: keyword
   short: information about user protection artifacts applied.
   type: object
 Endpoint.policy.applied.artifacts.user.identifiers:
@@ -755,6 +760,7 @@ dll.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 dll.Ext.code_signature:
@@ -1123,6 +1129,7 @@ elastic.agent:
   level: custom
   name: agent
   normalize: []
+  object_type: keyword
   short: The agent fields contain data about the Elastic Agent.
   type: object
 elastic.agent.id:
@@ -1823,6 +1830,7 @@ group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 group.Ext.real:
@@ -1832,6 +1840,7 @@ group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: Group info prior to any setgid operations.
   type: object
 group.Ext.real.id:
@@ -2124,6 +2133,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object
@@ -2289,6 +2299,7 @@ host.user.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: user
   short: Object for all custom defined fields to live in.
   type: object
@@ -2299,6 +2310,7 @@ host.user.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: user
   short: User info prior to any setuid operations.
   type: object
@@ -2371,6 +2383,7 @@ host.user.group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Object for all custom defined fields to live in.
   type: object
@@ -2381,6 +2394,7 @@ host.user.group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Group info prior to any setgid operations.
   type: object
@@ -2506,6 +2520,7 @@ process.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.Ext.ancestry:
@@ -3070,6 +3085,7 @@ process.parent.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
@@ -3172,6 +3188,7 @@ process.parent.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: The field set containing process info in case of any pid spoofing. This is
     mainly useful for process.parent.
@@ -3716,6 +3733,7 @@ process.thread.Ext:
   level: custom
   name: thread.Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.thread.Ext.call_stack:
@@ -3727,6 +3745,7 @@ process.thread.Ext.call_stack:
   level: custom
   name: call_stack
   normalize: []
+  object_type: keyword
   original_fieldset: call_stack
   short: Fields describing a stack frame.
   type: object
@@ -4374,6 +4393,7 @@ threat.enrichments.indicator.file.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Object for all custom defined fields to live in.
   type: object
@@ -4800,6 +4820,7 @@ threat.enrichments.indicator.file.Ext.original:
   level: custom
   name: Ext.original
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Original file information during a modification event.
   type: object
@@ -4936,6 +4957,7 @@ threat.enrichments.indicator.file.Ext.windows:
   level: custom
   name: Ext.windows
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Platform-specific Windows fields
   type: object
@@ -7023,6 +7045,7 @@ threat.indicator.file.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Object for all custom defined fields to live in.
   type: object
@@ -7449,6 +7472,7 @@ threat.indicator.file.Ext.original:
   level: custom
   name: Ext.original
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Original file information during a modification event.
   type: object
@@ -7585,6 +7609,7 @@ threat.indicator.file.Ext.windows:
   level: custom
   name: Ext.windows
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Platform-specific Windows fields
   type: object
@@ -9683,6 +9708,7 @@ user.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 user.Ext.real:
@@ -9692,6 +9718,7 @@ user.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: User info prior to any setuid operations.
   type: object
 user.Ext.real.id:
@@ -9758,6 +9785,7 @@ user.group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Object for all custom defined fields to live in.
   type: object
@@ -9768,6 +9796,7 @@ user.group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Group info prior to any setgid operations.
   type: object

--- a/schemas/v1/alerts/ransomware_event.yaml
+++ b/schemas/v1/alerts/ransomware_event.yaml
@@ -4587,6 +4587,18 @@ threat.enrichments.indicator.file.Ext.header_data:
   original_fieldset: file
   short: Header data
   type: text
+threat.enrichments.indicator.file.Ext.malware_classification.features:
+  dashed_name: threat-enrichments-indicator-file-Ext-malware-classification-features
+  description: The features extracted from this file and evaluated by the model.
+  enabled: false
+  flat_name: threat.enrichments.indicator.file.Ext.malware_classification.features
+  level: custom
+  name: features
+  normalize: []
+  object_type: keyword
+  original_fieldset: malware_classification
+  short: The features extracted from this file and evaluated by the model.
+  type: object
 threat.enrichments.indicator.file.Ext.malware_classification.features.data.buffer:
   dashed_name: threat-enrichments-indicator-file-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -7239,6 +7251,18 @@ threat.indicator.file.Ext.header_data:
   original_fieldset: file
   short: Header data
   type: text
+threat.indicator.file.Ext.malware_classification.features:
+  dashed_name: threat-indicator-file-Ext-malware-classification-features
+  description: The features extracted from this file and evaluated by the model.
+  enabled: false
+  flat_name: threat.indicator.file.Ext.malware_classification.features
+  level: custom
+  name: features
+  normalize: []
+  object_type: keyword
+  original_fieldset: malware_classification
+  short: The features extracted from this file and evaluated by the model.
+  type: object
 threat.indicator.file.Ext.malware_classification.features.data.buffer:
   dashed_name: threat-indicator-file-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually

--- a/schemas/v1/alerts/rule_detection_event.yaml
+++ b/schemas/v1/alerts/rule_detection_event.yaml
@@ -24,6 +24,7 @@ Events:
   level: custom
   name: Events
   normalize: []
+  object_type: keyword
   short: events array
   type: object
 Responses.@timestamp:
@@ -121,6 +122,7 @@ Responses.action.key.values:
   level: custom
   name: action.key.values
   normalize: []
+  object_type: keyword
   short: Values modified
   type: object
 Responses.action.key.values.actions:
@@ -591,6 +593,7 @@ threat.enrichments.indicator.file.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Object for all custom defined fields to live in.
   type: object
@@ -1017,6 +1020,7 @@ threat.enrichments.indicator.file.Ext.original:
   level: custom
   name: Ext.original
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Original file information during a modification event.
   type: object
@@ -1153,6 +1157,7 @@ threat.enrichments.indicator.file.Ext.windows:
   level: custom
   name: Ext.windows
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Platform-specific Windows fields
   type: object
@@ -3240,6 +3245,7 @@ threat.indicator.file.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Object for all custom defined fields to live in.
   type: object
@@ -3666,6 +3672,7 @@ threat.indicator.file.Ext.original:
   level: custom
   name: Ext.original
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Original file information during a modification event.
   type: object
@@ -3802,6 +3809,7 @@ threat.indicator.file.Ext.windows:
   level: custom
   name: Ext.windows
   normalize: []
+  object_type: keyword
   original_fieldset: file
   short: Platform-specific Windows fields
   type: object

--- a/schemas/v1/alerts/rule_detection_event.yaml
+++ b/schemas/v1/alerts/rule_detection_event.yaml
@@ -787,6 +787,18 @@ threat.enrichments.indicator.file.Ext.header_data:
   original_fieldset: file
   short: Header data
   type: text
+threat.enrichments.indicator.file.Ext.malware_classification.features:
+  dashed_name: threat-enrichments-indicator-file-Ext-malware-classification-features
+  description: The features extracted from this file and evaluated by the model.
+  enabled: false
+  flat_name: threat.enrichments.indicator.file.Ext.malware_classification.features
+  level: custom
+  name: features
+  normalize: []
+  object_type: keyword
+  original_fieldset: malware_classification
+  short: The features extracted from this file and evaluated by the model.
+  type: object
 threat.enrichments.indicator.file.Ext.malware_classification.features.data.buffer:
   dashed_name: threat-enrichments-indicator-file-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually
@@ -3439,6 +3451,18 @@ threat.indicator.file.Ext.header_data:
   original_fieldset: file
   short: Header data
   type: text
+threat.indicator.file.Ext.malware_classification.features:
+  dashed_name: threat-indicator-file-Ext-malware-classification-features
+  description: The features extracted from this file and evaluated by the model.
+  enabled: false
+  flat_name: threat.indicator.file.Ext.malware_classification.features
+  level: custom
+  name: features
+  normalize: []
+  object_type: keyword
+  original_fieldset: malware_classification
+  short: The features extracted from this file and evaluated by the model.
+  type: object
 threat.indicator.file.Ext.malware_classification.features.data.buffer:
   dashed_name: threat-indicator-file-Ext-malware-classification-features-data-buffer
   description: The features extracted from this file and evaluated by the model.  Usually

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -24,6 +24,7 @@ Target.process.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
@@ -775,6 +776,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object
@@ -956,6 +958,7 @@ process.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.Ext.ancestry:
@@ -1016,6 +1019,7 @@ process.Ext.api.metadata:
   level: custom
   name: metadata
   normalize: []
+  object_type: keyword
   original_fieldset: api
   short: Information related to the API call.
   type: object
@@ -1062,6 +1066,7 @@ process.Ext.api.parameters:
   level: custom
   name: parameters
   normalize: []
+  object_type: keyword
   original_fieldset: api
   short: Parameter values passed to the API call.
   type: object
@@ -1719,6 +1724,7 @@ process.thread.Ext:
   level: custom
   name: thread.Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.thread.Ext.call_stack:
@@ -1730,6 +1736,7 @@ process.thread.Ext.call_stack:
   level: custom
   name: call_stack
   normalize: []
+  object_type: keyword
   original_fieldset: call_stack
   short: Fields describing a stack frame.
   type: object
@@ -1925,6 +1932,7 @@ process.thread.Ext.call_stack_final_user_module.hash:
   level: custom
   name: thread.Ext.call_stack_final_user_module.hash
   normalize: []
+  object_type: keyword
   short: Hashes of the call_stack_final_user_module.
   type: object
 process.thread.Ext.call_stack_final_user_module.hash.sha256:

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -1032,6 +1032,7 @@ file.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 file.Ext.device.bus_type:
@@ -1285,6 +1286,7 @@ file.Ext.original:
   level: custom
   name: Ext.original
   normalize: []
+  object_type: keyword
   short: Original file information during a modification event.
   type: object
 file.Ext.original.gid:
@@ -1368,6 +1370,7 @@ file.Ext.windows:
   level: custom
   name: Ext.windows
   normalize: []
+  object_type: keyword
   short: Platform-specific Windows fields
   type: object
 file.Ext.windows.zone_identifier:
@@ -1772,6 +1775,7 @@ group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 group.Ext.real:
@@ -1781,6 +1785,7 @@ group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: Group info prior to any setgid operations.
   type: object
 group.Ext.real.id:
@@ -1933,6 +1938,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object
@@ -2114,6 +2120,7 @@ process.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.Ext.ancestry:
@@ -2534,6 +2541,7 @@ process.thread.Ext:
   level: custom
   name: thread.Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.thread.Ext.call_stack:
@@ -2545,6 +2553,7 @@ process.thread.Ext.call_stack:
   level: custom
   name: call_stack
   normalize: []
+  object_type: keyword
   original_fieldset: call_stack
   short: Fields describing a stack frame.
   type: object
@@ -2775,6 +2784,7 @@ user.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 user.Ext.real:
@@ -2784,6 +2794,7 @@ user.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: User info prior to any setuid operations.
   type: object
 user.Ext.real.id:
@@ -2850,6 +2861,7 @@ user.group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Object for all custom defined fields to live in.
   type: object
@@ -2860,6 +2872,7 @@ user.group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Group info prior to any setgid operations.
   type: object

--- a/schemas/v1/file/unquarantine.yaml
+++ b/schemas/v1/file/unquarantine.yaml
@@ -251,6 +251,7 @@ event.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 event.Ext.correlation:
@@ -260,6 +261,7 @@ event.Ext.correlation:
   level: custom
   name: Ext.correlation
   normalize: []
+  object_type: keyword
   short: Information about event this should be correlated with.
   type: object
 event.Ext.correlation.id:
@@ -898,6 +900,7 @@ file.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 file.Ext.original:
@@ -907,6 +910,7 @@ file.Ext.original:
   level: custom
   name: Ext.original
   normalize: []
+  object_type: keyword
   short: Original file information during a modification event.
   type: object
 file.Ext.original.path:
@@ -1070,6 +1074,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -277,6 +277,7 @@ dll.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 dll.Ext.code_signature:
@@ -1440,6 +1441,7 @@ file.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 file.Ext.code_signature:
@@ -1772,6 +1774,7 @@ group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 group.Ext.real:
@@ -1781,6 +1784,7 @@ group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: Group info prior to any setgid operations.
   type: object
 group.Ext.real.id:
@@ -1933,6 +1937,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object
@@ -2114,6 +2119,7 @@ process.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.Ext.ancestry:
@@ -2377,6 +2383,7 @@ process.thread.Ext:
   level: custom
   name: thread.Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.thread.Ext.call_stack:
@@ -2388,6 +2395,7 @@ process.thread.Ext.call_stack:
   level: custom
   name: call_stack
   normalize: []
+  object_type: keyword
   original_fieldset: call_stack
   short: Fields describing a stack frame.
   type: object
@@ -2618,6 +2626,7 @@ user.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 user.Ext.real:
@@ -2627,6 +2636,7 @@ user.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: User info prior to any setuid operations.
   type: object
 user.Ext.real.id:
@@ -2693,6 +2703,7 @@ user.group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Object for all custom defined fields to live in.
   type: object
@@ -2703,6 +2714,7 @@ user.group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Group info prior to any setgid operations.
   type: object

--- a/schemas/v1/metadata/metadata.yaml
+++ b/schemas/v1/metadata/metadata.yaml
@@ -37,6 +37,7 @@ Endpoint.configuration:
   level: custom
   name: configuration
   normalize: []
+  object_type: keyword
   short: Configuration fields represent the intended and applied setting for fields
     not part of a Policy setting This reflects what a given field is configured to
     do. The actual state of that same field is found in Endpoint.state
@@ -57,6 +58,7 @@ Endpoint.policy:
   level: custom
   name: policy
   normalize: []
+  object_type: keyword
   short: The policy fields are used to hold information about applied policy.
   type: object
 Endpoint.policy.applied:
@@ -66,6 +68,7 @@ Endpoint.policy.applied:
   level: custom
   name: policy.applied
   normalize: []
+  object_type: keyword
   short: information about the policy that is applied
   type: object
 Endpoint.policy.applied.id:
@@ -107,6 +110,7 @@ Endpoint.state:
   level: custom
   name: state
   normalize: []
+  object_type: keyword
   short: Represents the current state of a non-policy setting These fields reflect
     the current status of a field, which may differ from what it is configured to
     be (see Endpoint.configuration)
@@ -240,6 +244,7 @@ elastic.agent:
   level: custom
   name: agent
   normalize: []
+  object_type: keyword
   short: The agent fields contain data about the Elastic Agent.
   type: object
 elastic.agent.id:
@@ -1032,6 +1037,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -24,6 +24,7 @@ Endpoint.metrics:
   level: custom
   name: metrics
   normalize: []
+  object_type: keyword
   short: Metrics fields hold the endpoint and system's performance metrics
   type: object
 Endpoint.metrics.cpu:
@@ -33,6 +34,7 @@ Endpoint.metrics.cpu:
   level: custom
   name: metrics.cpu
   normalize: []
+  object_type: keyword
   short: CPU statistics
   type: object
 Endpoint.metrics.cpu.endpoint:
@@ -42,6 +44,7 @@ Endpoint.metrics.cpu.endpoint:
   level: custom
   name: metrics.cpu.endpoint
   normalize: []
+  object_type: keyword
   short: CPU metrics for the endpoint
   type: object
 Endpoint.metrics.cpu.endpoint.histogram:
@@ -82,6 +85,7 @@ Endpoint.metrics.disks:
   level: custom
   name: metrics.disks
   normalize: []
+  object_type: keyword
   short: An array of disk information for the host
   type: object
 Endpoint.metrics.disks.device:
@@ -150,6 +154,7 @@ Endpoint.metrics.documents_volume:
   level: custom
   name: metrics.documents_volume
   normalize: []
+  object_type: keyword
   short: Statistics about sent documents
   type: object
 Endpoint.metrics.documents_volume.alerts.sent_bytes:
@@ -213,6 +218,7 @@ Endpoint.metrics.documents_volume.api_events.sources:
   level: custom
   name: metrics.documents_volume.api_events.sources
   normalize: []
+  object_type: keyword
   short: An array of API Event document statistics per source
   type: object
 Endpoint.metrics.documents_volume.api_events.sources.sent_bytes:
@@ -633,6 +639,7 @@ Endpoint.metrics.malicious_behavior_rules:
   level: custom
   name: metrics.malicious_behavior_rules
   normalize: []
+  object_type: keyword
   short: An array of performance information about each malicious behavior rule
   type: object
 Endpoint.metrics.malicious_behavior_rules.endpoint_uptime_percent:
@@ -664,6 +671,7 @@ Endpoint.metrics.memory:
   level: custom
   name: metrics.memory
   normalize: []
+  object_type: keyword
   short: Memory statistics
   type: object
 Endpoint.metrics.memory.endpoint:
@@ -673,6 +681,7 @@ Endpoint.metrics.memory.endpoint:
   level: custom
   name: metrics.memory.endpoint
   normalize: []
+  object_type: keyword
   short: Endpoint memory utilization
   type: object
 Endpoint.metrics.memory.endpoint.private:
@@ -682,6 +691,7 @@ Endpoint.metrics.memory.endpoint.private:
   level: custom
   name: metrics.memory.endpoint.private
   normalize: []
+  object_type: keyword
   short: The memory private to the endpoint
   type: object
 Endpoint.metrics.memory.endpoint.private.latest:
@@ -712,6 +722,7 @@ Endpoint.metrics.system_impact:
   level: custom
   name: metrics.system_impact
   normalize: []
+  object_type: keyword
   short: An array of system impact information
   type: object
 Endpoint.metrics.system_impact.authentication_events.week_idle_ms:
@@ -1129,6 +1140,7 @@ Endpoint.metrics.threads:
   level: custom
   name: metrics.threads
   normalize: []
+  object_type: keyword
   short: Statistics about the individual Endpoint threads (array)
   type: object
 Endpoint.metrics.threads.cpu.mean:
@@ -1160,6 +1172,7 @@ Endpoint.metrics.uptime:
   level: custom
   name: metrics.uptime
   normalize: []
+  object_type: keyword
   short: Number of seconds since boot
   type: object
 Endpoint.metrics.uptime.endpoint:
@@ -2068,6 +2081,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object

--- a/schemas/v1/network/network.yaml
+++ b/schemas/v1/network/network.yaml
@@ -365,6 +365,7 @@ dns.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 dns.Ext.options:
@@ -1183,6 +1184,7 @@ group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 group.Ext.real:
@@ -1192,6 +1194,7 @@ group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: Group info prior to any setgid operations.
   type: object
 group.Ext.real.id:
@@ -1344,6 +1347,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object
@@ -1545,6 +1549,7 @@ http.response.Ext:
   level: custom
   name: response.Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 http.response.Ext.version:
@@ -1755,6 +1760,7 @@ process.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.Ext.ancestry:
@@ -2420,6 +2426,7 @@ user.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 user.Ext.real:
@@ -2429,6 +2436,7 @@ user.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: User info prior to any setuid operations.
   type: object
 user.Ext.real.id:
@@ -2495,6 +2503,7 @@ user.group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Object for all custom defined fields to live in.
   type: object
@@ -2505,6 +2514,7 @@ user.group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Group info prior to any setgid operations.
   type: object

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -26,6 +26,7 @@ Endpoint.configuration:
   level: custom
   name: configuration
   normalize: []
+  object_type: keyword
   short: Configuration fields represent the intended and applied setting for fields
     not part of a Policy setting This reflects what a given field is configured to
     do. The actual state of that same field is found in Endpoint.state
@@ -46,6 +47,7 @@ Endpoint.policy:
   level: custom
   name: policy
   normalize: []
+  object_type: keyword
   short: The policy fields are used to hold information about applied policy.
   type: object
 Endpoint.policy.applied:
@@ -55,6 +57,7 @@ Endpoint.policy.applied:
   level: custom
   name: policy.applied
   normalize: []
+  object_type: keyword
   short: information about the policy that is applied
   type: object
 Endpoint.policy.applied.actions:
@@ -107,6 +110,7 @@ Endpoint.policy.applied.artifacts:
   level: custom
   name: policy.applied.artifacts
   normalize: []
+  object_type: keyword
   short: information about protection artifacts applied.
   type: object
 Endpoint.policy.applied.artifacts.global:
@@ -116,6 +120,7 @@ Endpoint.policy.applied.artifacts.global:
   level: custom
   name: policy.applied.artifacts.global
   normalize: []
+  object_type: keyword
   short: information about global protection artifacts applied.
   type: object
 Endpoint.policy.applied.artifacts.global.identifiers:
@@ -164,6 +169,7 @@ Endpoint.policy.applied.artifacts.user:
   level: custom
   name: policy.applied.artifacts.user
   normalize: []
+  object_type: keyword
   short: information about user protection artifacts applied.
   type: object
 Endpoint.policy.applied.artifacts.user.identifiers:
@@ -243,6 +249,7 @@ Endpoint.policy.applied.response:
   level: custom
   name: policy.applied.response
   normalize: []
+  object_type: keyword
   short: the response of actions that failed in the applied policy
   type: object
 Endpoint.policy.applied.response.configurations:
@@ -253,6 +260,7 @@ Endpoint.policy.applied.response.configurations:
   level: custom
   name: policy.applied.response.configurations
   normalize: []
+  object_type: keyword
   short: the configurations of the applied policy
   type: object
 Endpoint.policy.applied.response.configurations.antivirus_registration:
@@ -264,6 +272,7 @@ Endpoint.policy.applied.response.configurations.antivirus_registration:
   level: custom
   name: policy.applied.response.configurations.antivirus_registration
   normalize: []
+  object_type: keyword
   short: overall antivirus registration configuration and status of the applied policy
   type: object
 Endpoint.policy.applied.response.configurations.antivirus_registration.concerned_actions:
@@ -336,6 +345,7 @@ Endpoint.policy.applied.response.configurations.events:
   level: custom
   name: policy.applied.response.configurations.events
   normalize: []
+  object_type: keyword
   short: overall event collection configuration and status of the applied policy
   type: object
 Endpoint.policy.applied.response.configurations.events.concerned_actions:
@@ -387,6 +397,7 @@ Endpoint.policy.applied.response.configurations.logging:
   level: custom
   name: policy.applied.response.configurations.logging
   normalize: []
+  object_type: keyword
   short: overall logging configuration and status of the applied policy
   type: object
 Endpoint.policy.applied.response.configurations.logging.concerned_actions:
@@ -417,6 +428,7 @@ Endpoint.policy.applied.response.configurations.malware:
   level: custom
   name: policy.applied.response.configurations.malware
   normalize: []
+  object_type: keyword
   short: overall malware configuration and status of the applied policy
   type: object
 Endpoint.policy.applied.response.configurations.malware.concerned_actions:
@@ -447,6 +459,7 @@ Endpoint.policy.applied.response.configurations.memory_protection:
   level: custom
   name: policy.applied.response.configurations.memory_protection
   normalize: []
+  object_type: keyword
   short: overall memory_protection configuration and status of the applied policy
   type: object
 Endpoint.policy.applied.response.configurations.memory_protection.concerned_actions:
@@ -498,6 +511,7 @@ Endpoint.policy.applied.response.configurations.streaming:
   level: custom
   name: policy.applied.response.configurations.streaming
   normalize: []
+  object_type: keyword
   short: overall data streaming configuration and status of the applied policy
   type: object
 Endpoint.policy.applied.response.configurations.streaming.concerned_actions:
@@ -529,6 +543,7 @@ Endpoint.policy.applied.response.diagnostic:
   level: custom
   name: policy.applied.response.diagnostic
   normalize: []
+  object_type: keyword
   short: the diagnostic configurations of the applied policy
   type: object
 Endpoint.policy.applied.response.diagnostic.behavior_protection.concerned_actions:
@@ -698,6 +713,7 @@ Endpoint.state:
   level: custom
   name: state
   normalize: []
+  object_type: keyword
   short: Represents the current state of a non-policy setting These fields reflect
     the current status of a field, which may differ from what it is configured to
     be (see Endpoint.configuration)
@@ -1578,6 +1594,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object

--- a/schemas/v1/process/linux_event_model_event.yaml
+++ b/schemas/v1/process/linux_event_model_event.yaml
@@ -939,6 +939,7 @@ process.entry_leader.tty:
   level: extended
   name: tty
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Information about the controlling TTY device.
   type: object
@@ -1404,6 +1405,7 @@ process.group_leader.tty:
   level: extended
   name: tty
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Information about the controlling TTY device.
   type: object
@@ -1516,6 +1518,7 @@ process.io:
   level: extended
   name: io
   normalize: []
+  object_type: keyword
   short: A chunk of input or output (IO) from a single process.
   type: object
 process.io.max_bytes_per_process_exceeded:
@@ -1951,6 +1954,7 @@ process.parent.tty:
   level: extended
   name: tty
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Information about the controlling TTY device.
   type: object
@@ -2629,6 +2633,7 @@ process.session_leader.tty:
   level: extended
   name: tty
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Information about the controlling TTY device.
   type: object
@@ -2750,6 +2755,7 @@ process.tty:
   level: extended
   name: tty
   normalize: []
+  object_type: keyword
   short: Information about the controlling TTY device.
   type: object
 process.tty.char_device.major:

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -931,6 +931,7 @@ group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 group.Ext.real:
@@ -940,6 +941,7 @@ group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: Group info prior to any setgid operations.
   type: object
 group.Ext.real.id:
@@ -1092,6 +1094,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object
@@ -1284,6 +1287,7 @@ process.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.Ext.ancestry:
@@ -1498,6 +1502,7 @@ process.Ext.dll.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: dll
   short: Object for all custom defined fields to live in.
   type: object
@@ -2109,6 +2114,7 @@ process.parent.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
@@ -2223,6 +2229,7 @@ process.parent.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: The field set containing process info in case of any pid spoofing. This is
     mainly useful for process.parent.
@@ -2647,6 +2654,7 @@ process.parent.thread.Ext:
   level: custom
   name: thread.Ext
   normalize: []
+  object_type: keyword
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
@@ -2659,6 +2667,7 @@ process.parent.thread.Ext.call_stack:
   level: custom
   name: call_stack
   normalize: []
+  object_type: keyword
   original_fieldset: call_stack
   short: Fields describing a stack frame.
   type: object
@@ -3175,6 +3184,7 @@ user.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 user.Ext.real:
@@ -3184,6 +3194,7 @@ user.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: User info prior to any setuid operations.
   type: object
 user.Ext.real.id:
@@ -3250,6 +3261,7 @@ user.group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Object for all custom defined fields to live in.
   type: object
@@ -3260,6 +3272,7 @@ user.group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Group info prior to any setgid operations.
   type: object

--- a/schemas/v1/registry/registry.yaml
+++ b/schemas/v1/registry/registry.yaml
@@ -974,6 +974,7 @@ group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 group.Ext.real:
@@ -983,6 +984,7 @@ group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: Group info prior to any setgid operations.
   type: object
 group.Ext.real.id:
@@ -1135,6 +1137,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object
@@ -1316,6 +1319,7 @@ process.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.Ext.ancestry:
@@ -1579,6 +1583,7 @@ process.thread.Ext:
   level: custom
   name: thread.Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.thread.Ext.call_stack:
@@ -1590,6 +1595,7 @@ process.thread.Ext.call_stack:
   level: custom
   name: call_stack
   normalize: []
+  object_type: keyword
   original_fieldset: call_stack
   short: Fields describing a stack frame.
   type: object
@@ -1908,6 +1914,7 @@ user.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 user.Ext.real:
@@ -1917,6 +1924,7 @@ user.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: User info prior to any setuid operations.
   type: object
 user.Ext.real.id:
@@ -1983,6 +1991,7 @@ user.group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Object for all custom defined fields to live in.
   type: object
@@ -1993,6 +2002,7 @@ user.group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Group info prior to any setgid operations.
   type: object

--- a/schemas/v1/security/security.yaml
+++ b/schemas/v1/security/security.yaml
@@ -931,6 +931,7 @@ group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 group.Ext.real:
@@ -940,6 +941,7 @@ group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: Group info prior to any setgid operations.
   type: object
 group.Ext.real.id:
@@ -1092,6 +1094,7 @@ host.os.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: os
   short: Object for all custom defined fields to live in.
   type: object
@@ -1273,6 +1276,7 @@ process.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 process.Ext.ancestry:
@@ -1687,6 +1691,7 @@ user.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   short: Object for all custom defined fields to live in.
   type: object
 user.Ext.real:
@@ -1696,6 +1701,7 @@ user.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   short: User info prior to any setuid operations.
   type: object
 user.Ext.real.id:
@@ -1762,6 +1768,7 @@ user.group.Ext:
   level: custom
   name: Ext
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Object for all custom defined fields to live in.
   type: object
@@ -1772,6 +1779,7 @@ user.group.Ext.real:
   level: custom
   name: Ext.real
   normalize: []
+  object_type: keyword
   original_fieldset: group
   short: Group info prior to any setgid operations.
   type: object


### PR DESCRIPTION
## Change Summary

for any field marked `type: object`, it must have the accompanying setting `object_type` per [package-spec](https://github.com/elastic/package-spec/pull/628). 

This sets all of our objects to `keyword`. 


### Sample values
N/A

Sample document:

N/A

## Release Target

8.12


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [x] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [] If this is a `metadata` change, I also updated both transform destination schemas to match 
^^ ????

### For Transform changes:

- ~~[ ] The new transform successfully starts in Kibana~~
- ~~[ ] The corresponding transform destination schema was updated if necessary~~
