### PR TITLE
Push an 8.12 preview from 8.11 changeset

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -208,7 +208,7 @@ def signUnpublishedArtifactsWithElastic(builtPackagesPath) {
 }
 
 def uploadUnpublishedToPackageStorage(builtPackagesPath) {
-  def dryRun = env.BRANCH_NAME != 'main'
+  def dryRun = env.BRANCH_NAME != '8.11'
   if (dryRun) {
     echo "Dry run: endpoint-package won't be published"
   }

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.11.1-preview
+version: 8.12.0-preview.2
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 # The default type is integration and will be set if empty.


### PR DESCRIPTION
## Change Summary

`8.12.0-preview.1` was pushed from `main`,  breaking a lot of tests, as serverless was still installing prerelease versions in (at least) tests.

Rolling back all changes to `main` since 8.11 branch was cut was a messier process than releasing an `8.12.0-preview.2` from here.

So this PR will create an 8.12 prerelease, with "known good" contents, which should be released on merge
