### PR TITLE
Add memory_region to api events

### DIFF
--- a/custom_subsets/elastic_endpoint/api/api.yaml
+++ b/custom_subsets/elastic_endpoint/api/api.yaml
@@ -61,6 +61,8 @@ fields:
           entity_id: {}
           Ext:
             fields:
+              memory_region:
+                fields: "*"
               token:
                 fields:
                   integrity_level_name: {}
@@ -86,6 +88,8 @@ fields:
                 fields: "*"
               parameters:
                 fields: "*"
+          memory_region:
+            fields: "*"
           token:
             fields:
               integrity_level_name: {}

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -36,6 +36,718 @@
       object_type: keyword
       description: Object for all custom defined fields to live in.
       default_field: false
+    - name: process.Ext.memory_region.allocation_base
+      level: custom
+      type: unsigned_long
+      description: Base address of the memory allocation containing the memory region.
+      example: 2431737462784
+      default_field: false
+    - name: process.Ext.memory_region.allocation_protection
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Original memory protection requested when the memory was allocated. Example values include "RWX" and "R-X".
+      example: RWX
+      default_field: false
+    - name: process.Ext.memory_region.allocation_size
+      level: custom
+      type: unsigned_long
+      description: Original memory size requested when the memory was allocated.
+      example: 4096
+      default_field: false
+    - name: process.Ext.memory_region.allocation_type
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The memory allocation type. Example values include "IMAGE", "MAPPED", and "PRIVATE".
+      example: PRIVATE
+      default_field: false
+    - name: process.Ext.memory_region.bytes_address
+      level: custom
+      type: unsigned_long
+      description: The address where bytes_compressed begins.
+      example: 2431737462784
+      default_field: false
+    - name: process.Ext.memory_region.bytes_allocation_offset
+      level: custom
+      type: unsigned_long
+      description: Offset of bytes_address the memory allocation. Equal to bytes_address - allocation_base.
+      example: 0
+      default_field: false
+    - name: process.Ext.memory_region.bytes_compressed
+      level: custom
+      type: keyword
+      description: Up to 4MB of raw data from the memory allocation. This is compressed with zlib.To reduce data volume, this is de-duplicated on the endpoint, and may be missing from many alerts if the same data would be sent multiple times.
+      example: eJzzSM3JyVcIzy/KSVEEABxJBD4=
+      index: false
+      doc_values: false
+      default_field: false
+    - name: process.Ext.memory_region.bytes_compressed_present
+      level: custom
+      type: boolean
+      description: Whether bytes_compressed is present in this event.
+      example: false
+      default_field: false
+    - name: process.Ext.memory_region.hash.sha256
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The sha256 of the memory region.
+      example: d25ff1e6c6460a7f9de39198d182058c1712726008d187e1953b83abe977e4a0
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.all_names
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: A sequence of signature names matched.
+      example: Windows.EICAR.Not-a-virus
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.identifier
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: malware signature identifier
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.primary
+      level: custom
+      type: object
+      object_type: keyword
+      description: The first matching details.
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.primary.matches
+      level: custom
+      type: keyword
+      description: The first matching details.
+      index: false
+      doc_values: false
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.primary.signature.hash
+      level: custom
+      type: nested
+      description: hash of file matching signature.
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.primary.signature.hash.sha256
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: sha256 hash of file matching signature.
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.primary.signature.id
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The id of the first yara rule matched.
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.primary.signature.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The name of the first yara rule matched.
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.secondary
+      level: custom
+      type: nested
+      description: Additional matching details if available.
+      enabled: false
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.version
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: malware signature version
+      default_field: false
+    - name: process.Ext.memory_region.mapped_path
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: If the memory corresponds to a file mapping, this is the file's path.
+      example: C:\Windows\System32\mshtml.dll
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.dotnet
+      level: custom
+      type: boolean
+      description: Whether this file is a .NET PE
+      example: 'true'
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.sections
+      level: custom
+      type: object
+      object_type: keyword
+      description: The file's relevant sections, if it is a PE
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha384
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA384 hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.tlsh
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: TLSH hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.sections.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The section's name
+      example: .reloc
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.streams
+      level: custom
+      type: object
+      object_type: keyword
+      description: The file's streams, if it is a PE
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha384
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA384 hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.tlsh
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: TLSH hash.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.Ext.streams.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The stream's name
+      example: .reloc
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU architecture target for the file.
+      example: x64
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.company
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.file_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the Go language imports in a PE file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).'
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.imphash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+      example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names and types.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported element names and types.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.original_file_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.pehash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the PE header and data from one or more PE sections. An pehash can be used to cluster files by transforming structural information about a file into a hash value.
+
+        Learn more at https://www.usenix.org/legacy/events/leet09/tech/full_papers/wicherski/wicherski_html/index.html.'
+      example: 73ff189b63cd6be375a7ff25179a38d347651975
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.product
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft® Windows® Operating System"
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields underneath `pe.sections.*`.'
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      default_field: false
+    - name: process.Ext.memory_region.mapped_pe_detected
+      level: custom
+      type: boolean
+      description: Whether the file at mapped_path is an executable.
+      example: false
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.dotnet
+      level: custom
+      type: boolean
+      description: Whether this file is a .NET PE
+      example: 'true'
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.sections
+      level: custom
+      type: object
+      object_type: keyword
+      description: The file's relevant sections, if it is a PE
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.sections.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.sections.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.sections.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.sections.hash.sha384
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA384 hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.sections.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.sections.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.sections.hash.tlsh
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: TLSH hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.sections.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The section's name
+      example: .reloc
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.streams
+      level: custom
+      type: object
+      object_type: keyword
+      description: The file's streams, if it is a PE
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.streams.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.streams.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.streams.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.streams.hash.sha384
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA384 hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.streams.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.streams.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.streams.hash.tlsh
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: TLSH hash.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.Ext.streams.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The stream's name
+      example: .reloc
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU architecture target for the file.
+      example: x64
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.company
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.file_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the Go language imports in a PE file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).'
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.imphash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+      example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names and types.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported element names and types.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.original_file_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.pehash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the PE header and data from one or more PE sections. An pehash can be used to cluster files by transforming structural information about a file into a hash value.
+
+        Learn more at https://www.usenix.org/legacy/events/leet09/tech/full_papers/wicherski/wicherski_html/index.html.'
+      example: 73ff189b63cd6be375a7ff25179a38d347651975
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.product
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft® Windows® Operating System"
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields underneath `pe.sections.*`.'
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      default_field: false
+    - name: process.Ext.memory_region.memory_pe_detected
+      level: custom
+      type: boolean
+      description: Whether an executable file was found in memory.
+      example: false
+      default_field: false
+    - name: process.Ext.memory_region.region_base
+      level: custom
+      type: unsigned_long
+      description: Base address of the memory region.
+      example: 2431737462784
+      default_field: false
+    - name: process.Ext.memory_region.region_protection
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Memory protection of the memory region. Example values include "RWX" and "R-X".
+      example: RWX
+      default_field: false
+    - name: process.Ext.memory_region.region_size
+      level: custom
+      type: unsigned_long
+      description: Size of the memory region.
+      example: 4096
+      default_field: false
+    - name: process.Ext.memory_region.region_state
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: State of the memory region. Example values include "RESERVE", "COMMIT", and "FREE".
+      example: COMMIT
+      default_field: false
+    - name: process.Ext.memory_region.strings
+      level: custom
+      type: keyword
+      description: Array of strings found within the memory region.
+      index: false
+      doc_values: false
+      default_field: false
     - name: process.Ext.token.integrity_level_name
       level: custom
       type: keyword
@@ -697,6 +1409,718 @@
 
         Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
       example: 'true'
