### PR TITLE
8.14 update custom documentation

### DIFF
--- a/custom_documentation/doc/endpoint/alerts/windows/windows_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_malicious_behavior_alert.md
@@ -48,8 +48,6 @@ This alert occurs when a Malicious Behavior alert occurs.
 | data_stream.dataset |
 | data_stream.namespace |
 | data_stream.type |
-| destination.ip |
-| destination.port |
 | dll.*<br /><br />dll contains dll data from the primary event in Events. It can contain any fields that any other events includes within the dll fieldset. |
 | ecs.version |
 | elastic.agent.id |
@@ -82,8 +80,6 @@ This alert occurs when a Malicious Behavior alert occurs.
 | host.os.type |
 | host.os.version |
 | message |
-| network.transport |
-| network.type |
 | process.*<br /><br />process contains the process data from the primary event in Events. It can contain any fields that any other events includes within the process fieldset. |
 | registry.*<br /><br />registry contains the registry data from the primary event in Events. It can contain any fields that any other events includes within the registry fieldset. |
 | rule.description |

--- a/custom_documentation/doc/endpoint/alerts/windows/windows_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_malicious_behavior_alert.md
@@ -48,6 +48,8 @@ This alert occurs when a Malicious Behavior alert occurs.
 | data_stream.dataset |
 | data_stream.namespace |
 | data_stream.type |
+| destination.ip |
+| destination.port |
 | dll.*<br /><br />dll contains dll data from the primary event in Events. It can contain any fields that any other events includes within the dll fieldset. |
 | ecs.version |
 | elastic.agent.id |
@@ -80,6 +82,8 @@ This alert occurs when a Malicious Behavior alert occurs.
 | host.os.type |
 | host.os.version |
 | message |
+| network.transport |
+| network.type |
 | process.*<br /><br />process contains the process data from the primary event in Events. It can contain any fields that any other events includes within the process fieldset. |
 | registry.*<br /><br />registry contains the registry data from the primary event in Events. It can contain any fields that any other events includes within the registry fieldset. |
 | rule.description |

--- a/custom_documentation/doc/endpoint/alerts/windows/windows_memory_threat_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_memory_threat_alert.md
@@ -57,6 +57,9 @@ This alert is generated when a Memory Threat alert occurs.
 | process.Ext.ancestry |
 | process.Ext.architecture |
 | process.Ext.code_signature.exists |
+| process.Ext.code_signature.status |
+| process.Ext.code_signature.subject_name |
+| process.Ext.code_signature.trusted |
 | process.Ext.memory_region.allocation_base |
 | process.Ext.memory_region.allocation_protection |
 | process.Ext.memory_region.allocation_size |
@@ -87,6 +90,9 @@ This alert is generated when a Memory Threat alert occurs.
 | process.args |
 | process.args_count |
 | process.code_signature.exists |
+| process.code_signature.status |
+| process.code_signature.subject_name |
+| process.code_signature.trusted |
 | process.command_line |
 | process.entity_id |
 | process.executable |

--- a/custom_documentation/doc/endpoint/alerts/windows/windows_memory_threat_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_memory_threat_alert.md
@@ -57,9 +57,6 @@ This alert is generated when a Memory Threat alert occurs.
 | process.Ext.ancestry |
 | process.Ext.architecture |
 | process.Ext.code_signature.exists |
-| process.Ext.code_signature.status |
-| process.Ext.code_signature.subject_name |
-| process.Ext.code_signature.trusted |
 | process.Ext.memory_region.allocation_base |
 | process.Ext.memory_region.allocation_protection |
 | process.Ext.memory_region.allocation_size |
@@ -90,9 +87,6 @@ This alert is generated when a Memory Threat alert occurs.
 | process.args |
 | process.args_count |
 | process.code_signature.exists |
-| process.code_signature.status |
-| process.code_signature.subject_name |
-| process.code_signature.trusted |
 | process.command_line |
 | process.entity_id |
 | process.executable |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
@@ -51,7 +51,6 @@ This event is generated when a file is created.
 | host.os.version |
 | message |
 | process.Ext.ancestry |
-| process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |
 | process.entry_leader.parent.entity_id |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
@@ -51,6 +51,7 @@ This event is generated when a file is created.
 | host.os.version |
 | message |
 | process.Ext.ancestry |
+| process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |
 | process.entry_leader.parent.entity_id |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_delete.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_delete.md
@@ -51,7 +51,6 @@ This event is generated when a file is deleted.
 | host.os.version |
 | message |
 | process.Ext.ancestry |
-| process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |
 | process.entry_leader.parent.entity_id |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_delete.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_delete.md
@@ -51,6 +51,7 @@ This event is generated when a file is deleted.
 | host.os.version |
 | message |
 | process.Ext.ancestry |
+| process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |
 | process.entry_leader.parent.entity_id |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_rename.md
@@ -28,8 +28,6 @@ This event is generated when a file is renamed.
 | event.outcome |
 | event.sequence |
 | event.type |
-| file.Ext.original.extension |
-| file.Ext.original.name |
 | file.Ext.original.path |
 | file.extension |
 | file.name |
@@ -54,7 +52,6 @@ This event is generated when a file is renamed.
 | host.os.version |
 | message |
 | process.Ext.ancestry |
-| process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |
 | process.entry_leader.parent.entity_id |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_rename.md
@@ -28,6 +28,8 @@ This event is generated when a file is renamed.
 | event.outcome |
 | event.sequence |
 | event.type |
+| file.Ext.original.extension |
+| file.Ext.original.name |
 | file.Ext.original.path |
 | file.extension |
 | file.name |
