### PR TITLE
Enable Unattended Transforms

### DIFF
--- a/package/endpoint/elasticsearch/transform/metadata_current/transform.yml
+++ b/package/endpoint/elasticsearch/transform/metadata_current/transform.yml
@@ -18,3 +18,5 @@ sync:
   time:
     field: event.ingested
     delay: 1s
+settings:
+  unattended: true

--- a/package/endpoint/elasticsearch/transform/metadata_united/transform.yml
+++ b/package/endpoint/elasticsearch/transform/metadata_united/transform.yml
@@ -24,3 +24,5 @@ pivot:
 description: Merges latest Endpoint and Agent metadata documents
 _meta:
   managed: true
+settings:
+  unattended: true


### PR DESCRIPTION
## Change Summary

the `unattended` setting was developed for these transforms as the ideal use-case. There were previous transient install issues with using in the past, that may have been resolved with https://github.com/elastic/elasticsearch/pull/101627

Local testing has so far resulted in consistent destination index being created, and working transforms:

![2023-11-02-143849_scrot](https://github.com/elastic/endpoint-package/assets/315796/44be854a-fb46-49b5-976b-3ce01b6f0a4f)
![2023-11-02-143948_scrot](https://github.com/elastic/endpoint-package/assets/315796/6efd3745-5eea-473f-b45f-a0909b7ae516)



## Release Target

8.12


## Q/A



### For Transform changes:

- [x] The new transform successfully starts in Kibana
- [x] The corresponding transform destination schema was updated if necessary