+      default_field: false
+    - name: Ext.memory_region.allocation_base
+      level: custom
+      type: unsigned_long
+      description: Base address of the memory allocation containing the memory region.
+      example: 2431737462784
+      default_field: false
+    - name: Ext.memory_region.allocation_protection
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Original memory protection requested when the memory was allocated. Example values include "RWX" and "R-X".
+      example: RWX
+      default_field: false
+    - name: Ext.memory_region.allocation_size
+      level: custom
+      type: unsigned_long
+      description: Original memory size requested when the memory was allocated.
+      example: 4096
+      default_field: false
+    - name: Ext.memory_region.allocation_type
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The memory allocation type. Example values include "IMAGE", "MAPPED", and "PRIVATE".
+      example: PRIVATE
+      default_field: false
+    - name: Ext.memory_region.bytes_address
+      level: custom
+      type: unsigned_long
+      description: The address where bytes_compressed begins.
+      example: 2431737462784
+      default_field: false
+    - name: Ext.memory_region.bytes_allocation_offset
+      level: custom
+      type: unsigned_long
+      description: Offset of bytes_address the memory allocation. Equal to bytes_address - allocation_base.
+      example: 0
+      default_field: false
+    - name: Ext.memory_region.bytes_compressed
+      level: custom
+      type: keyword
+      description: Up to 4MB of raw data from the memory allocation. This is compressed with zlib.To reduce data volume, this is de-duplicated on the endpoint, and may be missing from many alerts if the same data would be sent multiple times.
+      example: eJzzSM3JyVcIzy/KSVEEABxJBD4=
+      index: false
+      doc_values: false
+      default_field: false
+    - name: Ext.memory_region.bytes_compressed_present
+      level: custom
+      type: boolean
+      description: Whether bytes_compressed is present in this event.
+      example: false
+      default_field: false
+    - name: Ext.memory_region.hash.sha256
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The sha256 of the memory region.
+      example: d25ff1e6c6460a7f9de39198d182058c1712726008d187e1953b83abe977e4a0
+      default_field: false
+    - name: Ext.memory_region.malware_signature.all_names
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: A sequence of signature names matched.
+      example: Windows.EICAR.Not-a-virus
+      default_field: false
+    - name: Ext.memory_region.malware_signature.identifier
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: malware signature identifier
+      default_field: false
+    - name: Ext.memory_region.malware_signature.primary
+      level: custom
+      type: object
+      object_type: keyword
+      description: The first matching details.
+      default_field: false
+    - name: Ext.memory_region.malware_signature.primary.matches
+      level: custom
+      type: keyword
+      description: The first matching details.
+      index: false
+      doc_values: false
+      default_field: false
+    - name: Ext.memory_region.malware_signature.primary.signature.hash
+      level: custom
+      type: nested
+      description: hash of file matching signature.
+      default_field: false
+    - name: Ext.memory_region.malware_signature.primary.signature.hash.sha256
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: sha256 hash of file matching signature.
+      default_field: false
+    - name: Ext.memory_region.malware_signature.primary.signature.id
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The id of the first yara rule matched.
+      default_field: false
+    - name: Ext.memory_region.malware_signature.primary.signature.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The name of the first yara rule matched.
+      default_field: false
+    - name: Ext.memory_region.malware_signature.secondary
+      level: custom
+      type: nested
+      description: Additional matching details if available.
+      enabled: false
+      default_field: false
+    - name: Ext.memory_region.malware_signature.version
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: malware signature version
+      default_field: false
+    - name: Ext.memory_region.mapped_path
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: If the memory corresponds to a file mapping, this is the file's path.
+      example: C:\Windows\System32\mshtml.dll
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.dotnet
+      level: custom
+      type: boolean
+      description: Whether this file is a .NET PE
+      example: 'true'
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.sections
+      level: custom
+      type: object
+      object_type: keyword
+      description: The file's relevant sections, if it is a PE
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.sections.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.sections.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.sections.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.sections.hash.sha384
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA384 hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.sections.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.sections.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.sections.hash.tlsh
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: TLSH hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.sections.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The section's name
+      example: .reloc
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.streams
+      level: custom
+      type: object
+      object_type: keyword
+      description: The file's streams, if it is a PE
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.streams.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.streams.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.streams.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.streams.hash.sha384
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA384 hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.streams.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.streams.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.streams.hash.tlsh
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: TLSH hash.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.Ext.streams.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The stream's name
+      example: .reloc
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU architecture target for the file.
+      example: x64
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.company
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.file_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the Go language imports in a PE file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).'
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.imphash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+      example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names and types.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported element names and types.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.original_file_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.pehash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the PE header and data from one or more PE sections. An pehash can be used to cluster files by transforming structural information about a file into a hash value.
+
+        Learn more at https://www.usenix.org/legacy/events/leet09/tech/full_papers/wicherski/wicherski_html/index.html.'
+      example: 73ff189b63cd6be375a7ff25179a38d347651975
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.product
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft® Windows® Operating System"
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields underneath `pe.sections.*`.'
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      default_field: false
+    - name: Ext.memory_region.mapped_pe_detected
+      level: custom
+      type: boolean
+      description: Whether the file at mapped_path is an executable.
+      example: false
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.dotnet
+      level: custom
+      type: boolean
+      description: Whether this file is a .NET PE
+      example: 'true'
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.sections
+      level: custom
+      type: object
+      object_type: keyword
+      description: The file's relevant sections, if it is a PE
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.sections.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.sections.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.sections.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.sections.hash.sha384
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA384 hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.sections.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.sections.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.sections.hash.tlsh
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: TLSH hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.sections.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The section's name
+      example: .reloc
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.streams
+      level: custom
+      type: object
+      object_type: keyword
+      description: The file's streams, if it is a PE
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.streams.hash.md5
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: MD5 hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.streams.hash.sha1
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA1 hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.streams.hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.streams.hash.sha384
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA384 hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.streams.hash.sha512
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA512 hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.streams.hash.ssdeep
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SSDEEP hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.streams.hash.tlsh
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: TLSH hash.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.Ext.streams.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The stream's name
+      example: .reloc
+      default_field: false
+    - name: Ext.memory_region.memory_pe.architecture
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: CPU architecture target for the file.
+      example: x64
+      default_field: false
+    - name: Ext.memory_region.memory_pe.company
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal company name of the file, provided at compile-time.
+      example: Microsoft Corporation
+      default_field: false
+    - name: Ext.memory_region.memory_pe.description
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal description of the file, provided at compile-time.
+      example: Paint
+      default_field: false
+    - name: Ext.memory_region.memory_pe.file_version
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal version of the file, provided at compile-time.
+      example: 6.3.9600.17415
+      default_field: false
+    - name: Ext.memory_region.memory_pe.go_import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the Go language imports in a PE file excluding standard library imports. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        The algorithm used to calculate the Go symbol hash and a reference implementation are available [here](https://github.com/elastic/toutoumomoma).'
+      example: 10bddcb4cee42080f76c88d9ff964491
+      default_field: false
+    - name: Ext.memory_region.memory_pe.go_imports
+      level: extended
+      type: flattened
+      description: List of imported Go language element names and types.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.go_imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.go_imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of Go imports.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.go_stripped
+      level: extended
+      type: boolean
+      description: Set to true if the file is a Go executable that has had its symbols stripped or obfuscated and false if an unobfuscated Go executable.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.imphash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An imphash -- or import hash -- can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+      example: 0c6803c4e922103c4dca5963aad36ddf
+      default_field: false
+    - name: Ext.memory_region.memory_pe.import_hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the imports in a PE file. An import hash can be used to fingerprint binaries even after recompilation or other code-level transformations have occurred, which would change more traditional hash values.
+
+        This is a synonym for imphash.'
+      example: d41d8cd98f00b204e9800998ecf8427e
+      default_field: false
+    - name: Ext.memory_region.memory_pe.imports
+      level: extended
+      type: flattened
+      description: List of imported element names and types.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.imports_names_entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the list of imported element names and types.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.imports_names_var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the list of imported element names and types.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.original_file_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal name of the file, provided at compile-time.
+      example: MSPAINT.EXE
+      default_field: false
+    - name: Ext.memory_region.memory_pe.pehash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'A hash of the PE header and data from one or more PE sections. An pehash can be used to cluster files by transforming structural information about a file into a hash value.
+
+        Learn more at https://www.usenix.org/legacy/events/leet09/tech/full_papers/wicherski/wicherski_html/index.html.'
+      example: 73ff189b63cd6be375a7ff25179a38d347651975
+      default_field: false
+    - name: Ext.memory_region.memory_pe.product
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Internal product name of the file, provided at compile-time.
+      example: "Microsoft® Windows® Operating System"
+      default_field: false
+    - name: Ext.memory_region.memory_pe.sections
+      level: extended
+      type: nested
+      description: 'An array containing an object for each section of the PE file.
+
+        The keys that should be present in these objects are defined by sub-fields underneath `pe.sections.*`.'
+      default_field: false
+    - name: Ext.memory_region.memory_pe.sections.entropy
+      level: extended
+      type: long
+      format: number
+      description: Shannon entropy calculation from the section.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.sections.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: PE Section List name.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.sections.physical_size
+      level: extended
+      type: long
+      format: bytes
+      description: PE Section List physical size.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.sections.var_entropy
+      level: extended
+      type: long
+      format: number
+      description: Variance for Shannon entropy calculation from the section.
+      default_field: false
+    - name: Ext.memory_region.memory_pe.sections.virtual_size
+      level: extended
+      type: long
+      format: string
+      description: PE Section List virtual size. This is always the same as `physical_size`.
+      default_field: false
+    - name: Ext.memory_region.memory_pe_detected
+      level: custom
+      type: boolean
+      description: Whether an executable file was found in memory.
+      example: false
+      default_field: false
+    - name: Ext.memory_region.region_base
+      level: custom
+      type: unsigned_long
+      description: Base address of the memory region.
+      example: 2431737462784
+      default_field: false
+    - name: Ext.memory_region.region_protection
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Memory protection of the memory region. Example values include "RWX" and "R-X".
+      example: RWX
+      default_field: false
+    - name: Ext.memory_region.region_size
+      level: custom
+      type: unsigned_long
+      description: Size of the memory region.
+      example: 4096
+      default_field: false
+    - name: Ext.memory_region.region_state
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: State of the memory region. Example values include "RESERVE", "COMMIT", and "FREE".
+      example: COMMIT
+      default_field: false
+    - name: Ext.memory_region.strings
+      level: custom
+      type: keyword
+      description: Array of strings found within the memory region.
+      index: false
+      doc_values: false
       default_field: false
     - name: Ext.protection
       level: custom

--- a/package/endpoint/data_stream/api/sample_event.json
+++ b/package/endpoint/data_stream/api/sample_event.json
@@ -2,8 +2,37 @@
     "@timestamp": "2023-01-09T19:38:51.5141503Z",
     "Target": {
         "process": {
-            "name": "lsass.exe",
-            "pid": 956
+            "Ext": {
+                "memory_region": {
+                    "allocation_base": 1649160290304,
+                    "allocation_protection": "RWX",
+                    "allocation_size": 4096,
+                    "allocation_type": "PRIVATE",
+                    "bytes_address": 1649160290304,
+                    "bytes_allocation_offset": 0,
+                    "bytes_compressed": "eJztwbEJACAMALA+5uAtWnAoOPg/+EWnJO9k1bo742XuMRsEAAAA0OsD8lge9g==",
+                    "bytes_compressed_present": true,
+                    "hash": {
+                        "sha256": "0b28b598ef70fd2377613fd88a50d52047ae31c16f2c688f3aa4e0b98d63730c"
+                    },
+                    "memory_pe_detected": false,
+                    "region_base": 1649160290304,
+                    "region_protection": "R--",
+                    "region_size": 4096,
+                    "region_state": "COMMIT",
+                    "strings": [
+                        "shellcode",
+                        "seed=AAAA"
+                    ]
+                },
+                "token": {
+                    "integrity_level_name": "high"
+                }
+            },
+            "entity_id": "YWFhYWFhYWEtYWFhYS1hYWFhLWFhYWEtYWFhYWFhYWFhYWFhLTI1NzMyLTE2OTkwMDE3NDAuOTU4NTY4MDAw",
+            "executable": "C:\\Temp\\1_StayRunningWin32_x64.exe",
+            "name": "1_StayRunningWin32_x64.exe",
+            "pid": 25732
         }
     },
     "event": {
@@ -122,6 +151,17 @@
                     "trusted": false
                 }
             ],
+            "memory_region": {
+                "allocation_base": 140712018378752,
+                "allocation_protection": "RCX",
+                "allocation_size": 45056,
+                "allocation_type": "IMAGE",
+                "mapped_path": "C:\\Program Files\\Python39\\DLLs\\libffi-7.dll",
+                "region_base": 140712018395136,
+                "region_protection": "R-X",
+                "region_size": 8192,
+                "region_state": "COMMIT"
+            },
             "token": {
                 "integrity_level_name": "system"
             }

--- a/package/endpoint/data_stream/api/sample_event.json
+++ b/package/endpoint/data_stream/api/sample_event.json
@@ -8,11 +8,17 @@
     },
     "event": {
         "category": [
-            "api"
+            "api",
+            "intrusion_detection"
         ],
         "created": "2023-01-09T19:38:51.5141503Z",
+        "dataset": "endpoint.events.api",
         "id": "MvlgiHxIZtj1+Abi++++++ul",
         "kind": "event",
+        "module": "endpoint",
+        "outcome": "success",
+        "provider": "Microsoft-Windows-Threat-Intelligence",
+        "sequence": 3802,
         "type": [
             "credential_access"
         ]
@@ -50,7 +56,7 @@
             "version": "22H2 (10.0.22621.963)"
         }
     },