@@ -52,6 +54,7 @@ This event is generated when a file is renamed.
 | host.os.version |
 | message |
 | process.Ext.ancestry |
+| process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |
 | process.entry_leader.parent.entity_id |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_delete.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_delete.md
@@ -63,7 +63,6 @@ This event is generated when a file is deleted.
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
-| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_delete.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_delete.md
@@ -63,6 +63,7 @@ This event is generated when a file is deleted.
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
+| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_modification.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_modification.md
@@ -64,6 +64,7 @@ This event is generated when a file is modified.
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
+| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_modification.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_modification.md
@@ -64,7 +64,6 @@ This event is generated when a file is modified.
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
-| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_rename.md
@@ -32,6 +32,7 @@ This event is generated when a file is renamed.
 | event.outcome |
 | event.sequence |
 | event.type |
+| file.Ext.original.extension |
 | file.Ext.original.path |
 | file.extension |
 | file.inode |
@@ -64,6 +65,7 @@ This event is generated when a file is renamed.
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
+| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_rename.md
@@ -32,7 +32,6 @@ This event is generated when a file is renamed.
 | event.outcome |
 | event.sequence |
 | event.type |
-| file.Ext.original.extension |
 | file.Ext.original.path |
 | file.extension |
 | file.inode |
@@ -65,7 +64,6 @@ This event is generated when a file is renamed.
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
-| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_create.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_create.md
@@ -64,6 +64,7 @@ This event is generated when a file is created.
 | process.code_signature.status |
 | process.code_signature.subject_name |
 | process.code_signature.trusted |
+| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_create.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_create.md
@@ -64,7 +64,6 @@ This event is generated when a file is created.
 | process.code_signature.status |
 | process.code_signature.subject_name |
 | process.code_signature.trusted |
-| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_delete.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_delete.md
@@ -62,6 +62,7 @@ This event is generated when a file is deleted.
 | process.code_signature.status |
 | process.code_signature.subject_name |
 | process.code_signature.trusted |
+| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_delete.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_delete.md
@@ -62,7 +62,6 @@ This event is generated when a file is deleted.
 | process.code_signature.status |
 | process.code_signature.subject_name |
 | process.code_signature.trusted |
-| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_rename.md
@@ -35,6 +35,7 @@ This event is generated when a file is renamed.
 | file.Ext.entropy |
 | file.Ext.header_bytes |
 | file.Ext.monotonic_id |
+| file.Ext.original.extension |
 | file.Ext.original.name |
 | file.Ext.original.path |
 | file.extension |
@@ -65,6 +66,7 @@ This event is generated when a file is renamed.
 | process.code_signature.status |
 | process.code_signature.subject_name |
 | process.code_signature.trusted |
+| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_rename.md
@@ -35,7 +35,6 @@ This event is generated when a file is renamed.
 | file.Ext.entropy |
 | file.Ext.header_bytes |
 | file.Ext.monotonic_id |
-| file.Ext.original.extension |
 | file.Ext.original.name |
 | file.Ext.original.path |
 | file.extension |
@@ -66,7 +65,6 @@ This event is generated when a file is renamed.
 | process.code_signature.status |
 | process.code_signature.subject_name |
 | process.code_signature.trusted |
-| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -83,6 +83,8 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.malicious_behavior_rules.id |
 | Endpoint.metrics.memory.endpoint.private.latest |
 | Endpoint.metrics.memory.endpoint.private.mean |
+| Endpoint.metrics.system_impact.attack_surface_events.week_idle_ms |
+| Endpoint.metrics.system_impact.attack_surface_events.week_ms |
 | Endpoint.metrics.system_impact.authentication_events.week_idle_ms |
 | Endpoint.metrics.system_impact.authentication_events.week_ms |
 | Endpoint.metrics.system_impact.behavior_protection.week_idle_ms |
@@ -120,6 +122,8 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.system_impact.ransomware.week_ms |
 | Endpoint.metrics.system_impact.registry_events.week_idle_ms |
 | Endpoint.metrics.system_impact.registry_events.week_ms |
+| Endpoint.metrics.system_impact.tcpip_events.week_idle_ms |
+| Endpoint.metrics.system_impact.tcpip_events.week_ms |
 | Endpoint.metrics.system_impact.threat_intelligence_events.week_idle_ms |
 | Endpoint.metrics.system_impact.threat_intelligence_events.week_ms |
 | Endpoint.metrics.system_impact.volume_device_events.week_idle_ms |

--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -83,8 +83,6 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.malicious_behavior_rules.id |
 | Endpoint.metrics.memory.endpoint.private.latest |
 | Endpoint.metrics.memory.endpoint.private.mean |
-| Endpoint.metrics.system_impact.attack_surface_events.week_idle_ms |
-| Endpoint.metrics.system_impact.attack_surface_events.week_ms |
 | Endpoint.metrics.system_impact.authentication_events.week_idle_ms |
 | Endpoint.metrics.system_impact.authentication_events.week_ms |
 | Endpoint.metrics.system_impact.behavior_protection.week_idle_ms |
@@ -122,8 +120,6 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.system_impact.ransomware.week_ms |
 | Endpoint.metrics.system_impact.registry_events.week_idle_ms |
 | Endpoint.metrics.system_impact.registry_events.week_ms |
-| Endpoint.metrics.system_impact.tcpip_events.week_idle_ms |
-| Endpoint.metrics.system_impact.tcpip_events.week_ms |
 | Endpoint.metrics.system_impact.threat_intelligence_events.week_idle_ms |
 | Endpoint.metrics.system_impact.threat_intelligence_events.week_ms |
 | Endpoint.metrics.system_impact.volume_device_events.week_idle_ms |

