### PR TITLE
Original Extension field for file rename events

### DIFF
--- a/.buildkite/scripts/find_oldest_supported_version.py
+++ b/.buildkite/scripts/find_oldest_supported_version.py
@@ -116,7 +116,7 @@ def run(cfg: argparse.Namespace):
     with open(cfg.manifest_path, "r") as src:
         manifest_doc = yaml.safe_load(src)
 
-    kibana_version_condition = manifest_doc["conditions"]["kibana.version"]
+    kibana_version_condition = manifest_doc["conditions"]["kibana"]["version"]
     print(find_oldest_supported_version(kibana_version_condition), end="")
 
 

--- a/custom_schemas/custom_file.yml
+++ b/custom_schemas/custom_file.yml
@@ -93,6 +93,12 @@
       description: >
         Original file path prior to a modification event
 
+    - name: Ext.original.extension
+      level: custom
+      type: keyword
+      description: >
+        Original file extension prior to a modification event
+
     - name: Ext.original.mode
       level: custom
       type: keyword

--- a/custom_subsets/elastic_endpoint/file/file.yaml
+++ b/custom_subsets/elastic_endpoint/file/file.yaml
@@ -225,6 +225,7 @@ fields:
               name: {}
               path: {}
               mode: {}
+              extension: {}
               uid: {}
               owner: {}
               gid: {}

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -617,6 +617,12 @@
       ignore_above: 1024
       description: Original file path prior to a modification event
       default_field: false
+    - name: Ext.original.extension
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Original file extension prior to a modification event
+      default_field: false
     - name: Ext.original.uid
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -578,6 +578,12 @@
       object_type: keyword
       description: Original file information during a modification event.
       default_field: false
+    - name: Ext.original.extension
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Original file extension prior to a modification event
+      default_field: false
     - name: Ext.original.gid
       level: custom
       type: keyword
@@ -616,12 +622,6 @@
       type: keyword
       ignore_above: 1024
       description: Original file path prior to a modification event
-      default_field: false
-    - name: Ext.original.extension
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: Original file extension prior to a modification event
       default_field: false
     - name: Ext.original.uid
       level: custom

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1564,6 +1564,7 @@ sent by the endpoint.
 | file.Ext.malware_signature.version | Primary malware signature version. | keyword |
 | file.Ext.monotonic_id | File event monotonic ID. | unsigned_long |
 | file.Ext.original | Original file information during a modification event. | object |
+| file.Ext.original.extension | Original file extension prior to a modification event | keyword |
 | file.Ext.original.gid | Primary group ID (GID) of the file. | keyword |
 | file.Ext.original.group | Primary group name of the file. | keyword |
 | file.Ext.original.mode | Original file mode prior to a modification event | keyword |

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -1289,6 +1289,16 @@ file.Ext.original:
   object_type: keyword
   short: Original file information during a modification event.
   type: object
+file.Ext.original.extension:
+  dashed_name: file-Ext-original-extension
+  description: Original file extension prior to a modification event
+  flat_name: file.Ext.original.extension
+  ignore_above: 1024
+  level: custom
+  name: Ext.original.extension
+  normalize: []
+  short: Original file extension prior to a modification event
+  type: keyword
 file.Ext.original.gid:
   dashed_name: file-Ext-original-gid
   description: Primary group ID (GID) of the file.


### PR DESCRIPTION
## Change Summary


Add Original Extension field for file rename events

### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json


```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
