### PR TITLE
Added 'effective' user field.

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -23,13 +23,13 @@ spec:
       pipeline_file: ".buildkite/pipeline.yml.py"
       # branch_configuration must be a space separated list of branches
       # to build automatically.
-      branch_configuration: main 8.12
+      branch_configuration: main 8.12 8.13
       cancel_intermediate_builds: true
       # Do not accidently skip main or release branch that may be in the middle of releasing
-      cancel_intermediate_builds_branch_filter: '!main !8.12'
+      cancel_intermediate_builds_branch_filter: '!main !8.12 !8.13'
       skip_intermediate_builds: true
       # Do not accidently skip main or release branch that may be in the middle of releasing
-      skip_intermediate_builds_branch_filter: '!main !8.12'
+      skip_intermediate_builds_branch_filter: '!main !8.12 !8.13'
       provider_settings:
         build_pull_request_forks: false
         build_pull_request_labels_changed: false

--- a/custom_documentation/doc/endpoint/security/windows/windows_security_log_off.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_log_off.md
@@ -57,4 +57,10 @@ This event is generated when a user logs off of the computer.
 | user.domain |
 | user.id |
 | user.name |
+| user.effective.domain |
+| user.effective.id |
+| user.effective.name |
+| user.effective.email |
+| user.effective.full_name |
+| user.effective.hash |
 

--- a/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
@@ -58,4 +58,7 @@ This event is generated when a user logs on to the computer.
 | user.domain |
 | user.id |
 | user.name |
+| user.effective.domain |
+| user.effective.id |
+| user.effective.name |
 

--- a/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
@@ -61,4 +61,7 @@ This event is generated when a user logs on to the computer.
 | user.effective.domain |
 | user.effective.id |
 | user.effective.name |
+| user.effective.email |
+| user.effective.full_name |
+| user.effective.hash |
 

--- a/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_off.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_off.yaml
@@ -62,3 +62,9 @@ fields:
   - user.domain
   - user.id
   - user.name
+  - user.effective.domain
+  - user.effective.id
+  - user.effective.name
+  - user.effective.email
+  - user.effective.full_name
+  - user.effective.hash

--- a/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
@@ -66,3 +66,6 @@ fields:
   - user.effective.domain
   - user.effective.id
   - user.effective.name
+  - user.effective.email
+  - user.effective.full_name
+  - user.effective.hash

--- a/custom_subsets/elastic_endpoint/security/security.yaml
+++ b/custom_subsets/elastic_endpoint/security/security.yaml
@@ -83,6 +83,14 @@ fields:
       hash: {}
       id: {}
       name: {}
+      effective: {}
+        fields:
+          domain: {}
+          email: {}
+          full_name: {}
+          hash: {}
+          id: {}
+          name: {}
       group:
         fields:
           domain: {}

--- a/custom_subsets/elastic_endpoint/security/security.yaml
+++ b/custom_subsets/elastic_endpoint/security/security.yaml
@@ -83,7 +83,7 @@ fields:
       hash: {}
       id: {}
       name: {}
-      effective: {}
+      effective:
         fields:
           domain: {}
           email: {}

--- a/package/endpoint/data_stream/security/fields/fields.yml
+++ b/package/endpoint/data_stream/security/fields/fields.yml
@@ -886,3 +886,26 @@
           default_field: false
       description: Short name or login of the user.
       example: a.einstein
+    - name: user.effective.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier of the effective user.
+      example: S-1-5-21-202424912787-2692429404-2351956786-1000
+    - name: user.effective.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: match_only_text
+          default_field: false
+      description: Short name or login of the effective user.
+      example: a.einstein
+    - name: user.effective.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the effective user is a member of.
+
+        For example, an LDAP or Active Directory domain name.'

--- a/package/endpoint/data_stream/security/fields/fields.yml
+++ b/package/endpoint/data_stream/security/fields/fields.yml
@@ -909,3 +909,25 @@
       description: 'Name of the directory the effective user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