--- a/custom_documentation/doc/endpoint/network/linux/linux_network_connection_accepted.md
+++ b/custom_documentation/doc/endpoint/network/linux/linux_network_connection_accepted.md
@@ -53,6 +53,7 @@ This event is generated when a network connection is accepted.
 | network.transport |
 | network.type |
 | process.Ext.ancestry |
+| process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |
 | process.entry_leader.parent.entity_id |

--- a/custom_documentation/doc/endpoint/network/linux/linux_network_connection_accepted.md
+++ b/custom_documentation/doc/endpoint/network/linux/linux_network_connection_accepted.md
@@ -53,7 +53,6 @@ This event is generated when a network connection is accepted.
 | network.transport |
 | network.type |
 | process.Ext.ancestry |
-| process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |
 | process.entry_leader.parent.entity_id |

--- a/custom_documentation/doc/endpoint/network/linux/linux_network_connection_attempt.md
+++ b/custom_documentation/doc/endpoint/network/linux/linux_network_connection_attempt.md
@@ -59,7 +59,6 @@ This event is generated when there is an attempt to establish a network connecti
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
-| process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |
 | process.entry_leader.parent.entity_id |

--- a/custom_documentation/doc/endpoint/network/linux/linux_network_connection_attempt.md
+++ b/custom_documentation/doc/endpoint/network/linux/linux_network_connection_attempt.md
@@ -59,6 +59,7 @@ This event is generated when there is an attempt to establish a network connecti
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
+| process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |
 | process.entry_leader.parent.entity_id |

--- a/custom_documentation/doc/endpoint/network/linux/linux_network_disconnect.md
+++ b/custom_documentation/doc/endpoint/network/linux/linux_network_disconnect.md
@@ -65,6 +65,7 @@ This event is generated when a network session is terminated.
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
+| process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |
 | process.entry_leader.parent.entity_id |

--- a/custom_documentation/doc/endpoint/network/linux/linux_network_disconnect.md
+++ b/custom_documentation/doc/endpoint/network/linux/linux_network_disconnect.md
@@ -65,7 +65,6 @@ This event is generated when a network session is terminated.
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
-| process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |
 | process.entry_leader.parent.entity_id |

--- a/custom_documentation/doc/endpoint/network/macos/macos_network_connection_attempted.md
+++ b/custom_documentation/doc/endpoint/network/macos/macos_network_connection_attempted.md
@@ -59,7 +59,6 @@ This event is generated when a network connection is attempted.
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
-| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/network/macos/macos_network_connection_attempted.md
+++ b/custom_documentation/doc/endpoint/network/macos/macos_network_connection_attempted.md
@@ -59,6 +59,7 @@ This event is generated when a network connection is attempted.
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
+| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/network/macos/macos_network_disconnect_received.md
+++ b/custom_documentation/doc/endpoint/network/macos/macos_network_disconnect_received.md
@@ -60,7 +60,6 @@ This event is generated when a request to terminate a network connection occurs.
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
-| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/network/macos/macos_network_disconnect_received.md
+++ b/custom_documentation/doc/endpoint/network/macos/macos_network_disconnect_received.md
@@ -60,6 +60,7 @@ This event is generated when a request to terminate a network connection occurs.
 | process.code_signature.subject_name |
 | process.code_signature.team_id |
 | process.code_signature.trusted |
+| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_already_running.md
@@ -65,6 +65,7 @@ This event is generated for a process that was already running before Endpoint's
 | orchestrator.resource.parent.type |
 | orchestrator.resource.type |
 | process.Ext.ancestry |
+| process.Ext.trusted |
 | process.args |
 | process.args_count |
 | process.command_line |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_already_running.md
@@ -65,7 +65,6 @@ This event is generated for a process that was already running before Endpoint's
 | orchestrator.resource.parent.type |
 | orchestrator.resource.type |
 | process.Ext.ancestry |
-| process.Ext.trusted |
 | process.args |
 | process.args_count |
 | process.command_line |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_text_output.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_text_output.md
@@ -87,8 +87,6 @@ This event is generated when a process generates text output.
 | process.entry_leader.real_user.name |
 | process.entry_leader.same_as_process |
 | process.entry_leader.start |
-| process.entry_leader.supplemental_groups.id |
-| process.entry_leader.supplemental_groups.name |
 | process.entry_leader.user.id |
 | process.entry_leader.user.name |
 | process.entry_leader.working_directory |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_text_output.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_text_output.md
@@ -87,6 +87,8 @@ This event is generated when a process generates text output.
 | process.entry_leader.real_user.name |
 | process.entry_leader.same_as_process |
 | process.entry_leader.start |
+| process.entry_leader.supplemental_groups.id |
+| process.entry_leader.supplemental_groups.name |
 | process.entry_leader.user.id |
 | process.entry_leader.user.name |
 | process.entry_leader.working_directory |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_already_running.md
@@ -59,7 +59,6 @@ This event is generated for a process that was already running before Endpoint's
 | process.code_signature.trusted |
 | process.command_line |
 | process.entity_id |
-| process.env_vars |
 | process.executable |
 | process.hash.md5 |
 | process.hash.sha1 |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_already_running.md
@@ -59,6 +59,7 @@ This event is generated for a process that was already running before Endpoint's
 | process.code_signature.trusted |
 | process.command_line |
 | process.entity_id |
+| process.env_vars |
 | process.executable |
 | process.hash.md5 |
 | process.hash.sha1 |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_fork.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_fork.md
@@ -61,7 +61,6 @@ This event is generated when a new process is created using `fork()`.
 | process.code_signature.trusted |
 | process.command_line |
 | process.entity_id |
