### PR TITLE
make endpoint team sole owners of custom docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 # The security onboarding team manages this package.
 * @elastic/security-defend-workflows
+
+# The custom_docs do not ship with the package itself, and are managed by the endpoint team
+# later rules in this file take precedence over earlier
+/custom_documentation/ @elastic/elastic-endpoint


### PR DESCRIPTION
## Change Summary

Change owner of the `custom_documentation` folder (and all contents) to the endpoint team.


This folder and its contents are _not_ shipped into EPR, are _not_ linted by `elastic-package` and are _not_ regulated or restricted by `package-spec`. Its influence is entirely external.  Defend workflows team has no need to have oversight over the custom docs 



