### PR TITLE
Keylogging (Win32k ETW) API Event (production) (rename some fields)

### DIFF
--- a/custom_schemas/custom_api.yml
+++ b/custom_schemas/custom_api.yml
@@ -110,14 +110,14 @@
         Thread info flags.
       example: 16
 
-    - name: metadata.module_name
+    - name: metadata.start_address_module
       level: custom
       type: keyword
       description: >
         Name of the module associated with the starting address of a thread.
       example: "C:\\Windows\\System32\\DellTPad\\ApMsgFwd.exe"
 
-    - name: metadata.allocation_protection
+    - name: metadata.start_address_allocation_protection
       level: custom
       type: keyword
       description: >

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -1126,25 +1126,11 @@
       object_type: keyword
       description: Information related to the API call.
       default_field: false
-    - name: Ext.api.metadata.allocation_protection
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: Memory protection attributes associated with the starting address of a thread.
-      example: RCX
-      default_field: false
     - name: Ext.api.metadata.background_callcount
       level: custom
       type: unsigned_long
       description: This parameter indicates a number of all GetAsyncKeyState api calls, including unsuccessfull calls, between the last successfull GetAsyncKeyState call.
       example: 6021
-      default_field: false
-    - name: Ext.api.metadata.module_name
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: Name of the module associated with the starting address of a thread.
-      example: C:\Windows\System32\DellTPad\ApMsgFwd.exe
       default_field: false
     - name: Ext.api.metadata.ms_since_last_keyevent
       level: custom
@@ -1164,6 +1150,20 @@
       type: unsigned_long
       description: Return value of RegisterRawInputDevices API call.
       example: 1
+      default_field: false
+    - name: Ext.api.metadata.start_address_allocation_protection
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Memory protection attributes associated with the starting address of a thread.
+      example: RCX
+      default_field: false
+    - name: Ext.api.metadata.start_address_module
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Name of the module associated with the starting address of a thread.
+      example: C:\Windows\System32\DellTPad\ApMsgFwd.exe
       default_field: false
     - name: Ext.api.metadata.target_address_name
       level: custom

--- a/package/endpoint/data_stream/api/sample_event.json
+++ b/package/endpoint/data_stream/api/sample_event.json
@@ -107,8 +107,8 @@
                     "windows_count": 2,
                     "visible_windows_count": 0,
                     "thread_info_flags": 16,
-                    "module_name": "C:\\Windows\\System32\\DellTPad\\ApMsgFwd.exe",
-                    "allocation_protection": "RCX",
+                    "start_address_module": "C:\\Windows\\System32\\DellTPad\\ApMsgFwd.exe",
+                    "start_address_allocation_protection": "RCX",
                     "procedure_symbol": "taskbar.dll",
                     "ms_since_last_keyevent": 94,
                     "background_callcount": 6021

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -2340,19 +2340,6 @@ process.Ext.api.metadata:
   original_fieldset: api
   short: Information related to the API call.
   type: object
-process.Ext.api.metadata.allocation_protection:
-  dashed_name: process-Ext-api-metadata-allocation-protection
-  description: Memory protection attributes associated with the starting address of
-    a thread.
-  example: RCX
-  flat_name: process.Ext.api.metadata.allocation_protection
-  ignore_above: 1024
-  level: custom
-  name: metadata.allocation_protection
-  normalize: []
-  original_fieldset: api
-  short: Memory protection attributes associated with the starting address of a thread.
-  type: keyword
 process.Ext.api.metadata.background_callcount:
   dashed_name: process-Ext-api-metadata-background-callcount
   description: This parameter indicates a number of all GetAsyncKeyState api calls,
@@ -2366,18 +2353,6 @@ process.Ext.api.metadata.background_callcount:
   short: This parameter indicates a number of all GetAsyncKeyState api calls, including
     unsuccessfull calls, between the last successfull GetAsyncKeyState call.
   type: unsigned_long
-process.Ext.api.metadata.module_name:
-  dashed_name: process-Ext-api-metadata-module-name
-  description: Name of the module associated with the starting address of a thread.
-  example: C:\Windows\System32\DellTPad\ApMsgFwd.exe
-  flat_name: process.Ext.api.metadata.module_name
-  ignore_above: 1024
-  level: custom
-  name: metadata.module_name
-  normalize: []
-  original_fieldset: api
-  short: Name of the module associated with the starting address of a thread.
-  type: keyword
 process.Ext.api.metadata.ms_since_last_keyevent:
   dashed_name: process-Ext-api-metadata-ms-since-last-keyevent
   description: This parameter indicates an elapsed time in milliseconds between the
@@ -2414,6 +2389,31 @@ process.Ext.api.metadata.return_value:
   original_fieldset: api
   short: Return value of RegisterRawInputDevices API call.
   type: unsigned_long
+process.Ext.api.metadata.start_address_allocation_protection:
+  dashed_name: process-Ext-api-metadata-start-address-allocation-protection
+  description: Memory protection attributes associated with the starting address of
+    a thread.
+  example: RCX
+  flat_name: process.Ext.api.metadata.start_address_allocation_protection
+  ignore_above: 1024
+  level: custom
+  name: metadata.start_address_allocation_protection
+  normalize: []
+  original_fieldset: api
+  short: Memory protection attributes associated with the starting address of a thread.
+  type: keyword
+process.Ext.api.metadata.start_address_module:
+  dashed_name: process-Ext-api-metadata-start-address-module
+  description: Name of the module associated with the starting address of a thread.
+  example: C:\Windows\System32\DellTPad\ApMsgFwd.exe
+  flat_name: process.Ext.api.metadata.start_address_module
+  ignore_above: 1024
+  level: custom
+  name: metadata.start_address_module
+  normalize: []
+  original_fieldset: api
+  short: Name of the module associated with the starting address of a thread.
+  type: keyword
 process.Ext.api.metadata.target_address_name:
   dashed_name: process-Ext-api-metadata-target-address-name
   description: The name of the memory region targeted by the API call.


### PR DESCRIPTION
## Change Summary

This PR renames the following ECS fileds at `custom_api.yml` and its `sample_event.json`

* `metadata.module_name` to `metadata.start_address_module`
* `metadata.allocation_protection` to `metadata.start_address_allocation_protection`

### Sample values
Sample values/document are written in [the previous PR](https://github.com/elastic/endpoint-package/pull/444).

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->



## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