+    - name: effective.email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Effective user's email address, if available
+    - name: effective.full_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: match_only_text
+          default_field: false
+      description: Effective user's full name, if available.
+      example: Albert Einstein
+    - name: effective.hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique hash to correlate information for an effective user in anonymized form.
+
+        Useful if `user.effective.id` or `user.effective.name` contain confidential information and cannot be used.'

--- a/package/endpoint/data_stream/security/fields/fields.yml
+++ b/package/endpoint/data_stream/security/fields/fields.yml
@@ -886,13 +886,13 @@
           default_field: false
       description: Short name or login of the user.
       example: a.einstein
-    - name: user.effective.id
+    - name: effective.id
       level: core
       type: keyword
       ignore_above: 1024
       description: Unique identifier of the effective user.
       example: S-1-5-21-202424912787-2692429404-2351956786-1000
-    - name: user.effective.name
+    - name: effective.name
       level: core
       type: keyword
       ignore_above: 1024
@@ -902,7 +902,7 @@
           default_field: false
       description: Short name or login of the effective user.
       example: a.einstein
-    - name: user.effective.domain
+    - name: effective.domain
       level: extended
       type: keyword
       ignore_above: 1024

--- a/package/endpoint/data_stream/security/sample_event.json
+++ b/package/endpoint/data_stream/security/sample_event.json
@@ -95,4 +95,3 @@
         "name": "Default"
     }
 }
-

--- a/package/endpoint/data_stream/security/sample_event.json
+++ b/package/endpoint/data_stream/security/sample_event.json
@@ -89,7 +89,10 @@
         "effective": {
             "domain": "DESKTOP-1TK590J",
             "name": "EafTestLogon80589",
-            "id": "S-1-5-18"
+            "id": "S-1-5-18",
+	    "email": "EafTestLogon80589@DESKTOP-1TK590J.local",
+	    "full_name": "EafTestLogon80589",
+	    "hash": "f1297b0233914ec6ebf8fc01195e8712dfd8322f5e8d9d8bbe0083a0fc1860fd"
         },
         "id": "S-1-5-21-1749029863-1064264096-968553628-1001",
         "name": "Default"

--- a/package/endpoint/data_stream/security/sample_event.json
+++ b/package/endpoint/data_stream/security/sample_event.json
@@ -90,9 +90,9 @@
             "domain": "DESKTOP-1TK590J",
             "name": "EafTestLogon80589",
             "id": "S-1-5-18",
-	    "email": "EafTestLogon80589@DESKTOP-1TK590J.local",
-	    "full_name": "EafTestLogon80589",
-	    "hash": "f1297b0233914ec6ebf8fc01195e8712dfd8322f5e8d9d8bbe0083a0fc1860fd"
+            "email": "EafTestLogon80589@DESKTOP-1TK590J.local",
+            "full_name": "EafTestLogon80589",
+            "hash": "f1297b0233914ec6ebf8fc01195e8712dfd8322f5e8d9d8bbe0083a0fc1860fd"
         },
         "id": "S-1-5-21-1749029863-1064264096-968553628-1001",
         "name": "Default"

--- a/package/endpoint/data_stream/security/sample_event.json
+++ b/package/endpoint/data_stream/security/sample_event.json
@@ -85,8 +85,14 @@
         "outcome": "success"
     },
     "user": {
-        "domain": "NT AUTHORITY",
-        "name": "SYSTEM",
-        "id": "S-1-5-18"
+        "domain": "DESKTOP-1TK590J",
+        "effective": {
+            "domain": "DESKTOP-1TK590J",
+            "name": "EafTestLogon80589",
+            "id": "S-1-5-18"
+        },
+        "id": "S-1-5-21-1749029863-1064264096-968553628-1001",
+        "name": "Default"
     }
 }
+

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1895,9 +1895,6 @@ sent by the endpoint.
 | user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
