### PR TITLE
Allow Rerouting Processor for Elastic Defend

### DIFF
--- a/package/endpoint/data_stream/action_responses/manifest.yml
+++ b/package/endpoint/data_stream/action_responses/manifest.yml
@@ -6,3 +6,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/actions/manifest.yml
+++ b/package/endpoint/data_stream/actions/manifest.yml
@@ -6,3 +6,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/alerts/manifest.yml
+++ b/package/endpoint/data_stream/alerts/manifest.yml
@@ -11,3 +11,5 @@ elasticsearch:
             limit: 5000
     mappings:
       dynamic: false
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/api/manifest.yml
+++ b/package/endpoint/data_stream/api/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/collection/manifest.yml
+++ b/package/endpoint/data_stream/collection/manifest.yml
@@ -7,3 +7,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/file/manifest.yml
+++ b/package/endpoint/data_stream/file/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/heartbeat/manifest.yml
+++ b/package/endpoint/data_stream/heartbeat/manifest.yml
@@ -13,3 +13,5 @@ elasticsearch:
             - event.ingested
           order:
             - desc
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/library/manifest.yml
+++ b/package/endpoint/data_stream/library/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/metadata/manifest.yml
+++ b/package/endpoint/data_stream/metadata/manifest.yml
@@ -13,3 +13,5 @@ elasticsearch:
           order:
             - desc
             - asc
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/metrics/manifest.yml
+++ b/package/endpoint/data_stream/metrics/manifest.yml
@@ -4,3 +4,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/network/manifest.yml
+++ b/package/endpoint/data_stream/network/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/policy/manifest.yml
+++ b/package/endpoint/data_stream/policy/manifest.yml
@@ -4,3 +4,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/process/manifest.yml
+++ b/package/endpoint/data_stream/process/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/registry/manifest.yml
+++ b/package/endpoint/data_stream/registry/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  dynamic_dataset: true
+  dynamic_namespace: true

--- a/package/endpoint/data_stream/security/manifest.yml
+++ b/package/endpoint/data_stream/security/manifest.yml
@@ -5,3 +5,5 @@ elasticsearch:
   index_template:
     mappings:
       dynamic: false
+  dynamic_dataset: true
+  dynamic_namespace: true


### PR DESCRIPTION
Allow Routing to logs-*-* for the Elastic Defend Package, otherwise it's not possible to use the Reroute Processor in a Ingest Pipeline to ship Endpoint logs to a different Dataset/Namespace.

Referring to this Guide:
https://www.elastic.co/blog/simplifying-log-data-management-flexible-routing-elastic