-    "message": "Endpoint Credential Access event",
+    "message": "Endpoint API event - hand-crafted with a superset of fields",
     "process": {
         "Ext": {
             "ancestry": [
@@ -60,6 +66,13 @@
                 "YWFhYWFhYWEtYWFhYS1hYWFhLWFhYWEtYWFhYWFhYWFhYWFhLTQ2MDAtMTY3Mjk2NTcxMy40NzY1NDUyMDA="
             ],
             "api": {
+                "behaviors": [
+                    "cross-process"
+                ],
+                "metadata": {
+                    "target_address_name": "Unbacked",
+                    "target_address_path": "c:\\windows\\system32\\ntdll.dll"
+                },
                 "name": "OpenProcess",
                 "parameters": {
                     "desired_access": [
@@ -67,8 +80,39 @@
                         "PROCESS_VM_READ"
                     ],
                     "desired_access_numeric": 4112,
-                    "handle_type": "process"
-                }
+                    "handle_type": "process",
+                    "address": 2904525045760,
+                    "allocation_type": "COMMIT|RESERVE",
+                    "protection": "R-X",
+                    "protection_old": "R-X",
+                    "size": 16,
+                    "context_flags": 1048607,
+                    "r8": 8,
+                    "r9": 9,
+                    "rax": 10,
+                    "rbp": 3,
+                    "rbx": 11,
+                    "rcx": 2883351609344,
+                    "rdi": 5,
+                    "rdx": 13,
+                    "rip": 140706538588528,
+                    "rsi": 4,
+                    "rsp": 2,
+                    "eax": 10,
+                    "ebp": 3,
+                    "ebx": 11,
+                    "ecx": 12,
+                    "edi": 5,
+                    "edx": 0,
+                    "eip": 1,
+                    "esi": 4,
+                    "esp": 2,
+                    "argument1": 2583984274656,
+                    "argument2": 4105953215,
+                    "argument3": 31058890,
+                    "procedure": 140705553857280
+                },
+                "summary": "VirtualAllocEx( charmap.exe, NULL, 0x10, COMMIT|RESERVE, R-X )"
             },
             "code_signature": [
                 {
@@ -77,7 +121,10 @@
                     "subject_name": "Microsoft Windows",
                     "trusted": false
                 }
-            ]
+            ],
+            "token": {
+                "integrity_level_name": "system"
+            }
         },
         "code_signature": {
             "exists": true,
@@ -85,6 +132,7 @@
             "subject_name": "Microsoft Windows",
             "trusted": false
         },
+        "command_line": "",
         "entity_id": "YWFhYWFhYWEtYWFhYS1hYWFhLWFhYWEtYWFhYWFhYWFhYWFhLTkxNi0xNjczMjkzMTMwLjk0NjAwMjAw",
         "executable": "c\\git\\endpoint-dev\\Tools\\Leia\\modules\\exe_malware\\mimikatz.exe",
         "name": "mimikatz.exe",
@@ -93,45 +141,40 @@
             "Ext": {
                 "call_stack": [
                     {
-                        "instruction_pointer": 140717353267908,
-                        "module_path": "C:\\Windows\\System32\\ntdll.dll"
+                        "allocation_private_bytes": 4096,
+                        "protection_provenance": "dabapi.dll",
+                        "symbol_info": "c:\\windows\\system32\\ntdll.dll!ZwProtectVirtualMemory+0x14"
                     },
                     {
-                        "instruction_pointer": 140717309764254,
-                        "module_path": "C:\\Windows\\System32\\KernelBase.dll"
+                        "symbol_info": "c:\\windows\\system32\\kernelbase.dll!VirtualProtect+0x36"
                     },
                     {
-                        "instruction_pointer": 140697175487234,
-                        "module_path": "c\\users\\user\\desktop\\mimikatz.exe"
+                        "allocation_private_bytes": 8192,
+                        "callsite_leading_bytes": "c048895424204c8bc9488d0d801f0000418d500248ff15052a00000f1f4400004883c438c3cccccccccccccccccccccc4883ec2048b880bf1acaf87f0000ffd0",
+                        "callsite_trailing_bytes": "4883c420c3ec48498363e800498d4320ba2500000049c743e004000000440fb7ca4c8d05d0320000ba2b000000498943d848ff15f82a00000f1f4400004883c4",
+                        "protection": "RWX",
+                        "protection_provenance": "eventstests.exe",
+                        "symbol_info": "c:\\windows\\system32\\dabapi.dll!DabApiBufferFree+0x10"
                     },
                     {
-                        "instruction_pointer": 140697175488197,
-                        "module_path": "c\\users\\user\\desktop\\mimikatz.exe"
-                    },
-                    {
-                        "instruction_pointer": 140697175487041,
-                        "module_path": "c\\users\\user\\desktop\\mimikatz.exe"
-                    },
-                    {
-                        "instruction_pointer": 140697175277748,
-                        "module_path": "c\\users\\user\\desktop\\mimikatz.exe"
-                    },
-                    {
-                        "instruction_pointer": 140697175277292,
-                        "module_path": "c\\users\\user\\desktop\\mimikatz.exe"
-                    },
-                    {
-                        "instruction_pointer": 140697175276599,
-                        "module_path": "c\\users\\user\\desktop\\mimikatz.exe"
-                    },
-                    {
-                        "instruction_pointer": 140697175514281,
-                        "module_path": "c\\users\\user\\desktop\\mimikatz.exe"
+                        "symbol_info": "Unknown"
                     }
                 ],
-                "call_stack_contains_unbacked": false,
                 "call_stack_final_user_module": {
-                    "path": "mimikatz.exe"
+                    "code_signature": [
+                        {
+                            "exists": true,
+                            "status": "trusted",
+                            "subject_name": "Microsoft Windows",
+                            "trusted": true
+                        }
+                    ],
+                    "hash": {
+                        "sha256": "0386c57d59ee1292bb74d9878358da7a0ba00e5b56ed52fd6171b9e6d29d85aa"
+                    },
+                    "name": "dabapi.dll",
+                    "path": "c:\\windows\\system32\\dabapi.dll",
+                    "protection_provenance": "eventstests.exe"
                 }
             },
             "id": 11628

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -28,6 +28,1318 @@ Target.process.Ext:
   original_fieldset: process
   short: Object for all custom defined fields to live in.
   type: object
