### PR TITLE
remove obj type for api generated files

### DIFF
--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -110,7 +110,6 @@
     - name: process.Ext.memory_region.malware_signature.primary
       level: custom
       type: object
-      object_type: keyword
       description: The first matching details.
       default_field: false
     - name: process.Ext.memory_region.malware_signature.primary.matches
@@ -171,7 +170,6 @@
     - name: process.Ext.memory_region.mapped_pe.Ext.sections
       level: custom
       type: object
-      object_type: keyword
       description: The file's relevant sections, if it is a PE
       default_field: false
     - name: process.Ext.memory_region.mapped_pe.Ext.sections.hash.md5
@@ -226,7 +224,6 @@
     - name: process.Ext.memory_region.mapped_pe.Ext.streams
       level: custom
       type: object
-      object_type: keyword
       description: The file's streams, if it is a PE
       default_field: false
     - name: process.Ext.memory_region.mapped_pe.Ext.streams.hash.md5
@@ -447,7 +444,6 @@
     - name: process.Ext.memory_region.memory_pe.Ext.sections
       level: custom
       type: object
-      object_type: keyword
       description: The file's relevant sections, if it is a PE
       default_field: false
     - name: process.Ext.memory_region.memory_pe.Ext.sections.hash.md5
@@ -502,7 +498,6 @@
     - name: process.Ext.memory_region.memory_pe.Ext.streams
       level: custom
       type: object
-      object_type: keyword
       description: The file's streams, if it is a PE
       default_field: false
     - name: process.Ext.memory_region.memory_pe.Ext.streams.hash.md5
@@ -1574,7 +1569,6 @@
     - name: Ext.memory_region.malware_signature.primary
       level: custom
       type: object
-      object_type: keyword
       description: The first matching details.
       default_field: false
     - name: Ext.memory_region.malware_signature.primary.matches
@@ -1635,7 +1629,6 @@
     - name: Ext.memory_region.mapped_pe.Ext.sections
       level: custom
       type: object
-      object_type: keyword
       description: The file's relevant sections, if it is a PE
       default_field: false
     - name: Ext.memory_region.mapped_pe.Ext.sections.hash.md5
@@ -1690,7 +1683,6 @@
     - name: Ext.memory_region.mapped_pe.Ext.streams
       level: custom
       type: object
-      object_type: keyword
       description: The file's streams, if it is a PE
       default_field: false
     - name: Ext.memory_region.mapped_pe.Ext.streams.hash.md5
@@ -1911,7 +1903,6 @@
     - name: Ext.memory_region.memory_pe.Ext.sections
       level: custom
       type: object
-      object_type: keyword
       description: The file's relevant sections, if it is a PE
       default_field: false
     - name: Ext.memory_region.memory_pe.Ext.sections.hash.md5
@@ -1966,7 +1957,6 @@
     - name: Ext.memory_region.memory_pe.Ext.streams
       level: custom
       type: object
-      object_type: keyword
       description: The file's streams, if it is a PE
       default_field: false
     - name: Ext.memory_region.memory_pe.Ext.streams.hash.md5

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -168,7 +168,6 @@ Target.process.Ext.memory_region.malware_signature.primary:
   level: custom
   name: primary
   normalize: []
-  object_type: keyword
   original_fieldset: malware_signature
   short: The first matching details.
   type: object
@@ -279,7 +278,6 @@ Target.process.Ext.memory_region.mapped_pe.Ext.sections:
   level: custom
   name: Ext.sections
   normalize: []
-  object_type: keyword
   original_fieldset: pe
   short: The file's sections, if it is a PE
   type: object
@@ -379,7 +377,6 @@ Target.process.Ext.memory_region.mapped_pe.Ext.streams:
   level: custom
   name: Ext.streams
   normalize: []
-  object_type: keyword
   original_fieldset: pe
   short: The file's streams, if it is a PE
   type: object
@@ -787,7 +784,6 @@ Target.process.Ext.memory_region.memory_pe.Ext.sections:
   level: custom
   name: Ext.sections
   normalize: []
-  object_type: keyword
   original_fieldset: pe
   short: The file's sections, if it is a PE
   type: object
@@ -887,7 +883,6 @@ Target.process.Ext.memory_region.memory_pe.Ext.streams:
   level: custom
   name: Ext.streams
   normalize: []
-  object_type: keyword
   original_fieldset: pe
   short: The file's streams, if it is a PE
   type: object
@@ -3169,7 +3164,6 @@ process.Ext.memory_region.malware_signature.primary:
   level: custom
   name: primary
   normalize: []
-  object_type: keyword
   original_fieldset: malware_signature
   short: The first matching details.
   type: object
@@ -3280,7 +3274,6 @@ process.Ext.memory_region.mapped_pe.Ext.sections:
   level: custom
   name: Ext.sections
   normalize: []
-  object_type: keyword
   original_fieldset: pe
   short: The file's sections, if it is a PE
   type: object
@@ -3380,7 +3373,6 @@ process.Ext.memory_region.mapped_pe.Ext.streams:
   level: custom
   name: Ext.streams
   normalize: []
-  object_type: keyword
   original_fieldset: pe
   short: The file's streams, if it is a PE
   type: object
@@ -3788,7 +3780,6 @@ process.Ext.memory_region.memory_pe.Ext.sections:
   level: custom
   name: Ext.sections
   normalize: []
-  object_type: keyword
   original_fieldset: pe
   short: The file's sections, if it is a PE
   type: object
@@ -3888,7 +3879,6 @@ process.Ext.memory_region.memory_pe.Ext.streams:
   level: custom
   name: Ext.streams
   normalize: []
-  object_type: keyword
   original_fieldset: pe
   short: The file's streams, if it is a PE
   type: object


### PR DESCRIPTION
## Change Summary

8.12 branch failing from diffs on these files. Looking to reconcile

```
21:29:07  :100644 100644 a5e712032f1cac5b9d7e03da8c02f0abc6584c02 0000000000000000000000000000000000000000 M	package/endpoint/data_stream/api/fields/fields.yml
21:29:07  :100644 100644 407721a6722d79f1581e911b9bfd7086f3ea6d8d 0000000000000000000000000000000000000000 M	schemas/v1/api/api.yaml
```


## Release Target

8.12


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes

