### PR TITLE
mark integration as requiring root-level agent

### DIFF
--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -20,6 +20,9 @@ conditions:
   elastic:
     capabilities: ["security"]
     subscription: basic
+agent:
+  privileges:
+    root: true
 icons:
   - src: "/img/security-logo-color-64px.svg"
     size: "16x16"


### PR DESCRIPTION
## Change Summary

- [Integrations that run as root should mark themselves so](https://github.com/elastic/integrations/issues/8642)
- [Kibana will display root requirements](https://github.com/elastic/kibana/pull/170478)
- The field is [supported by package-spec](https://github.com/elastic/package-spec/pull/605)




## Release Target

8.12

