### PR TITLE
remove unreleased document fields documentation which were accidental…

### DIFF
--- a/custom_documentation/doc/endpoint/process/windows/windows_process_exit.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_exit.md
@@ -48,7 +48,6 @@ This event is generated when a process exits.
 | process.Ext.code_signature.status |
 | process.Ext.code_signature.subject_name |
 | process.Ext.code_signature.trusted |
-| process.Ext.hidden.behaviors.api |
 | process.Ext.mitigation_policies |
 | process.Ext.session_info.authentication_package |
 | process.Ext.session_info.client_address |

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_exit.yaml
@@ -53,7 +53,6 @@ fields:
   - process.Ext.code_signature.status
   - process.Ext.code_signature.subject_name
   - process.Ext.code_signature.trusted
-  - process.Ext.hidden.behaviors.api
   - process.Ext.mitigation_policies
   - process.Ext.session_info.authentication_package
   - process.Ext.session_info.client_address


### PR DESCRIPTION
…ly added

## Change Summary

Custom documentation cleanup. Accidentally the PR https://github.com/elastic/endpoint-package/pull/498 added document fields which were not released yet.

### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json


```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
