### PR TITLE
Add event.dataset to api datastream

### DIFF
--- a/custom_subsets/elastic_endpoint/api/api.yaml
+++ b/custom_subsets/elastic_endpoint/api/api.yaml
@@ -19,6 +19,7 @@ fields:
       action: {}
       category: {}
       created: {}
+      dataset: {}
       end: {}
       hash: {}
       id: {}

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -908,6 +908,16 @@
 
         In case the two timestamps are identical, `@timestamp` should be used.'
       example: '2016-05-23T08:05:34.857Z'
+    - name: dataset
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the dataset.
+
+        If an event source publishes more than one type of log or events (e.g. access log, error log), the dataset is used to specify which one the event comes from.
+
+        It''s recommended but not required to start the dataset name with the module name, followed by a dot, then the dataset name.'
+      example: apache.access
     - name: end
       level: extended
       type: date

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -1784,6 +1784,23 @@ event.created:
   normalize: []
   short: Time when the event was first read by an agent or by your pipeline.
   type: date
+event.dataset:
+  dashed_name: event-dataset
+  description: 'Name of the dataset.
+
+    If an event source publishes more than one type of log or events (e.g. access
+    log, error log), the dataset is used to specify which one the event comes from.
+
+    It''s recommended but not required to start the dataset name with the module name,
+    followed by a dot, then the dataset name.'
+  example: apache.access
+  flat_name: event.dataset
+  ignore_above: 1024
+  level: core
+  name: dataset
+  normalize: []
+  short: Name of the dataset.
+  type: keyword
 event.end:
   dashed_name: event-end
   description: '`event.end` contains the date when the event ended or when the activity


### PR DESCRIPTION
## Change Summary

Adds `event.dataset` to `api` datastream. Exists in most others


Fixes #492


## Release Target

8.15


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- ~~[ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))~~
- ~~[ ] If this is a `metadata` change, I also updated both transform destination schemas to match~~

