### PR TITLE
Add missing branch defs

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -23,13 +23,13 @@ spec:
       pipeline_file: ".buildkite/pipeline.yml.py"
       # branch_configuration must be a space separated list of branches
       # to build automatically.
-      branch_configuration: main 8.12
+      branch_configuration: main 8.12 8.13
       cancel_intermediate_builds: true
       # Do not accidently skip main or release branch that may be in the middle of releasing
-      cancel_intermediate_builds_branch_filter: '!main !8.12'
+      cancel_intermediate_builds_branch_filter: '!main !8.12 !8.13'
       skip_intermediate_builds: true
       # Do not accidently skip main or release branch that may be in the middle of releasing
-      skip_intermediate_builds_branch_filter: '!main !8.12'
+      skip_intermediate_builds_branch_filter: '!main !8.12 !8.13'
       provider_settings:
         build_pull_request_forks: false
         build_pull_request_labels_changed: false


### PR DESCRIPTION
## Change Summary

8.13 release happened, but new buildkite configs were not updated to treat the `8.13` release branch.. as a release branch.

This PR will be backported to that branch as well