+Target.process.Ext.memory_region.allocation_base:
+  dashed_name: Target-process-Ext-memory-region-allocation-base
+  description: Base address of the memory allocation containing the memory region.
+  example: 2431737462784
+  flat_name: Target.process.Ext.memory_region.allocation_base
+  level: custom
+  name: allocation_base
+  normalize: []
+  original_fieldset: memory_region
+  short: Base address of the memory allocation containing the memory region.
+  type: unsigned_long
+Target.process.Ext.memory_region.allocation_protection:
+  dashed_name: Target-process-Ext-memory-region-allocation-protection
+  description: Original memory protection requested when the memory was allocated.
+    Example values include "RWX" and "R-X".
+  example: RWX
+  flat_name: Target.process.Ext.memory_region.allocation_protection
+  ignore_above: 1024
+  level: custom
+  name: allocation_protection
+  normalize: []
+  original_fieldset: memory_region
+  short: Original memory protection requested when the memory was allocated. Example
+    values include "RWX" and "R-X".
+  type: keyword
+Target.process.Ext.memory_region.allocation_size:
+  dashed_name: Target-process-Ext-memory-region-allocation-size
+  description: Original memory size requested when the memory was allocated.
+  example: 4096
+  flat_name: Target.process.Ext.memory_region.allocation_size
+  level: custom
+  name: allocation_size
+  normalize: []
+  original_fieldset: memory_region
+  short: Original memory size requested when the memory was allocated.
+  type: unsigned_long
+Target.process.Ext.memory_region.allocation_type:
+  dashed_name: Target-process-Ext-memory-region-allocation-type
+  description: The memory allocation type. Example values include "IMAGE", "MAPPED",
+    and "PRIVATE".
+  example: PRIVATE
+  flat_name: Target.process.Ext.memory_region.allocation_type
+  ignore_above: 1024
+  level: custom
+  name: allocation_type
+  normalize: []
+  original_fieldset: memory_region
+  short: The memory allocation type. Example values include "IMAGE", "MAPPED", and
+    "PRIVATE".
+  type: keyword
+Target.process.Ext.memory_region.bytes_address:
+  dashed_name: Target-process-Ext-memory-region-bytes-address
+  description: The address where bytes_compressed begins.
+  example: 2431737462784
+  flat_name: Target.process.Ext.memory_region.bytes_address
+  level: custom
+  name: bytes_address
+  normalize: []
+  original_fieldset: memory_region
+  short: The address where bytes_compressed begins.
+  type: unsigned_long
+Target.process.Ext.memory_region.bytes_allocation_offset:
+  dashed_name: Target-process-Ext-memory-region-bytes-allocation-offset
+  description: Offset of bytes_address the memory allocation. Equal to bytes_address
+    - allocation_base.
+  example: 0
+  flat_name: Target.process.Ext.memory_region.bytes_allocation_offset
+  level: custom
+  name: bytes_allocation_offset
+  normalize: []
+  original_fieldset: memory_region
+  short: Offset of bytes_address the memory allocation. Equal to bytes_address - allocation_base.
+  type: unsigned_long
+Target.process.Ext.memory_region.bytes_compressed:
+  dashed_name: Target-process-Ext-memory-region-bytes-compressed
+  description: Up to 4MB of raw data from the memory allocation. This is compressed
+    with zlib.To reduce data volume, this is de-duplicated on the endpoint, and may
+    be missing from many alerts if the same data would be sent multiple times.
+  doc_values: false
+  example: eJzzSM3JyVcIzy/KSVEEABxJBD4=
+  flat_name: Target.process.Ext.memory_region.bytes_compressed
+  index: false
+  level: custom
+  name: bytes_compressed
+  normalize: []
+  original_fieldset: memory_region
+  short: Up to 4MB of raw data from the memory allocation.
+  type: keyword
+Target.process.Ext.memory_region.bytes_compressed_present:
+  dashed_name: Target-process-Ext-memory-region-bytes-compressed-present
+  description: Whether bytes_compressed is present in this event.
+  example: false
+  flat_name: Target.process.Ext.memory_region.bytes_compressed_present
+  level: custom
+  name: bytes_compressed_present
+  normalize: []
+  original_fieldset: memory_region
+  short: Whether bytes_compressed is present in this event.
+  type: boolean
+Target.process.Ext.memory_region.hash.sha256:
+  dashed_name: Target-process-Ext-memory-region-hash-sha256
+  description: The sha256 of the memory region.
+  example: d25ff1e6c6460a7f9de39198d182058c1712726008d187e1953b83abe977e4a0
+  flat_name: Target.process.Ext.memory_region.hash.sha256
+  ignore_above: 1024
+  level: custom
+  name: hash.sha256
+  normalize: []
+  original_fieldset: memory_region
+  short: The sha256 of the memory region.
+  type: keyword
+Target.process.Ext.memory_region.malware_signature.all_names:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-all-names
+  description: A sequence of signature names matched.
+  example: Windows.EICAR.Not-a-virus
+  flat_name: Target.process.Ext.memory_region.malware_signature.all_names
+  ignore_above: 1024
+  level: custom
+  name: all_names
+  normalize: []
+  original_fieldset: malware_signature
+  short: A sequence of signature names matched.
+  type: keyword
+Target.process.Ext.memory_region.malware_signature.identifier:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-identifier
+  description: malware signature identifier
+  flat_name: Target.process.Ext.memory_region.malware_signature.identifier
+  ignore_above: 1024
+  level: custom
+  name: identifier
+  normalize: []
+  original_fieldset: malware_signature
+  short: malware signature identifier
+  type: keyword
+Target.process.Ext.memory_region.malware_signature.primary:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-primary
+  description: The first matching details.
+  flat_name: Target.process.Ext.memory_region.malware_signature.primary
+  level: custom
+  name: primary
+  normalize: []
+  object_type: keyword
+  original_fieldset: malware_signature
+  short: The first matching details.
+  type: object
+Target.process.Ext.memory_region.malware_signature.primary.matches:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-primary-matches
+  description: The first matching details.
+  doc_values: false
+  flat_name: Target.process.Ext.memory_region.malware_signature.primary.matches
+  index: false
+  level: custom
+  name: primary.matches
+  normalize: []
+  original_fieldset: malware_signature
+  short: The first matching details.
+  type: keyword
+Target.process.Ext.memory_region.malware_signature.primary.signature.hash:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-primary-signature-hash
+  description: hash of file matching signature.
+  flat_name: Target.process.Ext.memory_region.malware_signature.primary.signature.hash
+  level: custom
+  name: primary.signature.hash
+  normalize: []
+  original_fieldset: malware_signature
+  short: hash of file matching signature.
+  type: nested
+Target.process.Ext.memory_region.malware_signature.primary.signature.hash.sha256:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-primary-signature-hash-sha256
+  description: sha256 hash of file matching signature.
+  flat_name: Target.process.Ext.memory_region.malware_signature.primary.signature.hash.sha256
+  ignore_above: 1024
+  level: custom
+  name: primary.signature.hash.sha256
+  normalize: []
+  original_fieldset: malware_signature
+  short: sha256 hash of file matching signature.
+  type: keyword
+Target.process.Ext.memory_region.malware_signature.primary.signature.id:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-primary-signature-id
+  description: The id of the first yara rule matched.
+  flat_name: Target.process.Ext.memory_region.malware_signature.primary.signature.id
+  ignore_above: 1024
+  level: custom
+  name: primary.signature.id
+  normalize: []
+  original_fieldset: malware_signature
+  short: The id of the first yara rule matched.
+  type: keyword
+Target.process.Ext.memory_region.malware_signature.primary.signature.name:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-primary-signature-name
+  description: The name of the first yara rule matched.
+  flat_name: Target.process.Ext.memory_region.malware_signature.primary.signature.name
+  ignore_above: 1024
+  level: custom
+  name: primary.signature.name
+  normalize: []
+  original_fieldset: malware_signature
+  short: The name of the first yara rule matched.
+  type: keyword
+Target.process.Ext.memory_region.malware_signature.secondary:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-secondary
+  description: Additional matching details if available.
+  enabled: false
+  flat_name: Target.process.Ext.memory_region.malware_signature.secondary
+  level: custom
+  name: secondary
+  normalize: []
+  original_fieldset: malware_signature
+  short: Additional matching details if available.
+  type: nested
+Target.process.Ext.memory_region.malware_signature.version:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-version
+  description: malware signature version
+  flat_name: Target.process.Ext.memory_region.malware_signature.version
+  ignore_above: 1024
+  level: custom
+  name: version
+  normalize: []
+  original_fieldset: malware_signature
+  short: malware signature version
+  type: keyword
+Target.process.Ext.memory_region.mapped_path:
+  dashed_name: Target-process-Ext-memory-region-mapped-path
+  description: If the memory corresponds to a file mapping, this is the file's path.
+  example: C:\Windows\System32\mshtml.dll
+  flat_name: Target.process.Ext.memory_region.mapped_path
+  ignore_above: 1024
+  level: custom
+  name: mapped_path
+  normalize: []
+  original_fieldset: memory_region
+  short: If the memory corresponds to a file mapping, this is the file's path.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.dotnet:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-dotnet
+  description: Whether this file is a .NET PE
+  example: 'true'
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.dotnet
+  level: custom
+  name: Ext.dotnet
+  normalize: []
+  original_fieldset: pe
+  short: Whether this file is a .NET PE
+  type: boolean
+Target.process.Ext.memory_region.mapped_pe.Ext.sections:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-sections
+  description: The file's relevant sections, if it is a PE
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.sections
+  level: custom
+  name: Ext.sections
+  normalize: []
+  object_type: keyword
+  original_fieldset: pe
+  short: The file's sections, if it is a PE
+  type: object
+Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.md5:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-sections-hash-md5
+  description: MD5 hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha1:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-sections-hash-sha1
+  description: SHA1 hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha256:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-sections-hash-sha256
+  description: SHA256 hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha384:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-sections-hash-sha384
+  description: SHA384 hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha384
+  ignore_above: 1024
+  level: extended
+  name: sha384
+  normalize: []
+  original_fieldset: hash
+  short: SHA384 hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha512:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-sections-hash-sha512
+  description: SHA512 hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.ssdeep:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-sections-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.tlsh:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-sections-hash-tlsh
+  description: TLSH hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.sections.hash.tlsh
+  ignore_above: 1024
+  level: extended
+  name: tlsh
+  normalize: []
+  original_fieldset: hash
+  short: TLSH hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.sections.name:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-sections-name
+  description: The section's name
+  example: .reloc
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.sections.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.sections.name
+  normalize: []
+  original_fieldset: pe
+  short: The section's name
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.streams:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-streams
+  description: The file's streams, if it is a PE
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.streams
+  level: custom
+  name: Ext.streams
+  normalize: []
+  object_type: keyword
+  original_fieldset: pe
+  short: The file's streams, if it is a PE
+  type: object
+Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.md5:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-streams-hash-md5
+  description: MD5 hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha1:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-streams-hash-sha1
+  description: SHA1 hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha256:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-streams-hash-sha256
+  description: SHA256 hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha384:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-streams-hash-sha384
+  description: SHA384 hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha384
+  ignore_above: 1024
+  level: extended
+  name: sha384
+  normalize: []
+  original_fieldset: hash
+  short: SHA384 hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha512:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-streams-hash-sha512
+  description: SHA512 hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.ssdeep:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-streams-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.tlsh:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-streams-hash-tlsh
+  description: TLSH hash.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.streams.hash.tlsh
+  ignore_above: 1024
+  level: extended
+  name: tlsh
+  normalize: []
+  original_fieldset: hash
+  short: TLSH hash.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.Ext.streams.name:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-Ext-streams-name
+  description: The stream's name
+  example: .reloc
+  flat_name: Target.process.Ext.memory_region.mapped_pe.Ext.streams.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.streams.name
+  normalize: []
+  original_fieldset: pe
+  short: The stream's name
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.architecture:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-architecture
+  description: CPU architecture target for the file.
+  example: x64
+  flat_name: Target.process.Ext.memory_region.mapped_pe.architecture
+  ignore_above: 1024
+  level: extended
+  name: architecture
+  normalize: []
+  original_fieldset: pe
+  short: CPU architecture target for the file.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.company:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: Target.process.Ext.memory_region.mapped_pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.description:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: Target.process.Ext.memory_region.mapped_pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.file_version:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: Target.process.Ext.memory_region.mapped_pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.go_import_hash:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-go-import-hash
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: Target.process.Ext.memory_region.mapped_pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in a PE file.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.go_imports:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+Target.process.Ext.memory_region.mapped_pe.go_imports_names_entropy:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+Target.process.Ext.memory_region.mapped_pe.go_imports_names_var_entropy:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+Target.process.Ext.memory_region.mapped_pe.go_stripped:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
+Target.process.Ext.memory_region.mapped_pe.imphash:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-imphash
+  description: 'A hash of the imports in a PE file. An imphash -- or import hash --
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+
+    Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+  example: 0c6803c4e922103c4dca5963aad36ddf
+  flat_name: Target.process.Ext.memory_region.mapped_pe.imphash
+  ignore_above: 1024
+  level: extended
+  name: imphash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in a PE file.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.import_hash:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: Target.process.Ext.memory_region.mapped_pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in a PE file.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.imports:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-imports
+  description: List of imported element names and types.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+Target.process.Ext.memory_region.mapped_pe.imports_names_entropy:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+Target.process.Ext.memory_region.mapped_pe.imports_names_var_entropy:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
+Target.process.Ext.memory_region.mapped_pe.original_file_name:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: Target.process.Ext.memory_region.mapped_pe.original_file_name
+  ignore_above: 1024
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.pehash:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-pehash
+  description: 'A hash of the PE header and data from one or more PE sections. An
+    pehash can be used to cluster files by transforming structural information about
+    a file into a hash value.
+
+    Learn more at https://www.usenix.org/legacy/events/leet09/tech/full_papers/wicherski/wicherski_html/index.html.'
+  example: 73ff189b63cd6be375a7ff25179a38d347651975
+  flat_name: Target.process.Ext.memory_region.mapped_pe.pehash
+  ignore_above: 1024
+  level: extended
+  name: pehash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the PE header and data from one or more PE sections.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.product:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: Target.process.Ext.memory_region.mapped_pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.sections:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: Target.process.Ext.memory_region.mapped_pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+Target.process.Ext.memory_region.mapped_pe.sections.entropy:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+Target.process.Ext.memory_region.mapped_pe.sections.name:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-sections-name
+  description: PE Section List name.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+Target.process.Ext.memory_region.mapped_pe.sections.physical_size:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+Target.process.Ext.memory_region.mapped_pe.sections.var_entropy:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+Target.process.Ext.memory_region.mapped_pe.sections.virtual_size:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: Target.process.Ext.memory_region.mapped_pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
+Target.process.Ext.memory_region.mapped_pe_detected:
+  dashed_name: Target-process-Ext-memory-region-mapped-pe-detected
+  description: Whether the file at mapped_path is an executable.
+  example: false
+  flat_name: Target.process.Ext.memory_region.mapped_pe_detected
+  level: custom
+  name: mapped_pe_detected
+  normalize: []
+  original_fieldset: memory_region
+  short: Whether the file at mapped_path is an executable.
+  type: boolean
+Target.process.Ext.memory_region.memory_pe.Ext.dotnet:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-dotnet
+  description: Whether this file is a .NET PE
+  example: 'true'
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.dotnet
+  level: custom
+  name: Ext.dotnet
+  normalize: []
+  original_fieldset: pe
+  short: Whether this file is a .NET PE
+  type: boolean
+Target.process.Ext.memory_region.memory_pe.Ext.sections:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-sections
+  description: The file's relevant sections, if it is a PE
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.sections
+  level: custom
+  name: Ext.sections
+  normalize: []
+  object_type: keyword
+  original_fieldset: pe
+  short: The file's sections, if it is a PE
+  type: object
+Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.md5:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-sections-hash-md5
+  description: MD5 hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.sha1:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-sections-hash-sha1
+  description: SHA1 hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.sha256:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-sections-hash-sha256
+  description: SHA256 hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.sha384:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-sections-hash-sha384
+  description: SHA384 hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.sha384
+  ignore_above: 1024
+  level: extended
+  name: sha384
+  normalize: []
+  original_fieldset: hash
+  short: SHA384 hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.sha512:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-sections-hash-sha512
+  description: SHA512 hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.ssdeep:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-sections-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.tlsh:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-sections-hash-tlsh
+  description: TLSH hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.sections.hash.tlsh
+  ignore_above: 1024
+  level: extended
+  name: tlsh
+  normalize: []
+  original_fieldset: hash
+  short: TLSH hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.sections.name:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-sections-name
+  description: The section's name
+  example: .reloc
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.sections.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.sections.name
+  normalize: []
+  original_fieldset: pe
+  short: The section's name
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.streams:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-streams
+  description: The file's streams, if it is a PE
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.streams
+  level: custom
+  name: Ext.streams
+  normalize: []
+  object_type: keyword
+  original_fieldset: pe
+  short: The file's streams, if it is a PE
+  type: object
+Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.md5:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-streams-hash-md5
+  description: MD5 hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.sha1:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-streams-hash-sha1
+  description: SHA1 hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.sha256:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-streams-hash-sha256
+  description: SHA256 hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.sha384:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-streams-hash-sha384
+  description: SHA384 hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.sha384
+  ignore_above: 1024
+  level: extended
+  name: sha384
+  normalize: []
+  original_fieldset: hash
+  short: SHA384 hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.sha512:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-streams-hash-sha512
+  description: SHA512 hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.ssdeep:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-streams-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.tlsh:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-streams-hash-tlsh
+  description: TLSH hash.
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.streams.hash.tlsh
+  ignore_above: 1024
+  level: extended
+  name: tlsh
+  normalize: []
+  original_fieldset: hash
+  short: TLSH hash.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.Ext.streams.name:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-Ext-streams-name
+  description: The stream's name
+  example: .reloc
+  flat_name: Target.process.Ext.memory_region.memory_pe.Ext.streams.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.streams.name
+  normalize: []
+  original_fieldset: pe
+  short: The stream's name
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.architecture:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-architecture
+  description: CPU architecture target for the file.
+  example: x64
+  flat_name: Target.process.Ext.memory_region.memory_pe.architecture
+  ignore_above: 1024
+  level: extended
+  name: architecture
+  normalize: []
+  original_fieldset: pe
+  short: CPU architecture target for the file.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.company:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: Target.process.Ext.memory_region.memory_pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.description:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: Target.process.Ext.memory_region.memory_pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.file_version:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: Target.process.Ext.memory_region.memory_pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.go_import_hash:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-go-import-hash
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: Target.process.Ext.memory_region.memory_pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in a PE file.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.go_imports:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: Target.process.Ext.memory_region.memory_pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+Target.process.Ext.memory_region.memory_pe.go_imports_names_entropy:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: Target.process.Ext.memory_region.memory_pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+Target.process.Ext.memory_region.memory_pe.go_imports_names_var_entropy:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: Target.process.Ext.memory_region.memory_pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+Target.process.Ext.memory_region.memory_pe.go_stripped:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: Target.process.Ext.memory_region.memory_pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
+Target.process.Ext.memory_region.memory_pe.imphash:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-imphash
+  description: 'A hash of the imports in a PE file. An imphash -- or import hash --
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+
+    Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+  example: 0c6803c4e922103c4dca5963aad36ddf
+  flat_name: Target.process.Ext.memory_region.memory_pe.imphash
+  ignore_above: 1024
+  level: extended
+  name: imphash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in a PE file.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.import_hash:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: Target.process.Ext.memory_region.memory_pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in a PE file.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.imports:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-imports
+  description: List of imported element names and types.
+  flat_name: Target.process.Ext.memory_region.memory_pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+Target.process.Ext.memory_region.memory_pe.imports_names_entropy:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: Target.process.Ext.memory_region.memory_pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+Target.process.Ext.memory_region.memory_pe.imports_names_var_entropy:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: Target.process.Ext.memory_region.memory_pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
+Target.process.Ext.memory_region.memory_pe.original_file_name:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: Target.process.Ext.memory_region.memory_pe.original_file_name
+  ignore_above: 1024
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.pehash:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-pehash
+  description: 'A hash of the PE header and data from one or more PE sections. An
+    pehash can be used to cluster files by transforming structural information about
+    a file into a hash value.
+
+    Learn more at https://www.usenix.org/legacy/events/leet09/tech/full_papers/wicherski/wicherski_html/index.html.'
+  example: 73ff189b63cd6be375a7ff25179a38d347651975
+  flat_name: Target.process.Ext.memory_region.memory_pe.pehash
+  ignore_above: 1024
+  level: extended
+  name: pehash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the PE header and data from one or more PE sections.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.product:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: Target.process.Ext.memory_region.memory_pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.sections:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: Target.process.Ext.memory_region.memory_pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+Target.process.Ext.memory_region.memory_pe.sections.entropy:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: Target.process.Ext.memory_region.memory_pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+Target.process.Ext.memory_region.memory_pe.sections.name:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-sections-name
+  description: PE Section List name.
+  flat_name: Target.process.Ext.memory_region.memory_pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+Target.process.Ext.memory_region.memory_pe.sections.physical_size:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: Target.process.Ext.memory_region.memory_pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+Target.process.Ext.memory_region.memory_pe.sections.var_entropy:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: Target.process.Ext.memory_region.memory_pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+Target.process.Ext.memory_region.memory_pe.sections.virtual_size:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: Target.process.Ext.memory_region.memory_pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
+Target.process.Ext.memory_region.memory_pe_detected:
+  dashed_name: Target-process-Ext-memory-region-memory-pe-detected
+  description: Whether an executable file was found in memory.
+  example: false
+  flat_name: Target.process.Ext.memory_region.memory_pe_detected
+  level: custom
+  name: memory_pe_detected
+  normalize: []
+  original_fieldset: memory_region
+  short: Whether an executable file was found in memory.
+  type: boolean
+Target.process.Ext.memory_region.region_base:
+  dashed_name: Target-process-Ext-memory-region-region-base
+  description: Base address of the memory region.
+  example: 2431737462784
+  flat_name: Target.process.Ext.memory_region.region_base
+  level: custom
+  name: region_base
+  normalize: []
+  original_fieldset: memory_region
+  short: Base address of the memory region.
+  type: unsigned_long
+Target.process.Ext.memory_region.region_protection:
+  dashed_name: Target-process-Ext-memory-region-region-protection
+  description: Memory protection of the memory region. Example values include "RWX"
+    and "R-X".
+  example: RWX
+  flat_name: Target.process.Ext.memory_region.region_protection
+  ignore_above: 1024
+  level: custom
+  name: region_protection
+  normalize: []
+  original_fieldset: memory_region
+  short: Memory protection of the memory region. Example values include "RWX" and
+    "R-X".
+  type: keyword
+Target.process.Ext.memory_region.region_size:
+  dashed_name: Target-process-Ext-memory-region-region-size
+  description: Size of the memory region.
+  example: 4096
+  flat_name: Target.process.Ext.memory_region.region_size
+  level: custom
+  name: region_size
+  normalize: []
+  original_fieldset: memory_region
+  short: Size of the memory region.
+  type: unsigned_long
+Target.process.Ext.memory_region.region_state:
+  dashed_name: Target-process-Ext-memory-region-region-state
+  description: State of the memory region. Example values include "RESERVE", "COMMIT",
+    and "FREE".
+  example: COMMIT
+  flat_name: Target.process.Ext.memory_region.region_state
+  ignore_above: 1024
+  level: custom
+  name: region_state
+  normalize: []
+  original_fieldset: memory_region
+  short: State of the memory region. Example values include "RESERVE", "COMMIT", and
+    "FREE".
+  type: keyword
+Target.process.Ext.memory_region.strings:
+  dashed_name: Target-process-Ext-memory-region-strings
+  description: Array of strings found within the memory region.
+  doc_values: false
+  flat_name: Target.process.Ext.memory_region.strings
+  index: false
+  level: custom
+  name: strings
+  normalize: []
+  original_fieldset: memory_region
+  short: Array of strings found within the memory region.
+  type: keyword
 Target.process.Ext.token.integrity_level_name:
   dashed_name: Target-process-Ext-token-integrity-level-name
   description: Human readable integrity level.
