### PR TITLE
Fix kibana version condition and additional buildkite settings

### DIFF
--- a/.buildkite/scripts/find_oldest_supported_version.py
+++ b/.buildkite/scripts/find_oldest_supported_version.py
@@ -116,8 +116,16 @@ def run(cfg: argparse.Namespace):
     with open(cfg.manifest_path, "r") as src:
         manifest_doc = yaml.safe_load(src)
 
-    kibana_version_condition = manifest_doc["conditions"]["kibana"]["version"]
-    print(find_oldest_supported_version(kibana_version_condition), end="")
+    kibana_version_condition = ""
+    if "kibana.version" in manifest_doc["conditions"]:
+        kibana_version_condition = manifest_doc["conditions"]["kibana.version"]
+    elif "kibana" in manifest_doc["conditions"]:
+        kibana_version_condition = manifest_doc["conditions"]["kibana"]["version"]
+
+    if kibana_version_condition:
+        print(find_oldest_supported_version(kibana_version_condition), end="")
+    else:
+        print("null")
 
 
 def main():

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -25,10 +25,10 @@ spec:
       # to build automatically.
       branch_configuration: main 8.12
       cancel_intermediate_builds: true
-      # Do accidently skip main or release branch that may be in the middle of releasing
+      # Do not accidently skip main or release branch that may be in the middle of releasing
       cancel_intermediate_builds_branch_filter: '!main !8.12'
       skip_intermediate_builds: true
-      # Do accidently skip main or release branch that may be in the middle of releasing
+      # Do not accidently skip main or release branch that may be in the middle of releasing
       skip_intermediate_builds_branch_filter: '!main !8.12'
       provider_settings:
         build_pull_request_forks: false

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -25,7 +25,11 @@ spec:
       # to build automatically.
       branch_configuration: main 8.12
       cancel_intermediate_builds: true
+      # Do accidently skip main or release branch that may be in the middle of releasing
+      cancel_intermediate_builds_branch_filter: '!main !8.12'
       skip_intermediate_builds: true
+      # Do accidently skip main or release branch that may be in the middle of releasing
+      skip_intermediate_builds_branch_filter: '!main !8.12'
       provider_settings:
         build_pull_request_forks: false
         build_pull_request_labels_changed: false


### PR DESCRIPTION
## Change Summary

Integration team used the same file .buildkite/scripts/find_oldest_supported_version.py, and made update to it. https://github.com/elastic/integrations/blob/main/.buildkite/scripts/find_oldest_supported_version.py

This file picks up some of the changes they introduced.

Also adding some condition logic to prevent accidental cancelation of main and 8.12 branch CI job.

### Sample values

Buildkite only changes 


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
