### PR TITLE
disable jenkins

### DIFF
--- a/.ci/jobs/endpoint-package-mbp.yml
+++ b/.ci/jobs/endpoint-package-mbp.yml
@@ -5,6 +5,7 @@
     description: endpoint-package
     project-type: multibranch
     script-path: .ci/Jenkinsfile
+    disabled: true
     scm:
       - github:
           branch-discovery: no-pr


### PR DESCRIPTION
## Change Summary

https://github.com/elastic/security-team/issues/6786

We confirmed that we are able to publish artifact using Buildkite pipeline https://buildkite.com/elastic/endpoint-package/builds/232, so this is a follow up PR that disables Jenkins pipeline.

Prior to merging this, someone with admin access to the repository must switch PR branch restriction to new Buildkite pipeline so that a PR is no longer blocked on Jenkins, but Buildkite CI.


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