@@ -1543,6 +2855,1318 @@ process.Ext.code_signature.trusted:
   normalize: []
   short: Stores the trust status of the certificate chain.
   type: boolean
+process.Ext.memory_region.allocation_base:
+  dashed_name: process-Ext-memory-region-allocation-base
+  description: Base address of the memory allocation containing the memory region.
+  example: 2431737462784
+  flat_name: process.Ext.memory_region.allocation_base
+  level: custom
+  name: allocation_base
+  normalize: []
+  original_fieldset: memory_region
+  short: Base address of the memory allocation containing the memory region.
+  type: unsigned_long
+process.Ext.memory_region.allocation_protection:
+  dashed_name: process-Ext-memory-region-allocation-protection
+  description: Original memory protection requested when the memory was allocated.
+    Example values include "RWX" and "R-X".
+  example: RWX
+  flat_name: process.Ext.memory_region.allocation_protection
+  ignore_above: 1024
+  level: custom
+  name: allocation_protection
+  normalize: []
+  original_fieldset: memory_region
+  short: Original memory protection requested when the memory was allocated. Example
+    values include "RWX" and "R-X".
+  type: keyword
+process.Ext.memory_region.allocation_size:
+  dashed_name: process-Ext-memory-region-allocation-size
+  description: Original memory size requested when the memory was allocated.
+  example: 4096
+  flat_name: process.Ext.memory_region.allocation_size
+  level: custom
+  name: allocation_size
+  normalize: []
+  original_fieldset: memory_region
+  short: Original memory size requested when the memory was allocated.
+  type: unsigned_long
+process.Ext.memory_region.allocation_type:
+  dashed_name: process-Ext-memory-region-allocation-type
+  description: The memory allocation type. Example values include "IMAGE", "MAPPED",
+    and "PRIVATE".
+  example: PRIVATE
+  flat_name: process.Ext.memory_region.allocation_type
+  ignore_above: 1024
+  level: custom
+  name: allocation_type
+  normalize: []
+  original_fieldset: memory_region
+  short: The memory allocation type. Example values include "IMAGE", "MAPPED", and
+    "PRIVATE".
+  type: keyword
+process.Ext.memory_region.bytes_address:
+  dashed_name: process-Ext-memory-region-bytes-address
+  description: The address where bytes_compressed begins.
+  example: 2431737462784
+  flat_name: process.Ext.memory_region.bytes_address
+  level: custom
+  name: bytes_address
+  normalize: []
+  original_fieldset: memory_region
+  short: The address where bytes_compressed begins.
+  type: unsigned_long
+process.Ext.memory_region.bytes_allocation_offset:
+  dashed_name: process-Ext-memory-region-bytes-allocation-offset
+  description: Offset of bytes_address the memory allocation. Equal to bytes_address
+    - allocation_base.
+  example: 0
+  flat_name: process.Ext.memory_region.bytes_allocation_offset
+  level: custom
+  name: bytes_allocation_offset
+  normalize: []
+  original_fieldset: memory_region
+  short: Offset of bytes_address the memory allocation. Equal to bytes_address - allocation_base.
+  type: unsigned_long
+process.Ext.memory_region.bytes_compressed:
+  dashed_name: process-Ext-memory-region-bytes-compressed
+  description: Up to 4MB of raw data from the memory allocation. This is compressed
+    with zlib.To reduce data volume, this is de-duplicated on the endpoint, and may
+    be missing from many alerts if the same data would be sent multiple times.
+  doc_values: false
+  example: eJzzSM3JyVcIzy/KSVEEABxJBD4=
+  flat_name: process.Ext.memory_region.bytes_compressed
+  index: false
+  level: custom
+  name: bytes_compressed
+  normalize: []
+  original_fieldset: memory_region
+  short: Up to 4MB of raw data from the memory allocation.
+  type: keyword
+process.Ext.memory_region.bytes_compressed_present:
+  dashed_name: process-Ext-memory-region-bytes-compressed-present
+  description: Whether bytes_compressed is present in this event.
+  example: false
+  flat_name: process.Ext.memory_region.bytes_compressed_present
+  level: custom
+  name: bytes_compressed_present
+  normalize: []
+  original_fieldset: memory_region
+  short: Whether bytes_compressed is present in this event.
+  type: boolean
+process.Ext.memory_region.hash.sha256:
+  dashed_name: process-Ext-memory-region-hash-sha256
+  description: The sha256 of the memory region.
+  example: d25ff1e6c6460a7f9de39198d182058c1712726008d187e1953b83abe977e4a0
+  flat_name: process.Ext.memory_region.hash.sha256
+  ignore_above: 1024
+  level: custom
+  name: hash.sha256
+  normalize: []
+  original_fieldset: memory_region
+  short: The sha256 of the memory region.
+  type: keyword
+process.Ext.memory_region.malware_signature.all_names:
+  dashed_name: process-Ext-memory-region-malware-signature-all-names
+  description: A sequence of signature names matched.
+  example: Windows.EICAR.Not-a-virus
+  flat_name: process.Ext.memory_region.malware_signature.all_names
+  ignore_above: 1024
+  level: custom
+  name: all_names
+  normalize: []
+  original_fieldset: malware_signature
+  short: A sequence of signature names matched.
+  type: keyword
+process.Ext.memory_region.malware_signature.identifier:
+  dashed_name: process-Ext-memory-region-malware-signature-identifier
+  description: malware signature identifier
+  flat_name: process.Ext.memory_region.malware_signature.identifier
+  ignore_above: 1024
+  level: custom
+  name: identifier
+  normalize: []
+  original_fieldset: malware_signature
+  short: malware signature identifier
+  type: keyword
+process.Ext.memory_region.malware_signature.primary:
+  dashed_name: process-Ext-memory-region-malware-signature-primary
+  description: The first matching details.
+  flat_name: process.Ext.memory_region.malware_signature.primary
+  level: custom
+  name: primary
+  normalize: []
+  object_type: keyword
+  original_fieldset: malware_signature
+  short: The first matching details.
+  type: object
+process.Ext.memory_region.malware_signature.primary.matches:
+  dashed_name: process-Ext-memory-region-malware-signature-primary-matches
+  description: The first matching details.
+  doc_values: false
+  flat_name: process.Ext.memory_region.malware_signature.primary.matches
+  index: false
+  level: custom
+  name: primary.matches
+  normalize: []
+  original_fieldset: malware_signature
+  short: The first matching details.
+  type: keyword
+process.Ext.memory_region.malware_signature.primary.signature.hash:
+  dashed_name: process-Ext-memory-region-malware-signature-primary-signature-hash
+  description: hash of file matching signature.
+  flat_name: process.Ext.memory_region.malware_signature.primary.signature.hash
+  level: custom
+  name: primary.signature.hash
+  normalize: []
+  original_fieldset: malware_signature
+  short: hash of file matching signature.
+  type: nested
+process.Ext.memory_region.malware_signature.primary.signature.hash.sha256:
+  dashed_name: process-Ext-memory-region-malware-signature-primary-signature-hash-sha256
+  description: sha256 hash of file matching signature.
+  flat_name: process.Ext.memory_region.malware_signature.primary.signature.hash.sha256
+  ignore_above: 1024
+  level: custom
+  name: primary.signature.hash.sha256
+  normalize: []
+  original_fieldset: malware_signature
+  short: sha256 hash of file matching signature.
+  type: keyword
+process.Ext.memory_region.malware_signature.primary.signature.id:
+  dashed_name: process-Ext-memory-region-malware-signature-primary-signature-id
+  description: The id of the first yara rule matched.
+  flat_name: process.Ext.memory_region.malware_signature.primary.signature.id
+  ignore_above: 1024
+  level: custom
+  name: primary.signature.id
+  normalize: []
+  original_fieldset: malware_signature
+  short: The id of the first yara rule matched.
+  type: keyword
+process.Ext.memory_region.malware_signature.primary.signature.name:
+  dashed_name: process-Ext-memory-region-malware-signature-primary-signature-name
+  description: The name of the first yara rule matched.
+  flat_name: process.Ext.memory_region.malware_signature.primary.signature.name
+  ignore_above: 1024
+  level: custom
+  name: primary.signature.name
+  normalize: []
+  original_fieldset: malware_signature
+  short: The name of the first yara rule matched.
+  type: keyword
+process.Ext.memory_region.malware_signature.secondary:
+  dashed_name: process-Ext-memory-region-malware-signature-secondary
+  description: Additional matching details if available.
+  enabled: false
+  flat_name: process.Ext.memory_region.malware_signature.secondary
+  level: custom
+  name: secondary
+  normalize: []
+  original_fieldset: malware_signature
+  short: Additional matching details if available.
+  type: nested
+process.Ext.memory_region.malware_signature.version:
+  dashed_name: process-Ext-memory-region-malware-signature-version
+  description: malware signature version
+  flat_name: process.Ext.memory_region.malware_signature.version
+  ignore_above: 1024
+  level: custom
+  name: version
+  normalize: []
+  original_fieldset: malware_signature
+  short: malware signature version
+  type: keyword
+process.Ext.memory_region.mapped_path:
+  dashed_name: process-Ext-memory-region-mapped-path
+  description: If the memory corresponds to a file mapping, this is the file's path.
+  example: C:\Windows\System32\mshtml.dll
+  flat_name: process.Ext.memory_region.mapped_path
+  ignore_above: 1024
+  level: custom
+  name: mapped_path
+  normalize: []
+  original_fieldset: memory_region
+  short: If the memory corresponds to a file mapping, this is the file's path.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.dotnet:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-dotnet
+  description: Whether this file is a .NET PE
+  example: 'true'
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.dotnet
+  level: custom
+  name: Ext.dotnet
+  normalize: []
+  original_fieldset: pe
+  short: Whether this file is a .NET PE
+  type: boolean
+process.Ext.memory_region.mapped_pe.Ext.sections:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-sections
+  description: The file's relevant sections, if it is a PE
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.sections
+  level: custom
+  name: Ext.sections
+  normalize: []
+  object_type: keyword
+  original_fieldset: pe
+  short: The file's sections, if it is a PE
+  type: object
+process.Ext.memory_region.mapped_pe.Ext.sections.hash.md5:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-sections-hash-md5
+  description: MD5 hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha1:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-sections-hash-sha1
+  description: SHA1 hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha256:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-sections-hash-sha256
+  description: SHA256 hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha384:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-sections-hash-sha384
+  description: SHA384 hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha384
+  ignore_above: 1024
+  level: extended
+  name: sha384
+  normalize: []
+  original_fieldset: hash
+  short: SHA384 hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha512:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-sections-hash-sha512
+  description: SHA512 hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.sections.hash.ssdeep:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-sections-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.sections.hash.tlsh:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-sections-hash-tlsh
+  description: TLSH hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.tlsh
+  ignore_above: 1024
+  level: extended
+  name: tlsh
+  normalize: []
+  original_fieldset: hash
+  short: TLSH hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.sections.name:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-sections-name
+  description: The section's name
+  example: .reloc
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.sections.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.sections.name
+  normalize: []
+  original_fieldset: pe
+  short: The section's name
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.streams:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-streams
+  description: The file's streams, if it is a PE
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.streams
+  level: custom
+  name: Ext.streams
+  normalize: []
+  object_type: keyword
+  original_fieldset: pe
+  short: The file's streams, if it is a PE
+  type: object
+process.Ext.memory_region.mapped_pe.Ext.streams.hash.md5:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-streams-hash-md5
+  description: MD5 hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha1:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-streams-hash-sha1
+  description: SHA1 hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha256:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-streams-hash-sha256
+  description: SHA256 hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha384:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-streams-hash-sha384
+  description: SHA384 hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha384
+  ignore_above: 1024
+  level: extended
+  name: sha384
+  normalize: []
+  original_fieldset: hash
+  short: SHA384 hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha512:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-streams-hash-sha512
+  description: SHA512 hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.streams.hash.ssdeep:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-streams-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.streams.hash.tlsh:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-streams-hash-tlsh
+  description: TLSH hash.
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.tlsh
+  ignore_above: 1024
+  level: extended
+  name: tlsh
+  normalize: []
+  original_fieldset: hash
+  short: TLSH hash.
+  type: keyword
+process.Ext.memory_region.mapped_pe.Ext.streams.name:
+  dashed_name: process-Ext-memory-region-mapped-pe-Ext-streams-name
+  description: The stream's name
+  example: .reloc
+  flat_name: process.Ext.memory_region.mapped_pe.Ext.streams.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.streams.name
+  normalize: []
+  original_fieldset: pe
+  short: The stream's name
+  type: keyword
+process.Ext.memory_region.mapped_pe.architecture:
+  dashed_name: process-Ext-memory-region-mapped-pe-architecture
+  description: CPU architecture target for the file.
+  example: x64
+  flat_name: process.Ext.memory_region.mapped_pe.architecture
+  ignore_above: 1024
+  level: extended
+  name: architecture
+  normalize: []
+  original_fieldset: pe
+  short: CPU architecture target for the file.
+  type: keyword
+process.Ext.memory_region.mapped_pe.company:
+  dashed_name: process-Ext-memory-region-mapped-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: process.Ext.memory_region.mapped_pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+process.Ext.memory_region.mapped_pe.description:
+  dashed_name: process-Ext-memory-region-mapped-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: process.Ext.memory_region.mapped_pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+process.Ext.memory_region.mapped_pe.file_version:
+  dashed_name: process-Ext-memory-region-mapped-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: process.Ext.memory_region.mapped_pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+process.Ext.memory_region.mapped_pe.go_import_hash:
+  dashed_name: process-Ext-memory-region-mapped-pe-go-import-hash
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.Ext.memory_region.mapped_pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in a PE file.
+  type: keyword
+process.Ext.memory_region.mapped_pe.go_imports:
+  dashed_name: process-Ext-memory-region-mapped-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.Ext.memory_region.mapped_pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+process.Ext.memory_region.mapped_pe.go_imports_names_entropy:
+  dashed_name: process-Ext-memory-region-mapped-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.Ext.memory_region.mapped_pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.Ext.memory_region.mapped_pe.go_imports_names_var_entropy:
+  dashed_name: process-Ext-memory-region-mapped-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.Ext.memory_region.mapped_pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.Ext.memory_region.mapped_pe.go_stripped:
+  dashed_name: process-Ext-memory-region-mapped-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.Ext.memory_region.mapped_pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
+process.Ext.memory_region.mapped_pe.imphash:
+  dashed_name: process-Ext-memory-region-mapped-pe-imphash
+  description: 'A hash of the imports in a PE file. An imphash -- or import hash --
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+
+    Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+  example: 0c6803c4e922103c4dca5963aad36ddf
+  flat_name: process.Ext.memory_region.mapped_pe.imphash
+  ignore_above: 1024
+  level: extended
+  name: imphash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in a PE file.
+  type: keyword
+process.Ext.memory_region.mapped_pe.import_hash:
+  dashed_name: process-Ext-memory-region-mapped-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.Ext.memory_region.mapped_pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in a PE file.
+  type: keyword
+process.Ext.memory_region.mapped_pe.imports:
+  dashed_name: process-Ext-memory-region-mapped-pe-imports
+  description: List of imported element names and types.
+  flat_name: process.Ext.memory_region.mapped_pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+process.Ext.memory_region.mapped_pe.imports_names_entropy:
+  dashed_name: process-Ext-memory-region-mapped-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.Ext.memory_region.mapped_pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.Ext.memory_region.mapped_pe.imports_names_var_entropy:
+  dashed_name: process-Ext-memory-region-mapped-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.Ext.memory_region.mapped_pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
+process.Ext.memory_region.mapped_pe.original_file_name:
+  dashed_name: process-Ext-memory-region-mapped-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: process.Ext.memory_region.mapped_pe.original_file_name
+  ignore_above: 1024
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: keyword
+process.Ext.memory_region.mapped_pe.pehash:
+  dashed_name: process-Ext-memory-region-mapped-pe-pehash
+  description: 'A hash of the PE header and data from one or more PE sections. An
+    pehash can be used to cluster files by transforming structural information about
+    a file into a hash value.
+
+    Learn more at https://www.usenix.org/legacy/events/leet09/tech/full_papers/wicherski/wicherski_html/index.html.'
+  example: 73ff189b63cd6be375a7ff25179a38d347651975
+  flat_name: process.Ext.memory_region.mapped_pe.pehash
+  ignore_above: 1024
+  level: extended
+  name: pehash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the PE header and data from one or more PE sections.
+  type: keyword
+process.Ext.memory_region.mapped_pe.product:
+  dashed_name: process-Ext-memory-region-mapped-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: process.Ext.memory_region.mapped_pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+process.Ext.memory_region.mapped_pe.sections:
+  dashed_name: process-Ext-memory-region-mapped-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: process.Ext.memory_region.mapped_pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+process.Ext.memory_region.mapped_pe.sections.entropy:
+  dashed_name: process-Ext-memory-region-mapped-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.Ext.memory_region.mapped_pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+process.Ext.memory_region.mapped_pe.sections.name:
+  dashed_name: process-Ext-memory-region-mapped-pe-sections-name
+  description: PE Section List name.
+  flat_name: process.Ext.memory_region.mapped_pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+process.Ext.memory_region.mapped_pe.sections.physical_size:
+  dashed_name: process-Ext-memory-region-mapped-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: process.Ext.memory_region.mapped_pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+process.Ext.memory_region.mapped_pe.sections.var_entropy:
+  dashed_name: process-Ext-memory-region-mapped-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.Ext.memory_region.mapped_pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+process.Ext.memory_region.mapped_pe.sections.virtual_size:
+  dashed_name: process-Ext-memory-region-mapped-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: process.Ext.memory_region.mapped_pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
+process.Ext.memory_region.mapped_pe_detected:
+  dashed_name: process-Ext-memory-region-mapped-pe-detected
+  description: Whether the file at mapped_path is an executable.
+  example: false
+  flat_name: process.Ext.memory_region.mapped_pe_detected
+  level: custom
+  name: mapped_pe_detected
+  normalize: []
+  original_fieldset: memory_region
+  short: Whether the file at mapped_path is an executable.
+  type: boolean
+process.Ext.memory_region.memory_pe.Ext.dotnet:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-dotnet
+  description: Whether this file is a .NET PE
+  example: 'true'
+  flat_name: process.Ext.memory_region.memory_pe.Ext.dotnet
+  level: custom
+  name: Ext.dotnet
+  normalize: []
+  original_fieldset: pe
+  short: Whether this file is a .NET PE
+  type: boolean
+process.Ext.memory_region.memory_pe.Ext.sections:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-sections
+  description: The file's relevant sections, if it is a PE
+  flat_name: process.Ext.memory_region.memory_pe.Ext.sections
+  level: custom
+  name: Ext.sections
+  normalize: []
+  object_type: keyword
+  original_fieldset: pe
+  short: The file's sections, if it is a PE
+  type: object
+process.Ext.memory_region.memory_pe.Ext.sections.hash.md5:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-sections-hash-md5
+  description: MD5 hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.sections.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.sections.hash.sha1:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-sections-hash-sha1
+  description: SHA1 hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.sections.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.sections.hash.sha256:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-sections-hash-sha256
+  description: SHA256 hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.sections.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.sections.hash.sha384:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-sections-hash-sha384
+  description: SHA384 hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.sections.hash.sha384
+  ignore_above: 1024
+  level: extended
+  name: sha384
+  normalize: []
+  original_fieldset: hash
+  short: SHA384 hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.sections.hash.sha512:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-sections-hash-sha512
+  description: SHA512 hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.sections.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.sections.hash.ssdeep:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-sections-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.sections.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.sections.hash.tlsh:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-sections-hash-tlsh
+  description: TLSH hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.sections.hash.tlsh
+  ignore_above: 1024
+  level: extended
+  name: tlsh
+  normalize: []
+  original_fieldset: hash
+  short: TLSH hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.sections.name:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-sections-name
+  description: The section's name
+  example: .reloc
+  flat_name: process.Ext.memory_region.memory_pe.Ext.sections.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.sections.name
+  normalize: []
+  original_fieldset: pe
+  short: The section's name
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.streams:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-streams
+  description: The file's streams, if it is a PE
+  flat_name: process.Ext.memory_region.memory_pe.Ext.streams
+  level: custom
+  name: Ext.streams
+  normalize: []
+  object_type: keyword
+  original_fieldset: pe
+  short: The file's streams, if it is a PE
+  type: object
+process.Ext.memory_region.memory_pe.Ext.streams.hash.md5:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-streams-hash-md5
+  description: MD5 hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.streams.hash.md5
+  ignore_above: 1024
+  level: extended
+  name: md5
+  normalize: []
+  original_fieldset: hash
+  short: MD5 hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.streams.hash.sha1:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-streams-hash-sha1
+  description: SHA1 hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.streams.hash.sha1
+  ignore_above: 1024
+  level: extended
+  name: sha1
+  normalize: []
+  original_fieldset: hash
+  short: SHA1 hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.streams.hash.sha256:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-streams-hash-sha256
+  description: SHA256 hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.streams.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.streams.hash.sha384:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-streams-hash-sha384
+  description: SHA384 hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.streams.hash.sha384
+  ignore_above: 1024
+  level: extended
+  name: sha384
+  normalize: []
+  original_fieldset: hash
+  short: SHA384 hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.streams.hash.sha512:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-streams-hash-sha512
+  description: SHA512 hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.streams.hash.sha512
+  ignore_above: 1024
+  level: extended
+  name: sha512
+  normalize: []
+  original_fieldset: hash
+  short: SHA512 hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.streams.hash.ssdeep:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-streams-hash-ssdeep
+  description: SSDEEP hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.streams.hash.ssdeep
+  ignore_above: 1024
+  level: extended
+  name: ssdeep
+  normalize: []
+  original_fieldset: hash
+  short: SSDEEP hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.streams.hash.tlsh:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-streams-hash-tlsh
+  description: TLSH hash.
+  flat_name: process.Ext.memory_region.memory_pe.Ext.streams.hash.tlsh
+  ignore_above: 1024
+  level: extended
+  name: tlsh
+  normalize: []
+  original_fieldset: hash
+  short: TLSH hash.
+  type: keyword
+process.Ext.memory_region.memory_pe.Ext.streams.name:
+  dashed_name: process-Ext-memory-region-memory-pe-Ext-streams-name
+  description: The stream's name
+  example: .reloc
+  flat_name: process.Ext.memory_region.memory_pe.Ext.streams.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.streams.name
+  normalize: []
+  original_fieldset: pe
+  short: The stream's name
+  type: keyword
+process.Ext.memory_region.memory_pe.architecture:
+  dashed_name: process-Ext-memory-region-memory-pe-architecture
+  description: CPU architecture target for the file.
+  example: x64
+  flat_name: process.Ext.memory_region.memory_pe.architecture
+  ignore_above: 1024
+  level: extended
+  name: architecture
+  normalize: []
+  original_fieldset: pe
+  short: CPU architecture target for the file.
+  type: keyword
+process.Ext.memory_region.memory_pe.company:
+  dashed_name: process-Ext-memory-region-memory-pe-company
+  description: Internal company name of the file, provided at compile-time.
+  example: Microsoft Corporation
+  flat_name: process.Ext.memory_region.memory_pe.company
+  ignore_above: 1024
+  level: extended
+  name: company
+  normalize: []
+  original_fieldset: pe
+  short: Internal company name of the file, provided at compile-time.
+  type: keyword
+process.Ext.memory_region.memory_pe.description:
+  dashed_name: process-Ext-memory-region-memory-pe-description
+  description: Internal description of the file, provided at compile-time.
+  example: Paint
+  flat_name: process.Ext.memory_region.memory_pe.description
+  ignore_above: 1024
+  level: extended
+  name: description
+  normalize: []
+  original_fieldset: pe
+  short: Internal description of the file, provided at compile-time.
+  type: keyword
+process.Ext.memory_region.memory_pe.file_version:
+  dashed_name: process-Ext-memory-region-memory-pe-file-version
+  description: Internal version of the file, provided at compile-time.
+  example: 6.3.9600.17415
+  flat_name: process.Ext.memory_region.memory_pe.file_version
+  ignore_above: 1024
+  level: extended
+  name: file_version
+  normalize: []
+  original_fieldset: pe
+  short: Process name.
+  type: keyword
+process.Ext.memory_region.memory_pe.go_import_hash:
+  dashed_name: process-Ext-memory-region-memory-pe-go-import-hash
+  description: 'A hash of the Go language imports in a PE file excluding standard
+    library imports. An import hash can be used to fingerprint binaries even after
+    recompilation or other code-level transformations have occurred, which would change
+    more traditional hash values.
+
+    The algorithm used to calculate the Go symbol hash and a reference implementation
+    are available [here](https://github.com/elastic/toutoumomoma).'
+  example: 10bddcb4cee42080f76c88d9ff964491
+  flat_name: process.Ext.memory_region.memory_pe.go_import_hash
+  ignore_above: 1024
+  level: extended
+  name: go_import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the Go language imports in a PE file.
+  type: keyword
+process.Ext.memory_region.memory_pe.go_imports:
+  dashed_name: process-Ext-memory-region-memory-pe-go-imports
+  description: List of imported Go language element names and types.
+  flat_name: process.Ext.memory_region.memory_pe.go_imports
+  level: extended
+  name: go_imports
+  normalize: []
+  original_fieldset: pe
+  short: List of imported Go language element names and types.
+  type: flattened
+process.Ext.memory_region.memory_pe.go_imports_names_entropy:
+  dashed_name: process-Ext-memory-region-memory-pe-go-imports-names-entropy
+  description: Shannon entropy calculation from the list of Go imports.
+  flat_name: process.Ext.memory_region.memory_pe.go_imports_names_entropy
+  format: number
+  level: extended
+  name: go_imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of Go imports.
+  type: long
+process.Ext.memory_region.memory_pe.go_imports_names_var_entropy:
+  dashed_name: process-Ext-memory-region-memory-pe-go-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of Go imports.
+  flat_name: process.Ext.memory_region.memory_pe.go_imports_names_var_entropy
+  format: number
+  level: extended
+  name: go_imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of Go imports.
+  type: long
+process.Ext.memory_region.memory_pe.go_stripped:
+  dashed_name: process-Ext-memory-region-memory-pe-go-stripped
+  description: Set to true if the file is a Go executable that has had its symbols
+    stripped or obfuscated and false if an unobfuscated Go executable.
+  flat_name: process.Ext.memory_region.memory_pe.go_stripped
+  level: extended
+  name: go_stripped
+  normalize: []
+  original_fieldset: pe
+  short: Whether the file is a stripped or obfuscated Go executable.
+  type: boolean
+process.Ext.memory_region.memory_pe.imphash:
+  dashed_name: process-Ext-memory-region-memory-pe-imphash
+  description: 'A hash of the imports in a PE file. An imphash -- or import hash --
+    can be used to fingerprint binaries even after recompilation or other code-level
+    transformations have occurred, which would change more traditional hash values.
+
+    Learn more at https://www.fireeye.com/blog/threat-research/2014/01/tracking-malware-import-hashing.html.'
+  example: 0c6803c4e922103c4dca5963aad36ddf
+  flat_name: process.Ext.memory_region.memory_pe.imphash
+  ignore_above: 1024
+  level: extended
+  name: imphash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in a PE file.
+  type: keyword
+process.Ext.memory_region.memory_pe.import_hash:
+  dashed_name: process-Ext-memory-region-memory-pe-import-hash
+  description: 'A hash of the imports in a PE file. An import hash can be used to
+    fingerprint binaries even after recompilation or other code-level transformations
+    have occurred, which would change more traditional hash values.
+
+    This is a synonym for imphash.'
+  example: d41d8cd98f00b204e9800998ecf8427e
+  flat_name: process.Ext.memory_region.memory_pe.import_hash
+  ignore_above: 1024
+  level: extended
+  name: import_hash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the imports in a PE file.
+  type: keyword
+process.Ext.memory_region.memory_pe.imports:
+  dashed_name: process-Ext-memory-region-memory-pe-imports
+  description: List of imported element names and types.
+  flat_name: process.Ext.memory_region.memory_pe.imports
+  level: extended
+  name: imports
+  normalize:
+  - array
+  original_fieldset: pe
+  short: List of imported element names and types.
+  type: flattened
+process.Ext.memory_region.memory_pe.imports_names_entropy:
+  dashed_name: process-Ext-memory-region-memory-pe-imports-names-entropy
+  description: Shannon entropy calculation from the list of imported element names
+    and types.
+  flat_name: process.Ext.memory_region.memory_pe.imports_names_entropy
+  format: number
+  level: extended
+  name: imports_names_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the list of imported element names and types.
+  type: long
+process.Ext.memory_region.memory_pe.imports_names_var_entropy:
+  dashed_name: process-Ext-memory-region-memory-pe-imports-names-var-entropy
+  description: Variance for Shannon entropy calculation from the list of imported
+    element names and types.
+  flat_name: process.Ext.memory_region.memory_pe.imports_names_var_entropy
+  format: number
+  level: extended
+  name: imports_names_var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the list of imported element
+    names and types.
+  type: long
+process.Ext.memory_region.memory_pe.original_file_name:
+  dashed_name: process-Ext-memory-region-memory-pe-original-file-name
+  description: Internal name of the file, provided at compile-time.
+  example: MSPAINT.EXE
+  flat_name: process.Ext.memory_region.memory_pe.original_file_name
+  ignore_above: 1024
+  level: extended
+  name: original_file_name
+  normalize: []
+  original_fieldset: pe
+  short: Internal name of the file, provided at compile-time.
+  type: keyword
+process.Ext.memory_region.memory_pe.pehash:
+  dashed_name: process-Ext-memory-region-memory-pe-pehash
+  description: 'A hash of the PE header and data from one or more PE sections. An
+    pehash can be used to cluster files by transforming structural information about
+    a file into a hash value.
+
+    Learn more at https://www.usenix.org/legacy/events/leet09/tech/full_papers/wicherski/wicherski_html/index.html.'
+  example: 73ff189b63cd6be375a7ff25179a38d347651975
+  flat_name: process.Ext.memory_region.memory_pe.pehash
+  ignore_above: 1024
+  level: extended
+  name: pehash
+  normalize: []
+  original_fieldset: pe
+  short: A hash of the PE header and data from one or more PE sections.
+  type: keyword
+process.Ext.memory_region.memory_pe.product:
+  dashed_name: process-Ext-memory-region-memory-pe-product
+  description: Internal product name of the file, provided at compile-time.
+  example: "Microsoft\xAE Windows\xAE Operating System"
+  flat_name: process.Ext.memory_region.memory_pe.product
+  ignore_above: 1024
+  level: extended
+  name: product
+  normalize: []
+  original_fieldset: pe
+  short: Internal product name of the file, provided at compile-time.
+  type: keyword
+process.Ext.memory_region.memory_pe.sections:
+  dashed_name: process-Ext-memory-region-memory-pe-sections
+  description: 'An array containing an object for each section of the PE file.
+
+    The keys that should be present in these objects are defined by sub-fields underneath
+    `pe.sections.*`.'
+  flat_name: process.Ext.memory_region.memory_pe.sections
+  level: extended
+  name: sections
+  normalize:
+  - array
+  original_fieldset: pe
+  short: Section information of the PE file.
+  type: nested
+process.Ext.memory_region.memory_pe.sections.entropy:
+  dashed_name: process-Ext-memory-region-memory-pe-sections-entropy
+  description: Shannon entropy calculation from the section.
+  flat_name: process.Ext.memory_region.memory_pe.sections.entropy
+  format: number
+  level: extended
+  name: sections.entropy
+  normalize: []
+  original_fieldset: pe
+  short: Shannon entropy calculation from the section.
+  type: long
+process.Ext.memory_region.memory_pe.sections.name:
+  dashed_name: process-Ext-memory-region-memory-pe-sections-name
+  description: PE Section List name.
+  flat_name: process.Ext.memory_region.memory_pe.sections.name
+  ignore_above: 1024
+  level: extended
+  name: sections.name
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List name.
+  type: keyword
+process.Ext.memory_region.memory_pe.sections.physical_size:
+  dashed_name: process-Ext-memory-region-memory-pe-sections-physical-size
+  description: PE Section List physical size.
+  flat_name: process.Ext.memory_region.memory_pe.sections.physical_size
+  format: bytes
+  level: extended
+  name: sections.physical_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List physical size.
+  type: long
+process.Ext.memory_region.memory_pe.sections.var_entropy:
+  dashed_name: process-Ext-memory-region-memory-pe-sections-var-entropy
+  description: Variance for Shannon entropy calculation from the section.
+  flat_name: process.Ext.memory_region.memory_pe.sections.var_entropy
+  format: number
+  level: extended
+  name: sections.var_entropy
+  normalize: []
+  original_fieldset: pe
+  short: Variance for Shannon entropy calculation from the section.
+  type: long
+process.Ext.memory_region.memory_pe.sections.virtual_size:
+  dashed_name: process-Ext-memory-region-memory-pe-sections-virtual-size
+  description: PE Section List virtual size. This is always the same as `physical_size`.
+  flat_name: process.Ext.memory_region.memory_pe.sections.virtual_size
+  format: string
+  level: extended
+  name: sections.virtual_size
+  normalize: []
+  original_fieldset: pe
+  short: PE Section List virtual size. This is always the same as `physical_size`.
+  type: long
+process.Ext.memory_region.memory_pe_detected:
+  dashed_name: process-Ext-memory-region-memory-pe-detected
+  description: Whether an executable file was found in memory.
+  example: false
+  flat_name: process.Ext.memory_region.memory_pe_detected
+  level: custom
+  name: memory_pe_detected
+  normalize: []
+  original_fieldset: memory_region
+  short: Whether an executable file was found in memory.
+  type: boolean
+process.Ext.memory_region.region_base:
+  dashed_name: process-Ext-memory-region-region-base
+  description: Base address of the memory region.
+  example: 2431737462784
+  flat_name: process.Ext.memory_region.region_base
+  level: custom
+  name: region_base
+  normalize: []
+  original_fieldset: memory_region
+  short: Base address of the memory region.
+  type: unsigned_long
+process.Ext.memory_region.region_protection:
+  dashed_name: process-Ext-memory-region-region-protection
+  description: Memory protection of the memory region. Example values include "RWX"
+    and "R-X".
+  example: RWX
+  flat_name: process.Ext.memory_region.region_protection
+  ignore_above: 1024
+  level: custom
+  name: region_protection
+  normalize: []
+  original_fieldset: memory_region
+  short: Memory protection of the memory region. Example values include "RWX" and
+    "R-X".
+  type: keyword
+process.Ext.memory_region.region_size:
+  dashed_name: process-Ext-memory-region-region-size
+  description: Size of the memory region.
+  example: 4096
+  flat_name: process.Ext.memory_region.region_size
+  level: custom
+  name: region_size
+  normalize: []
+  original_fieldset: memory_region
+  short: Size of the memory region.
+  type: unsigned_long
+process.Ext.memory_region.region_state:
+  dashed_name: process-Ext-memory-region-region-state
+  description: State of the memory region. Example values include "RESERVE", "COMMIT",
+    and "FREE".
+  example: COMMIT
+  flat_name: process.Ext.memory_region.region_state
+  ignore_above: 1024
+  level: custom
+  name: region_state
+  normalize: []
+  original_fieldset: memory_region
+  short: State of the memory region. Example values include "RESERVE", "COMMIT", and
+    "FREE".
+  type: keyword
+process.Ext.memory_region.strings:
+  dashed_name: process-Ext-memory-region-strings
+  description: Array of strings found within the memory region.
+  doc_values: false
+  flat_name: process.Ext.memory_region.strings
+  index: false
+  level: custom
+  name: strings
+  normalize: []
+  original_fieldset: memory_region
+  short: Array of strings found within the memory region.
+  type: keyword
 process.Ext.protection:
   dashed_name: process-Ext-protection
   description: Indicates the protection level of this process.  Uses the same syntax


### PR DESCRIPTION
Add missing `[Target.]process.Ext.memory_region` fields to api events.
These optional fields were introduced in 8.11.0