-| process.env_vars |
 | process.executable |
 | process.exit_code |
 | process.hash.md5 |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_fork.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_fork.md
@@ -61,6 +61,7 @@ This event is generated when a new process is created using `fork()`.
 | process.code_signature.trusted |
 | process.command_line |
 | process.entity_id |
+| process.env_vars |
 | process.executable |
 | process.exit_code |
 | process.hash.md5 |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_remote_thread.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_remote_thread.md
@@ -63,7 +63,6 @@ This event is generated when a remote thread is created.
 | process.code_signature.trusted |
 | process.command_line |
 | process.entity_id |
-| process.env_vars |
 | process.executable |
 | process.hash.md5 |
 | process.hash.sha1 |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_remote_thread.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_remote_thread.md
@@ -63,6 +63,7 @@ This event is generated when a remote thread is created.
 | process.code_signature.trusted |
 | process.command_line |
 | process.entity_id |
+| process.env_vars |
 | process.executable |
 | process.hash.md5 |
 | process.hash.sha1 |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
@@ -53,6 +53,7 @@ This event is generated for a process that was already running before Endpoint's
 | process.Ext.protection |
 | process.Ext.relative_file_creation_time |
 | process.Ext.session_info.authentication_package |
+| process.Ext.session_info.client_address |
 | process.Ext.session_info.id |
 | process.Ext.session_info.logon_type |
 | process.Ext.session_info.relative_logon_time |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
@@ -53,7 +53,6 @@ This event is generated for a process that was already running before Endpoint's
 | process.Ext.protection |
 | process.Ext.relative_file_creation_time |
 | process.Ext.session_info.authentication_package |
-| process.Ext.session_info.client_address |
 | process.Ext.session_info.id |
 | process.Ext.session_info.logon_type |
 | process.Ext.session_info.relative_logon_time |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_create.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_create.md
@@ -49,7 +49,6 @@ This event is generated when a process is created.
 | process.Ext.code_signature.status |
 | process.Ext.code_signature.subject_name |
 | process.Ext.code_signature.trusted |
-| process.Ext.created_suspended |
 | process.Ext.defense_evasions |
 | process.Ext.device.bus_type |
 | process.Ext.device.dos_name |
@@ -67,7 +66,6 @@ This event is generated when a process is created.
 | process.Ext.relative_file_creation_time |
 | process.Ext.relative_file_name_modify_time |
 | process.Ext.session_info.authentication_package |
-| process.Ext.session_info.client_address |
 | process.Ext.session_info.id |
 | process.Ext.session_info.logon_type |
 | process.Ext.session_info.relative_logon_time |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_create.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_create.md
@@ -49,6 +49,7 @@ This event is generated when a process is created.
 | process.Ext.code_signature.status |
 | process.Ext.code_signature.subject_name |
 | process.Ext.code_signature.trusted |
+| process.Ext.created_suspended |
 | process.Ext.defense_evasions |
 | process.Ext.device.bus_type |
 | process.Ext.device.dos_name |
@@ -66,6 +67,7 @@ This event is generated when a process is created.
 | process.Ext.relative_file_creation_time |
 | process.Ext.relative_file_name_modify_time |
 | process.Ext.session_info.authentication_package |
+| process.Ext.session_info.client_address |
 | process.Ext.session_info.id |
 | process.Ext.session_info.logon_type |
 | process.Ext.session_info.relative_logon_time |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_exit.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_exit.md
@@ -48,8 +48,10 @@ This event is generated when a process exits.
 | process.Ext.code_signature.status |
 | process.Ext.code_signature.subject_name |
 | process.Ext.code_signature.trusted |
+| process.Ext.hidden.behaviors.api |
 | process.Ext.mitigation_policies |
 | process.Ext.session_info.authentication_package |
+| process.Ext.session_info.client_address |
 | process.Ext.session_info.logon_type |
 | process.Ext.session_info.relative_logon_time |
 | process.Ext.session_info.relative_password_age |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_exit.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_exit.md
@@ -48,10 +48,8 @@ This event is generated when a process exits.
 | process.Ext.code_signature.status |
 | process.Ext.code_signature.subject_name |
 | process.Ext.code_signature.trusted |
-| process.Ext.hidden.behaviors.api |
 | process.Ext.mitigation_policies |
 | process.Ext.session_info.authentication_package |
-| process.Ext.session_info.client_address |
 | process.Ext.session_info.logon_type |
 | process.Ext.session_info.relative_logon_time |
 | process.Ext.session_info.relative_password_age |

--- a/custom_documentation/doc/endpoint/security/windows/windows_security_log_off.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_log_off.md
@@ -20,7 +20,6 @@ This event is generated when a user logs off of the computer.
 | elastic.agent.id |
 | event.action |
 | event.category |
-| event.code |
 | event.created |
 | event.dataset |
 | event.id |
@@ -49,7 +48,6 @@ This event is generated when a user logs off of the computer.
 | process.Ext.code_signature.status |
 | process.Ext.code_signature.subject_name |
 | process.Ext.code_signature.trusted |
-| process.Ext.session_info.logon_type |
 | process.code_signature.exists |
 | process.code_signature.status |
 | process.code_signature.subject_name |
@@ -57,12 +55,12 @@ This event is generated when a user logs off of the computer.
 | process.entity_id |
 | process.executable |
 | user.domain |
+| user.id |
+| user.name |
 | user.effective.domain |
+| user.effective.id |
+| user.effective.name |
 | user.effective.email |
 | user.effective.full_name |
 | user.effective.hash |
-| user.effective.id |
-| user.effective.name |
-| user.id |
-| user.name |
 

