### PR TITLE
Prepare main branch for next release cycle

### DIFF
--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,3 +1,8 @@
+- version: "8.15.0-next"
+  changes:
+    - description: TBD
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/99999
 - version: "8.14.0"
   changes:
     - description: 'HWBP => Production'

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.14.0
+version: 8.15.0-prerelease.0
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 # The default type is integration and will be set if empty.
@@ -14,7 +14,7 @@ policy_templates:
     multiple: false
 conditions:
   kibana:
-    version: "^8.14.0"
+    version: "^8.15.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
   # >= <the version> && < 8.0.0
   elastic:


### PR DESCRIPTION
## Change Summary

`8.14.0` has been released. An `8.14` branch has been created for any further releases on that line. This converts the `main` branch to the 8.15 cycle now