-| user.effective.domain | Name of the directory the effective user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| user.effective.id | Unique identifier of the effective user. | keyword |
-| user.effective.name | Short name or login of the effective user. | keyword |
 
 
 ### network

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2708,6 +2708,9 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.effective.domain | Name of the directory the effective user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.effective.id | Unique identifier of the effective user. | keyword |
+| user.effective.name | Short name or login of the effective user. | keyword |
 | user.email | User email address. | keyword |
 | user.full_name | User's full name, if available. | keyword |
 | user.group.Ext | Object for all custom defined fields to live in. | object |
@@ -2720,9 +2723,6 @@ sent by the endpoint.
 | user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
-| user.user.effective.domain | Name of the directory the effective user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| user.user.effective.id | Unique identifier of the effective user. | keyword |
-| user.user.effective.name | Short name or login of the effective user. | keyword |
 
 
 ## Metrics

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1895,6 +1895,9 @@ sent by the endpoint.
 | user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
+| user.effective.domain | Name of the directory the effective user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.effective.id | Unique identifier of the effective user. | keyword |
+| user.effective.name | Short name or login of the effective user. | keyword |
 
 
 ### network

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2723,6 +2723,9 @@ sent by the endpoint.
 | user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
+| user.email | Effective user's email address, if available | keyword |
+| user.full_name | Effective user's full name, if available. | keyword |
+| user.hash| Unique hash to correlate information for an effective user in anonymized form. Useful if `user.effective.id` or `user.effective.name` contain confidential information and cannot be used.| keyword |
 
 
 ## Metrics

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2720,6 +2720,9 @@ sent by the endpoint.
 | user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
+| user.user.effective.domain | Name of the directory the effective user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.user.effective.id | Unique identifier of the effective user. | keyword |
+| user.user.effective.name | Short name or login of the effective user. | keyword |
 
 
 ## Metrics

--- a/schemas/v1/security/security.yaml
+++ b/schemas/v1/security/security.yaml
@@ -1730,6 +1730,89 @@ user.domain:
   normalize: []
   short: Name of the directory the user is a member of.
   type: keyword
+user.effective.domain:
+  dashed_name: user-effective-domain
+  description: 'Name of the directory the user is a member of.
+
+    For example, an LDAP or Active Directory domain name.'
+  flat_name: user.effective.domain
+  ignore_above: 1024
+  level: extended
+  name: domain
+  normalize: []
+  original_fieldset: user
+  short: Name of the directory the user is a member of.
+  type: keyword
+user.effective.email:
+  dashed_name: user-effective-email
+  description: User email address.
+  flat_name: user.effective.email
+  ignore_above: 1024
+  level: extended
+  name: email
+  normalize: []
+  original_fieldset: user
+  short: User email address.
+  type: keyword
+user.effective.full_name:
+  dashed_name: user-effective-full-name
+  description: User's full name, if available.
+  example: Albert Einstein
+  flat_name: user.effective.full_name
+  ignore_above: 1024
+  level: extended
+  multi_fields:
+  - flat_name: user.effective.full_name.text
+    name: text
+    type: match_only_text
+  name: full_name
+  normalize: []
+  original_fieldset: user
+  short: User's full name, if available.
+  type: keyword
+user.effective.hash:
+  dashed_name: user-effective-hash
+  description: 'Unique user hash to correlate information for a user in anonymized
+    form.
+
+    Useful if `user.id` or `user.name` contain confidential information and cannot
+    be used.'
+  flat_name: user.effective.hash
+  ignore_above: 1024
+  level: extended
+  name: hash
+  normalize: []
+  original_fieldset: user
+  short: Unique user hash to correlate information for a user in anonymized form.
+  type: keyword
+user.effective.id:
+  dashed_name: user-effective-id
+  description: Unique identifier of the user.
+  example: S-1-5-21-202424912787-2692429404-2351956786-1000
+  flat_name: user.effective.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  original_fieldset: user
+  short: Unique identifier of the user.
+  type: keyword
+user.effective.name:
+  dashed_name: user-effective-name
+  description: Short name or login of the user.
+  example: a.einstein
+  flat_name: user.effective.name
+  ignore_above: 1024
+  level: core
+  multi_fields:
+  - flat_name: user.effective.name.text
+    name: text
+    type: match_only_text
+  name: name
+  normalize: []
+  original_fieldset: user
+  short: Short name or login of the user.
+  type: keyword
 user.email:
   dashed_name: user-email
   description: User email address.