--- a/custom_documentation/doc/endpoint/security/windows/windows_security_log_off.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_log_off.md
@@ -20,6 +20,7 @@ This event is generated when a user logs off of the computer.
 | elastic.agent.id |
 | event.action |
 | event.category |
+| event.code |
 | event.created |
 | event.dataset |
 | event.id |
@@ -48,6 +49,7 @@ This event is generated when a user logs off of the computer.
 | process.Ext.code_signature.status |
 | process.Ext.code_signature.subject_name |
 | process.Ext.code_signature.trusted |
+| process.Ext.session_info.logon_type |
 | process.code_signature.exists |
 | process.code_signature.status |
 | process.code_signature.subject_name |
@@ -55,12 +57,12 @@ This event is generated when a user logs off of the computer.
 | process.entity_id |
 | process.executable |
 | user.domain |
-| user.id |
-| user.name |
 | user.effective.domain |
-| user.effective.id |
-| user.effective.name |
 | user.effective.email |
 | user.effective.full_name |
 | user.effective.hash |
+| user.effective.id |
+| user.effective.name |
+| user.id |
+| user.name |
 

--- a/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
@@ -20,7 +20,6 @@ This event is generated when a user logs on to the computer.
 | elastic.agent.id |
 | event.action |
 | event.category |
-| event.code |
 | event.created |
 | event.dataset |
 | event.id |
@@ -49,7 +48,6 @@ This event is generated when a user logs on to the computer.
 | process.Ext.code_signature.status |
 | process.Ext.code_signature.subject_name |
 | process.Ext.code_signature.trusted |
-| process.Ext.session_info.logon_type |
 | process.code_signature.exists |
 | process.code_signature.status |
 | process.code_signature.subject_name |
@@ -58,12 +56,12 @@ This event is generated when a user logs on to the computer.
 | process.executable |
 | process.name |
 | user.domain |
+| user.id |
+| user.name |
 | user.effective.domain |
+| user.effective.id |
+| user.effective.name |
 | user.effective.email |
 | user.effective.full_name |
 | user.effective.hash |
-| user.effective.id |
-| user.effective.name |
-| user.id |
-| user.name |
 

--- a/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
@@ -20,6 +20,7 @@ This event is generated when a user logs on to the computer.
 | elastic.agent.id |
 | event.action |
 | event.category |
+| event.code |
 | event.created |
 | event.dataset |
 | event.id |
@@ -48,6 +49,7 @@ This event is generated when a user logs on to the computer.
 | process.Ext.code_signature.status |
 | process.Ext.code_signature.subject_name |
 | process.Ext.code_signature.trusted |
+| process.Ext.session_info.logon_type |
 | process.code_signature.exists |
 | process.code_signature.status |
 | process.code_signature.subject_name |
@@ -56,12 +58,12 @@ This event is generated when a user logs on to the computer.
 | process.executable |
 | process.name |
 | user.domain |
-| user.id |
-| user.name |
 | user.effective.domain |
-| user.effective.id |
-| user.effective.name |
 | user.effective.email |
 | user.effective.full_name |
 | user.effective.hash |
+| user.effective.id |
+| user.effective.name |
+| user.id |
+| user.name |
 

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malicious_behavior_alert.yaml
@@ -53,6 +53,8 @@ fields:
   - data_stream.dataset
   - data_stream.namespace
   - data_stream.type
+  - destination.ip
+  - destination.port
   - dll.*
   - ecs.version
   - elastic.agent.id
@@ -85,6 +87,8 @@ fields:
   - host.os.type
   - host.os.version
   - message
+  - network.transport
+  - network.type
   - process.*
   - registry.*
   - rule.description

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_memory_threat_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_memory_threat_alert.yaml
@@ -62,6 +62,9 @@ fields:
   - process.Ext.ancestry
   - process.Ext.architecture
   - process.Ext.code_signature.exists
+  - process.Ext.code_signature.status
+  - process.Ext.code_signature.subject_name
+  - process.Ext.code_signature.trusted
   - process.Ext.memory_region.allocation_base
   - process.Ext.memory_region.allocation_protection
   - process.Ext.memory_region.allocation_size
@@ -92,6 +95,9 @@ fields:
   - process.args
   - process.args_count
   - process.code_signature.exists
+  - process.code_signature.status
+  - process.code_signature.subject_name
+  - process.code_signature.trusted
   - process.command_line
   - process.entity_id
   - process.executable

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
@@ -56,6 +56,7 @@ fields:
   - host.os.version
   - message
   - process.Ext.ancestry
+  - process.command_line
   - process.entity_id
   - process.entry_leader.entity_id
   - process.entry_leader.parent.entity_id

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_delete.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_delete.yaml
@@ -56,6 +56,7 @@ fields:
   - host.os.version
   - message
   - process.Ext.ancestry
+  - process.command_line
   - process.entity_id
   - process.entry_leader.entity_id
   - process.entry_leader.parent.entity_id

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_rename.yaml
@@ -59,6 +59,7 @@ fields:
   - host.os.version
   - message
   - process.Ext.ancestry
+  - process.command_line
   - process.entity_id
   - process.entry_leader.entity_id
   - process.entry_leader.parent.entity_id

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_rename.yaml
@@ -33,6 +33,8 @@ fields:
   - event.outcome
   - event.sequence
   - event.type
+  - file.Ext.original.extension
+  - file.Ext.original.name
   - file.Ext.original.path
   - file.extension
   - file.name

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_delete.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_delete.yaml
@@ -68,6 +68,7 @@ fields:
   - process.code_signature.subject_name
   - process.code_signature.team_id
   - process.code_signature.trusted
