### PR TITLE
artifacts manifest update age, snapshot date (#440)

### DIFF
--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -336,6 +336,16 @@
       type: object
       description: information about global protection artifacts applied.
 
+    - name: policy.applied.artifacts.global.update_age
+      level: custom
+      type: unsigned_long
+      description: number of days since global artifacts were made up-to-date
+
+    - name: policy.applied.artifacts.global.snapshot
+      level: custom
+      type: keyword
+      description: the snapshot date of applied global artifacts or 'latest'
+
     - name: policy.applied.artifacts.global.version
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -70,6 +70,17 @@
       ignore_above: 1024
       description: the sha256 of global artifacts applied.
       default_field: false
+    - name: policy.applied.artifacts.global.snapshot
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: the snapshot date of applied global artifacts or 'latest'
+      default_field: false
+    - name: policy.applied.artifacts.global.update_age
+      level: custom
+      type: unsigned_long
+      description: number of days since global artifacts were made up-to-date
+      default_field: false
     - name: policy.applied.artifacts.global.version
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/alerts/sample_event.json
+++ b/package/endpoint/data_stream/alerts/sample_event.json
@@ -449,6 +449,8 @@
                                 "name": "production-rules-windows-v1"
                             }
                         ],
+                        "update_age": 0,
+                        "snapshot": "2023-09-26",
                         "version": "1.0.260"
                     },
                     "user": {

--- a/package/endpoint/data_stream/policy/fields/fields.yml
+++ b/package/endpoint/data_stream/policy/fields/fields.yml
@@ -100,6 +100,17 @@
       ignore_above: 1024
       description: the sha256 of global artifacts applied.
       default_field: false
+    - name: policy.applied.artifacts.global.snapshot
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: the snapshot date of applied global artifacts or 'latest'
+      default_field: false
+    - name: policy.applied.artifacts.global.update_age
+      level: custom
+      type: unsigned_long
+      description: number of days since global artifacts were made up-to-date
+      default_field: false
     - name: policy.applied.artifacts.global.version
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/policy/sample_event.json
+++ b/package/endpoint/data_stream/policy/sample_event.json
@@ -525,6 +525,8 @@
                                 "name": "production-rules-windows-v1"
                             }
                         ],
+                        "update_age": 0,
+                        "snapshot": "2023-09-26",
                         "version": "1.0.261"
                     },
                     "user": {

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -83,6 +83,25 @@ Endpoint.policy.applied.artifacts.global.identifiers.sha256:
   normalize: []
   short: the sha256 of global artifacts applied.
   type: keyword
+Endpoint.policy.applied.artifacts.global.snapshot:
+  dashed_name: Endpoint-policy-applied-artifacts-global-snapshot
+  description: the snapshot date of applied global artifacts or 'latest'
+  flat_name: Endpoint.policy.applied.artifacts.global.snapshot
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.artifacts.global.snapshot
+  normalize: []
+  short: the snapshot date of applied global artifacts or 'latest'
+  type: keyword
+Endpoint.policy.applied.artifacts.global.update_age:
+  dashed_name: Endpoint-policy-applied-artifacts-global-update-age
+  description: number of days since global artifacts were made up-to-date
+  flat_name: Endpoint.policy.applied.artifacts.global.update_age
+  level: custom
+  name: policy.applied.artifacts.global.update_age
+  normalize: []
+  short: number of days since global artifacts were made up-to-date
+  type: unsigned_long
 Endpoint.policy.applied.artifacts.global.version:
   dashed_name: Endpoint-policy-applied-artifacts-global-version
   description: the version of global artifacts applied.

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -83,6 +83,25 @@ Endpoint.policy.applied.artifacts.global.identifiers.sha256:
   normalize: []
   short: the sha256 of global artifacts applied.
   type: keyword
+Endpoint.policy.applied.artifacts.global.snapshot:
+  dashed_name: Endpoint-policy-applied-artifacts-global-snapshot
+  description: the snapshot date of applied global artifacts or 'latest'
+  flat_name: Endpoint.policy.applied.artifacts.global.snapshot
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.artifacts.global.snapshot
+  normalize: []
+  short: the snapshot date of applied global artifacts or 'latest'
+  type: keyword
+Endpoint.policy.applied.artifacts.global.update_age:
+  dashed_name: Endpoint-policy-applied-artifacts-global-update-age
+  description: number of days since global artifacts were made up-to-date
+  flat_name: Endpoint.policy.applied.artifacts.global.update_age
+  level: custom
+  name: policy.applied.artifacts.global.update_age
+  normalize: []
+  short: number of days since global artifacts were made up-to-date
+  type: unsigned_long
 Endpoint.policy.applied.artifacts.global.version:
   dashed_name: Endpoint-policy-applied-artifacts-global-version
   description: the version of global artifacts applied.

--- a/schemas/v1/alerts/ransomware_event.yaml
+++ b/schemas/v1/alerts/ransomware_event.yaml
@@ -83,6 +83,25 @@ Endpoint.policy.applied.artifacts.global.identifiers.sha256:
   normalize: []
   short: the sha256 of global artifacts applied.
   type: keyword
+Endpoint.policy.applied.artifacts.global.snapshot:
+  dashed_name: Endpoint-policy-applied-artifacts-global-snapshot
+  description: the snapshot date of applied global artifacts or 'latest'
+  flat_name: Endpoint.policy.applied.artifacts.global.snapshot
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.artifacts.global.snapshot
+  normalize: []
+  short: the snapshot date of applied global artifacts or 'latest'
+  type: keyword
+Endpoint.policy.applied.artifacts.global.update_age:
+  dashed_name: Endpoint-policy-applied-artifacts-global-update-age
+  description: number of days since global artifacts were made up-to-date
+  flat_name: Endpoint.policy.applied.artifacts.global.update_age
+  level: custom
+  name: policy.applied.artifacts.global.update_age
+  normalize: []
+  short: number of days since global artifacts were made up-to-date
+  type: unsigned_long
 Endpoint.policy.applied.artifacts.global.version:
   dashed_name: Endpoint-policy-applied-artifacts-global-version
   description: the version of global artifacts applied.

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -147,6 +147,25 @@ Endpoint.policy.applied.artifacts.global.identifiers.sha256:
   normalize: []
   short: the sha256 of global artifacts applied.
   type: keyword
+Endpoint.policy.applied.artifacts.global.snapshot:
+  dashed_name: Endpoint-policy-applied-artifacts-global-snapshot
+  description: the snapshot date of applied global artifacts or 'latest'
+  flat_name: Endpoint.policy.applied.artifacts.global.snapshot
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.artifacts.global.snapshot
+  normalize: []
+  short: the snapshot date of applied global artifacts or 'latest'
+  type: keyword
+Endpoint.policy.applied.artifacts.global.update_age:
+  dashed_name: Endpoint-policy-applied-artifacts-global-update-age
+  description: number of days since global artifacts were made up-to-date
+  flat_name: Endpoint.policy.applied.artifacts.global.update_age
+  level: custom
+  name: policy.applied.artifacts.global.update_age
+  normalize: []
+  short: number of days since global artifacts were made up-to-date
+  type: unsigned_long
 Endpoint.policy.applied.artifacts.global.version:
   dashed_name: Endpoint-policy-applied-artifacts-global-version
   description: the version of global artifacts applied.


### PR DESCRIPTION
backports #440 to `8.11`

This PR merged after the 8.11 freeze, but was never backported to the 8.11 branch.

Including it for the upcoming `8.11.1` release once #445 merges