### PR DESCRIPTION
## Change Summary
This adds the "effective" field to the user field of security events. 


### Sample values

Sample document:
```
{
    "@timestamp": "2024-03-28T13:57:06.9120679Z",
    "agent": {
        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
        "type": "endpoint",
        "version": "8.14.0-SNAPSHOT"
    },
    "data_stream": {
        "dataset": "endpoint.events.security",
        "namespace": "default",
        "type": "logs"
    },
    "ecs": {
        "version": "8.10.0"
    },
    "elastic": {
        "agent": {
            "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
        }
    },
    "event": {
        "action": "log_on",
        "category": [
            "authentication",
            "session"
        ],
        "created": "2024-03-28T13:57:06.9120679Z",
        "dataset": "endpoint.events.security",
        "id": "NUJr8jg5OdZe9mSa++++++EF",
        "kind": "event",
        "module": "endpoint",
        "outcome": "success",
        "sequence": 1234,
        "type": [
            "start"
        ]
    },
    "host": {
        "architecture": "x86_64",
        "hostname": "desktop-1tk590j",
        "id": "dabadaba-0000-0000-0000-000000000000",
        "ip": [
            "192.168.157.189",
            "fe80::4687:22c0:187:a16e",
            "169.254.58.69",
            "fe80::8d58:8a17:2e45:3163",
            "127.0.0.1",
            "::1"
        ],
        "mac": [
            "00-0c-29-1c-6d-2b",
            "7c-b5-66-a8-17-35"
        ],
        "name": "desktop-1tk590j",
        "os": {
            "Ext": {
                "variant": "Windows 11 Pro"
            },
            "family": "windows",
            "full": "Windows 11 Pro 21H2 (10.0.22000.2538)",
            "kernel": "21H2 (10.0.22000.2538)",
            "name": "Windows",
            "platform": "windows",
            "type": "windows",
            "version": "21H2 (10.0.22000.2538)"
        }
    },
    "message": "Endpoint security event",
    "process": {
        "Ext": {
            "ancestry": [
                "YWFhYWFhYWEtYWFhYS1hYWFhLWFhYWEtYWFhYWFhYWFhYWFhLTE3NDkyLTE3MTE2MzQxMzIuMzUwMTI1ODAw",
                "YWFhYWFhYWEtYWFhYS1hYWFhLWFhYWEtYWFhYWFhYWFhYWFhLTkyMjAtMTcxMTEyNDcyOS4zNjIzNDgwMA=="
            ],
            "code_signature": [
                {
                    "exists": true,
                    "status": "trusted",
                    "subject_name": "Python Software Foundation",
                    "trusted": true
                }
            ]
        },
        "code_signature": {
            "exists": true,
            "status": "trusted",
            "subject_name": "Python Software Foundation",
            "trusted": true
        },
        "entity_id": "YWFhYWFhYWEtYWFhYS1hYWFhLWFhYWEtYWFhYWFhYWFhYWFhLTE1MjA0LTE3MTE2MzQxMzIuMzY4ODU1NTAw",
        "executable": "C:\\Users\\Default.DESKTOP-1TK590J\\AppData\\Local\\Programs\\Python\\Python38\\python.exe",
        "name": "C:\\Users\\Default.DESKTOP-1TK590J\\AppData\\Local\\Programs\\Python\\Python38\\python.exe"
    },
    "user": {
        "domain": "DESKTOP-1TK590J",
        "effective": {
            "domain": "DESKTOP-1TK590J",
            "name": "EafTestLogon80589"
        },
        "id": "S-1-5-21-1749029863-1064264096-968553628-1001",
        "name": "Default"
    }
}
```

## Release Target

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