+  - process.command_line
   - process.entity_id
   - process.executable
   - process.name

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_modification.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_modification.yaml
@@ -69,6 +69,7 @@ fields:
   - process.code_signature.subject_name
   - process.code_signature.team_id
   - process.code_signature.trusted
+  - process.command_line
   - process.entity_id
   - process.executable
   - process.name

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_rename.yaml
@@ -70,6 +70,7 @@ fields:
   - process.code_signature.subject_name
   - process.code_signature.team_id
   - process.code_signature.trusted
+  - process.command_line
   - process.entity_id
   - process.executable
   - process.name

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_rename.yaml
@@ -37,6 +37,7 @@ fields:
   - event.outcome
   - event.sequence
   - event.type
+  - file.Ext.original.extension
   - file.Ext.original.path
   - file.extension
   - file.inode

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_create.yaml
@@ -69,6 +69,7 @@ fields:
   - process.code_signature.status
   - process.code_signature.subject_name
   - process.code_signature.trusted
+  - process.command_line
   - process.entity_id
   - process.executable
   - process.name

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_delete.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_delete.yaml
@@ -67,6 +67,7 @@ fields:
   - process.code_signature.status
   - process.code_signature.subject_name
   - process.code_signature.trusted
+  - process.command_line
   - process.entity_id
   - process.executable
   - process.name

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_rename.yaml
@@ -71,6 +71,7 @@ fields:
   - process.code_signature.status
   - process.code_signature.subject_name
   - process.code_signature.trusted
+  - process.command_line
   - process.entity_id
   - process.executable
   - process.name

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_rename.yaml
@@ -40,6 +40,7 @@ fields:
   - file.Ext.entropy
   - file.Ext.header_bytes
   - file.Ext.monotonic_id
+  - file.Ext.original.extension
   - file.Ext.original.name
   - file.Ext.original.path
   - file.extension

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -127,6 +127,8 @@ fields:
   - Endpoint.metrics.system_impact.ransomware.week_ms
   - Endpoint.metrics.system_impact.registry_events.week_idle_ms
   - Endpoint.metrics.system_impact.registry_events.week_ms
+  - Endpoint.metrics.system_impact.tcpip_events.week_idle_ms
+  - Endpoint.metrics.system_impact.tcpip_events.week_ms
   - Endpoint.metrics.system_impact.threat_intelligence_events.week_idle_ms
   - Endpoint.metrics.system_impact.threat_intelligence_events.week_ms
   - Endpoint.metrics.system_impact.volume_device_events.week_idle_ms

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -90,6 +90,8 @@ fields:
   - Endpoint.metrics.malicious_behavior_rules.id
   - Endpoint.metrics.memory.endpoint.private.latest
   - Endpoint.metrics.memory.endpoint.private.mean
+  - Endpoint.metrics.system_impact.attack_surface_events.week_idle_ms
+  - Endpoint.metrics.system_impact.attack_surface_events.week_ms
   - Endpoint.metrics.system_impact.authentication_events.week_idle_ms
   - Endpoint.metrics.system_impact.authentication_events.week_ms
   - Endpoint.metrics.system_impact.behavior_protection.week_idle_ms

--- a/custom_documentation/src/endpoint/data_stream/network/linux/linux_network_connection_accepted.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/linux/linux_network_connection_accepted.yaml
@@ -58,6 +58,7 @@ fields:
   - network.transport
   - network.type
   - process.Ext.ancestry
+  - process.command_line
   - process.entity_id
   - process.entry_leader.entity_id
   - process.entry_leader.parent.entity_id

--- a/custom_documentation/src/endpoint/data_stream/network/linux/linux_network_connection_attempt.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/linux/linux_network_connection_attempt.yaml
@@ -65,6 +65,7 @@ fields:
   - process.code_signature.subject_name
   - process.code_signature.team_id
   - process.code_signature.trusted
+  - process.command_line
   - process.entity_id
   - process.entry_leader.entity_id
   - process.entry_leader.parent.entity_id

--- a/custom_documentation/src/endpoint/data_stream/network/linux/linux_network_disconnect.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/linux/linux_network_disconnect.yaml
@@ -70,6 +70,7 @@ fields:
   - process.code_signature.subject_name
   - process.code_signature.team_id
   - process.code_signature.trusted
+  - process.command_line
   - process.entity_id
   - process.entry_leader.entity_id
   - process.entry_leader.parent.entity_id

--- a/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_connection_attempted.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_connection_attempted.yaml
@@ -64,6 +64,7 @@ fields:
   - process.code_signature.subject_name
   - process.code_signature.team_id
   - process.code_signature.trusted
+  - process.command_line
   - process.entity_id
   - process.executable
   - process.name

--- a/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_disconnect_received.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_disconnect_received.yaml
@@ -66,6 +66,7 @@ fields:
   - process.code_signature.subject_name
   - process.code_signature.team_id
   - process.code_signature.trusted
+  - process.command_line
   - process.entity_id
   - process.executable
   - process.name

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_already_running.yaml
@@ -71,6 +71,7 @@ fields:
   - orchestrator.resource.parent.type
   - orchestrator.resource.type
   - process.Ext.ancestry
+  - process.Ext.trusted
   - process.args
   - process.args_count
   - process.command_line

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_text_output.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_text_output.yaml
@@ -92,6 +92,8 @@ fields:
   - process.entry_leader.real_user.name
   - process.entry_leader.same_as_process
   - process.entry_leader.start
+  - process.entry_leader.supplemental_groups.id
+  - process.entry_leader.supplemental_groups.name
   - process.entry_leader.user.id
   - process.entry_leader.user.name
   - process.entry_leader.working_directory

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_already_running.yaml
@@ -65,6 +65,7 @@ fields:
   - process.code_signature.trusted
   - process.command_line
   - process.entity_id
+  - process.env_vars
   - process.executable
   - process.hash.md5
   - process.hash.sha1

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork.yaml
@@ -66,6 +66,7 @@ fields:
   - process.code_signature.trusted
   - process.command_line
   - process.entity_id
+  - process.env_vars
   - process.executable
   - process.exit_code
   - process.hash.md5

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_remote_thread.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_remote_thread.yaml
@@ -68,6 +68,7 @@ fields:
   - process.code_signature.trusted
   - process.command_line
   - process.entity_id
+  - process.env_vars
   - process.executable
   - process.hash.md5
   - process.hash.sha1

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
@@ -59,6 +59,7 @@ fields:
   - process.Ext.protection
   - process.Ext.relative_file_creation_time
   - process.Ext.session_info.authentication_package
+  - process.Ext.session_info.client_address
   - process.Ext.session_info.id
   - process.Ext.session_info.logon_type
   - process.Ext.session_info.relative_logon_time

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create.yaml
@@ -54,6 +54,7 @@ fields:
   - process.Ext.code_signature.status
   - process.Ext.code_signature.subject_name
   - process.Ext.code_signature.trusted
+  - process.Ext.created_suspended
   - process.Ext.defense_evasions
   - process.Ext.device.bus_type
   - process.Ext.device.dos_name
@@ -71,6 +72,7 @@ fields:
   - process.Ext.relative_file_creation_time
   - process.Ext.relative_file_name_modify_time
   - process.Ext.session_info.authentication_package
+  - process.Ext.session_info.client_address
   - process.Ext.session_info.id
   - process.Ext.session_info.logon_type
   - process.Ext.session_info.relative_logon_time

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_exit.yaml
@@ -55,6 +55,7 @@ fields:
   - process.Ext.code_signature.trusted
   - process.Ext.mitigation_policies
   - process.Ext.session_info.authentication_package
+  - process.Ext.session_info.client_address
   - process.Ext.session_info.logon_type
   - process.Ext.session_info.relative_logon_time
   - process.Ext.session_info.relative_password_age

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_exit.yaml
@@ -53,6 +53,7 @@ fields:
   - process.Ext.code_signature.status
   - process.Ext.code_signature.subject_name
   - process.Ext.code_signature.trusted
+  - process.Ext.hidden.behaviors.api
   - process.Ext.mitigation_policies
   - process.Ext.session_info.authentication_package
   - process.Ext.session_info.client_address

--- a/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_off.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_off.yaml
@@ -60,11 +60,11 @@ fields:
   - process.entity_id
   - process.executable
   - user.domain
-  - user.id
-  - user.name
   - user.effective.domain
-  - user.effective.id
-  - user.effective.name
   - user.effective.email
   - user.effective.full_name
   - user.effective.hash
+  - user.effective.id
+  - user.effective.name
+  - user.id
+  - user.name

--- a/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_off.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_off.yaml
@@ -25,6 +25,7 @@ fields:
   - elastic.agent.id
   - event.action
   - event.category
+  - event.code
   - event.created
   - event.dataset
   - event.id
@@ -53,6 +54,7 @@ fields:
   - process.Ext.code_signature.status
   - process.Ext.code_signature.subject_name
   - process.Ext.code_signature.trusted
+  - process.Ext.session_info.logon_type
   - process.code_signature.exists
   - process.code_signature.status
   - process.code_signature.subject_name

--- a/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
@@ -61,11 +61,11 @@ fields:
   - process.executable
   - process.name
   - user.domain
-  - user.id
-  - user.name
   - user.effective.domain
-  - user.effective.id
-  - user.effective.name
   - user.effective.email
   - user.effective.full_name
   - user.effective.hash
+  - user.effective.id
+  - user.effective.name
+  - user.id
+  - user.name

--- a/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
@@ -25,6 +25,7 @@ fields:
   - elastic.agent.id
   - event.action
   - event.category
+  - event.code
   - event.created
   - event.dataset
   - event.id
@@ -53,6 +54,7 @@ fields:
   - process.Ext.code_signature.status
   - process.Ext.code_signature.subject_name
   - process.Ext.code_signature.trusted
+  - process.Ext.session_info.logon_type
   - process.code_signature.exists
   - process.code_signature.status
   - process.code_signature.subject_name

--- a/package/endpoint/data_stream/security/fields/fields.yml
+++ b/package/endpoint/data_stream/security/fields/fields.yml
@@ -811,6 +811,55 @@
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
+    - name: effective.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the user is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+      default_field: false
+    - name: effective.email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: User email address.
+      default_field: false
+    - name: effective.full_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: match_only_text
+      description: User's full name, if available.
+      example: Albert Einstein
+      default_field: false
+    - name: effective.hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique user hash to correlate information for a user in anonymized form.
+
+        Useful if `user.id` or `user.name` contain confidential information and cannot be used.'
+      default_field: false
+    - name: effective.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier of the user.
+      example: S-1-5-21-202424912787-2692429404-2351956786-1000
+      default_field: false
+    - name: effective.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: match_only_text
+      description: Short name or login of the user.
+      example: a.einstein
+      default_field: false
     - name: email
       level: extended
       type: keyword
@@ -886,48 +935,3 @@
           default_field: false
       description: Short name or login of the user.
       example: a.einstein
-    - name: effective.id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique identifier of the effective user.
-      example: S-1-5-21-202424912787-2692429404-2351956786-1000
-    - name: effective.name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: match_only_text
-          default_field: false
-      description: Short name or login of the effective user.
-      example: a.einstein
-    - name: effective.domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the directory the effective user is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
-    - name: effective.email
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: Effective user's email address, if available
-    - name: effective.full_name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: match_only_text
-          default_field: false
-      description: Effective user's full name, if available.
-      example: Albert Einstein
-    - name: effective.hash
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique hash to correlate information for an effective user in anonymized form.
-
-        Useful if `user.effective.id` or `user.effective.name` contain confidential information and cannot be used.'

--- a/package/endpoint/data_stream/security/fields/fields.yml
+++ b/package/endpoint/data_stream/security/fields/fields.yml
@@ -811,55 +811,6 @@
       description: 'Name of the directory the user is a member of.
 
         For example, an LDAP or Active Directory domain name.'
-    - name: effective.domain
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Name of the directory the user is a member of.
-
-        For example, an LDAP or Active Directory domain name.'
-      default_field: false
-    - name: effective.email
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: User email address.
-      default_field: false
-    - name: effective.full_name
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: match_only_text
-      description: User's full name, if available.
-      example: Albert Einstein
-      default_field: false
-    - name: effective.hash
-      level: extended
-      type: keyword
-      ignore_above: 1024
-      description: 'Unique user hash to correlate information for a user in anonymized form.
-
-        Useful if `user.id` or `user.name` contain confidential information and cannot be used.'
-      default_field: false
-    - name: effective.id
-      level: core
-      type: keyword
-      ignore_above: 1024
-      description: Unique identifier of the user.
-      example: S-1-5-21-202424912787-2692429404-2351956786-1000
-      default_field: false
-    - name: effective.name
-      level: core
-      type: keyword
-      ignore_above: 1024
-      multi_fields:
-        - name: text
-          type: match_only_text
-      description: Short name or login of the user.
-      example: a.einstein
-      default_field: false
     - name: email
       level: extended
       type: keyword
@@ -935,3 +886,48 @@
           default_field: false
       description: Short name or login of the user.
       example: a.einstein
+    - name: effective.id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Unique identifier of the effective user.
+      example: S-1-5-21-202424912787-2692429404-2351956786-1000
+    - name: effective.name
+      level: core
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: match_only_text
+          default_field: false
+      description: Short name or login of the effective user.
+      example: a.einstein
+    - name: effective.domain
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the directory the effective user is a member of.
+
+        For example, an LDAP or Active Directory domain name.'
+    - name: effective.email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Effective user's email address, if available
+    - name: effective.full_name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      multi_fields:
+        - name: text
+          type: match_only_text
+          default_field: false
+      description: Effective user's full name, if available.
+      example: Albert Einstein
+    - name: effective.hash
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique hash to correlate information for an effective user in anonymized form.
+
+        Useful if `user.effective.id` or `user.effective.name` contain confidential information and cannot be used.'

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2713,12 +2713,12 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| user.effective.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| user.effective.email | User email address. | keyword |
-| user.effective.full_name | User's full name, if available. | keyword |
-| user.effective.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
-| user.effective.id | Unique identifier of the user. | keyword |
-| user.effective.name | Short name or login of the user. | keyword |
+| user.effective.domain | Name of the directory the effective user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.effective.email | Effective user's email address, if available | keyword |
+| user.effective.full_name | Effective user's full name, if available. | keyword |
+| user.effective.hash | Unique hash to correlate information for an effective user in anonymized form. Useful if `user.effective.id` or `user.effective.name` contain confidential information and cannot be used. | keyword |
+| user.effective.id | Unique identifier of the effective user. | keyword |
+| user.effective.name | Short name or login of the effective user. | keyword |
 | user.email | User email address. | keyword |
 | user.full_name | User's full name, if available. | keyword |
 | user.group.Ext | Object for all custom defined fields to live in. | object |

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2713,12 +2713,12 @@ sent by the endpoint.
 | user.Ext.real.id | One or multiple unique identifiers of the user. | keyword |
 | user.Ext.real.name | Short name or login of the user. | keyword |
 | user.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| user.effective.domain | Name of the directory the effective user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
-| user.effective.email | Effective user's email address, if available | keyword |
-| user.effective.full_name | Effective user's full name, if available. | keyword |
-| user.effective.hash | Unique hash to correlate information for an effective user in anonymized form. Useful if `user.effective.id` or `user.effective.name` contain confidential information and cannot be used. | keyword |
-| user.effective.id | Unique identifier of the effective user. | keyword |
-| user.effective.name | Short name or login of the effective user. | keyword |
+| user.effective.domain | Name of the directory the user is a member of. For example, an LDAP or Active Directory domain name. | keyword |
+| user.effective.email | User email address. | keyword |
+| user.effective.full_name | User's full name, if available. | keyword |
+| user.effective.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
+| user.effective.id | Unique identifier of the user. | keyword |
+| user.effective.name | Short name or login of the user. | keyword |
 | user.email | User email address. | keyword |
 | user.full_name | User's full name, if available. | keyword |
 | user.group.Ext | Object for all custom defined fields to live in. | object |


### PR DESCRIPTION
## Change Summary

Similar to https://github.com/elastic/endpoint-package/pull/496 but this time on 8.14 branch using newly developed update script https://github.com/elastic/endpoint-dev/pull/14407

~Again `make clean all` did a little change outside `custom_documentation` directory, in 2 files. It seems justified, there was a change in `user.effective.*` descriptions so it updated `fields.yaml` and `README.md`.~

I removed any changes made by `make clean all` outside `custom_documentation` directory.

### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json


```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
