### PR TITLE
WMI Activity API events (and + 9 events) metrics

### DIFF
--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -930,6 +930,18 @@
       index: false
       description: The total milliseconds spent queueing ETW Win32k events (currently, only keylogging events) for the process over the last week
 
+    - name: metrics.system_impact.wmi_events.week_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent on ETW WMI Activity events for the process over the last week
+
+    - name: metrics.system_impact.wmi_events.week_idle_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent queueing ETW Activity events for the process over the last week
+
     - name: metrics.system_impact.process.executable
       level: custom
       type: unsigned_long

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -566,6 +566,26 @@
       type: long
       description: Total size of suppressed documents
 
+    - name: metrics.documents_volume.volume_device_events.sent_count
+      level: custom
+      type: long
+      description: Number of sent documents
+
+    - name: metrics.documents_volume.volume_device_events.sent_bytes
+      level: custom
+      type: long
+      description: Total size of sent documents
+
+    - name: metrics.documents_volume.volume_device_events.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed documents
+
+    - name: metrics.documents_volume.volume_device_events.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed documents
+
     - name: metrics.documents_volume.alerts.sent_count
       level: custom
       type: long
@@ -1025,6 +1045,30 @@
       type: unsigned_long
       index: false
       description: The total milliseconds spent queueing ETW TCP/IP events for the process over the last week
+
+    - name: metrics.system_impact.volume_device_events.week_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent on volume device events for the process over the last week
+
+    - name: metrics.system_impact.volume_device_events.week_idle_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent queueing volume device events for the process over the last week
+
+    - name: metrics.system_impact.attack_surface_events.week_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent on attack surface events for the process over the last week
+
+    - name: metrics.system_impact.attack_surface_events.week_idle_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent queueing attack surface events for the process over the last week
 
     - name: metrics.system_impact.process.executable
       level: custom

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -942,6 +942,42 @@
       index: false
       description: The total milliseconds spent queueing ETW Activity events for the process over the last week
 
+    - name: metrics.system_impact.cred_access_events.week_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent on Credential Access events for the process over the last week
+
+    - name: metrics.system_impact.cred_access_events.week_idle_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent queueing Credential Access events for the process over the last week
+
+    - name: metrics.system_impact.ransomware.week_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent on Ransomware events for the process over the last week
+
+    - name: metrics.system_impact.ransomware.week_idle_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent queueing Ransomware events for the process over the last week
+
+    - name: metrics.system_impact.process_injection.week_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent on Process Injection events for the process over the last week
+
+    - name: metrics.system_impact.process_injection.week_idle_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent queueing Process Injection events for the process over the last week
+
     - name: metrics.system_impact.process.executable
       level: custom
       type: unsigned_long

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -940,43 +940,91 @@
       level: custom
       type: unsigned_long
       index: false
-      description: The total milliseconds spent queueing ETW Activity events for the process over the last week
+      description: The total milliseconds spent queueing ETW WMI Activity events for the process over the last week
 
     - name: metrics.system_impact.cred_access_events.week_ms
       level: custom
       type: unsigned_long
       index: false
-      description: The total milliseconds spent on Credential Access events for the process over the last week
+      description: The total milliseconds spent on credential access events for the process over the last week
 
     - name: metrics.system_impact.cred_access_events.week_idle_ms
       level: custom
       type: unsigned_long
       index: false
-      description: The total milliseconds spent queueing Credential Access events for the process over the last week
+      description: The total milliseconds spent queueing credential access events for the process over the last week
 
     - name: metrics.system_impact.ransomware.week_ms
       level: custom
       type: unsigned_long
       index: false
-      description: The total milliseconds spent on Ransomware events for the process over the last week
+      description: The total milliseconds spent on ransomware events for the process over the last week
 
     - name: metrics.system_impact.ransomware.week_idle_ms
       level: custom
       type: unsigned_long
       index: false
-      description: The total milliseconds spent queueing Ransomware events for the process over the last week
+      description: The total milliseconds spent queueing ransomware events for the process over the last week
 
     - name: metrics.system_impact.process_injection.week_ms
       level: custom
       type: unsigned_long
       index: false
-      description: The total milliseconds spent on Process Injection events for the process over the last week
+      description: The total milliseconds spent on process injection events for the process over the last week
 
     - name: metrics.system_impact.process_injection.week_idle_ms
       level: custom
       type: unsigned_long
       index: false
-      description: The total milliseconds spent queueing Process Injection events for the process over the last week
+      description: The total milliseconds spent queueing process injection events for the process over the last week
+
+    - name: metrics.system_impact.memory_scan.week_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent on memory scan events for the process over the last week
+
+    - name: metrics.system_impact.memory_scan.week_idle_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent queueing memory scan events for the process over the last week
+
+    - name: metrics.system_impact.behavior_protection.week_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent on behavior protection events for the process over the last week
+
+    - name: metrics.system_impact.behavior_protection.week_idle_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent queueing behavior protection events for the process over the last week
+
+    - name: metrics.system_impact.diagnostic_behavior_protection.week_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent on diagnostic behavior protection events for the process over the last week
+
+    - name: metrics.system_impact.diagnostic_behavior_protection.week_idle_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent queueing diagnostic behavior protection for the process over the last week
+
+    - name: metrics.system_impact.tcpip_events.week_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent on ETW TCP/IP events for the process over the last week
+
+    - name: metrics.system_impact.tcpip_events.week_idle_ms
+      level: custom
+      type: unsigned_long
+      index: false
+      description: The total milliseconds spent queueing ETW TCP/IP events for the process over the last week
 
     - name: metrics.system_impact.process.executable
       level: custom

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -434,6 +434,20 @@
       index: false
       doc_values: false
       default_field: false
+    - name: metrics.system_impact.cred_access_events.week_idle_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent queueing Credential Access events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.cred_access_events.week_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent on Credential Access events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
     - name: metrics.system_impact.dns_events.week_idle_ms
       level: custom
       type: unsigned_long
@@ -609,6 +623,34 @@
       level: custom
       type: unsigned_long
       description: The total milliseconds spent on process events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.process_injection.week_idle_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent queueing Process Injection events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.process_injection.week_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent on Process Injection events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.ransomware.week_idle_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent queueing Ransomware events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.ransomware.week_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent on Ransomware events for the process over the last week
       index: false
       doc_values: false
       default_field: false

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -654,6 +654,20 @@
       index: false
       doc_values: false
       default_field: false
+    - name: metrics.system_impact.wmi_events.week_idle_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent queueing ETW Activity events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.wmi_events.week_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent on ETW WMI Activity events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
     - name: metrics.threads
       level: custom
       type: object

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -434,17 +434,45 @@
       index: false
       doc_values: false
       default_field: false
+    - name: metrics.system_impact.behavior_protection.week_idle_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent queueing behavior protection events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.behavior_protection.week_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent on behavior protection events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
     - name: metrics.system_impact.cred_access_events.week_idle_ms
       level: custom
       type: unsigned_long
-      description: The total milliseconds spent queueing Credential Access events for the process over the last week
+      description: The total milliseconds spent queueing credential access events for the process over the last week
       index: false
       doc_values: false
       default_field: false
     - name: metrics.system_impact.cred_access_events.week_ms
       level: custom
       type: unsigned_long
-      description: The total milliseconds spent on Credential Access events for the process over the last week
+      description: The total milliseconds spent on credential access events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.diagnostic_behavior_protection.week_idle_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent queueing diagnostic behavior protection for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.diagnostic_behavior_protection.week_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent on diagnostic behavior protection events for the process over the last week
       index: false
       doc_values: false
       default_field: false
@@ -501,6 +529,20 @@
       level: custom
       type: unsigned_long
       description: The total milliseconds spent on malware scanning due to the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.memory_scan.week_idle_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent queueing memory scan events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.memory_scan.week_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent on memory scan events for the process over the last week
       index: false
       doc_values: false
       default_field: false
@@ -629,28 +671,28 @@
     - name: metrics.system_impact.process_injection.week_idle_ms
       level: custom
       type: unsigned_long
-      description: The total milliseconds spent queueing Process Injection events for the process over the last week
+      description: The total milliseconds spent queueing process injection events for the process over the last week
       index: false
       doc_values: false
       default_field: false
     - name: metrics.system_impact.process_injection.week_ms
       level: custom
       type: unsigned_long
-      description: The total milliseconds spent on Process Injection events for the process over the last week
+      description: The total milliseconds spent on process injection events for the process over the last week
       index: false
       doc_values: false
       default_field: false
     - name: metrics.system_impact.ransomware.week_idle_ms
       level: custom
       type: unsigned_long
-      description: The total milliseconds spent queueing Ransomware events for the process over the last week
+      description: The total milliseconds spent queueing ransomware events for the process over the last week
       index: false
       doc_values: false
       default_field: false
     - name: metrics.system_impact.ransomware.week_ms
       level: custom
       type: unsigned_long
-      description: The total milliseconds spent on Ransomware events for the process over the last week
+      description: The total milliseconds spent on ransomware events for the process over the last week
       index: false
       doc_values: false
       default_field: false
@@ -665,6 +707,20 @@
       level: custom
       type: unsigned_long
       description: The total milliseconds spent on registry events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.tcpip_events.week_idle_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent queueing ETW TCP/IP events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.tcpip_events.week_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent on ETW TCP/IP events for the process over the last week
       index: false
       doc_values: false
       default_field: false
@@ -699,7 +755,7 @@
     - name: metrics.system_impact.wmi_events.week_idle_ms
       level: custom
       type: unsigned_long
-      description: The total milliseconds spent queueing ETW Activity events for the process over the last week
+      description: The total milliseconds spent queueing ETW WMI Activity events for the process over the last week
       index: false
       doc_values: false
       default_field: false

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -353,6 +353,26 @@
       type: long
       description: Number of suppressed documents
       default_field: false
+    - name: metrics.documents_volume.volume_device_events.sent_bytes
+      level: custom
+      type: long
+      description: Total size of sent documents
+      default_field: false
+    - name: metrics.documents_volume.volume_device_events.sent_count
+      level: custom
+      type: long
+      description: Number of sent documents
+      default_field: false
+    - name: metrics.documents_volume.volume_device_events.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed documents
+      default_field: false
+    - name: metrics.documents_volume.volume_device_events.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed documents
+      default_field: false
     - name: metrics.event_filter.active_global_count
       level: custom
       type: long
@@ -417,6 +437,20 @@
       type: object
       description: An array of system impact information
       enabled: false
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.attack_surface_events.week_idle_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent queueing attack surface events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.attack_surface_events.week_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent on attack surface events for the process over the last week
       index: false
       doc_values: false
       default_field: false
@@ -735,6 +769,20 @@
       level: custom
       type: unsigned_long
       description: The total milliseconds spent on ETW Threat-Intelligence events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.volume_device_events.week_idle_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent queueing volume device events for the process over the last week
+      index: false
+      doc_values: false
+      default_field: false
+    - name: metrics.system_impact.volume_device_events.week_ms
+      level: custom
+      type: unsigned_long
+      description: The total milliseconds spent on volume device events for the process over the last week
       index: false
       doc_values: false
       default_field: false

--- a/package/endpoint/data_stream/metrics/sample_event.json
+++ b/package/endpoint/data_stream/metrics/sample_event.json
@@ -43,7 +43,7 @@
                         "week_ms": 8
                     },
                     "overall": {
-                        "week_ms": 11744
+                        "week_ms": 11774
                     },
                     "authentication_events": {
                         "week_ms": 155
@@ -59,6 +59,9 @@
                     },
                     "win32k_events": {
                         "week_ms": 50
+                    },
+                    "wmi_events": {
+                        "week_ms": 30
                     }
                 },
                 {
@@ -86,7 +89,7 @@
                         "week_ms": 3
                     },
                     "overall": {
-                        "week_ms": 8290
+                        "week_ms": 8300
                     },
                     "library_load_events": {
                         "week_ms": 7890
@@ -98,6 +101,9 @@
                         "week_ms": 300
                     },
                     "win32k_events": {
+                        "week_ms": 10
+                    },
+                    "wmi_events": {
                         "week_ms": 10
                     }
                 },
@@ -304,13 +310,16 @@
                         "week_ms": 8
                     },
                     "overall": {
-                        "week_ms": 1068
+                        "week_ms": 1098
                     },
                     "library_load_events": {
                         "week_ms": 85
                     },
                     "threat_intelligence_events": {
                         "week_ms": 250
+                    },
+                    "wmi_events": {
+                        "week_ms": 30
                     }
                 },
                 {
@@ -612,13 +621,16 @@
                         "week_ms": 5
                     },
                     "overall": {
-                        "week_ms": 345
+                        "week_ms": 375
                     },
                     "library_load_events": {
                         "week_ms": 14
                     },
                     "threat_intelligence_events": {
                         "week_ms": 50
+                    },
+                    "wmi_events": {
+                        "week_ms": 30
                     }
                 }
             ],

--- a/package/endpoint/data_stream/metrics/sample_event.json
+++ b/package/endpoint/data_stream/metrics/sample_event.json
@@ -14,6 +14,7 @@
             "system_impact": [
                 {
                     "file_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 418
                     },
                     "process": {
@@ -28,62 +29,89 @@
                         "executable": "C:\\Windows\\System32\\svchost.exe"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 7483
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 78
                     },
                     "registry_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 248
                     },
                     "dns_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 16
                     },
                     "network_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 8
                     },
                     "overall": {
-                        "week_ms": 11920
+                        "week_idle_ms": 0,
+                        "week_ms": 11935
                     },
                     "authentication_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 155
                     },
                     "library_load_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 3028
                     },
                     "cred_access_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 10
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 250
                     },
                     "win32k_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 50
                     },
                     "wmi_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 10
                     },
                     "ransomware": {
+                        "week_idle_ms": 0,
                         "week_ms": 50
                     },
                     "process_injection": {
+                        "week_idle_ms": 0,
                         "week_ms": 6
                     },
                     "memory_scan": {
+                        "week_idle_ms": 0,
                         "week_ms": 20
                     },
                     "behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 40
                     },
                     "diagnostic_behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 50
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 20
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 10
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 5
                     }
                 },
                 {
                     "file_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 46
                     },
                     "process": {
@@ -98,50 +126,73 @@
                         "executable": "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 2
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 19
                     },
                     "registry_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 3
                     },
                     "overall": {
-                        "week_ms": 8530
+                        "week_idle_ms": 0,
+                        "week_ms": 8560
                     },
                     "library_load_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 7890
                     },
                     "cred_access_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 20
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 300
                     },
                     "win32k_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 10
                     },
                     "wmi_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 10
                     },
                     "process_injection": {
+                        "week_idle_ms": 0,
                         "week_ms": 100
                     },
                     "memory_scan": {
+                        "week_idle_ms": 0,
                         "week_ms": 30
                     },
                     "behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 40
                     },
                     "diagnostic_behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 50
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 10
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 20
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 10
                     }
                 },
                 {
                     "file_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 1641
                     },
                     "process": {
@@ -156,35 +207,53 @@
                         "executable": "C:\\Program Files\\Winlogbeat\\winlogbeat.exe"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 2589
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 419
                     },
                     "registry_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 1
                     },
                     "network_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 32
                     },
                     "overall": {
-                        "week_ms": 5166
+                        "week_idle_ms": 0,
+                        "week_ms": 5200
                     },
                     "library_load_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 4
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 360
                     },
                     "memory_scan": {
+                        "week_idle_ms": 0,
                         "week_ms": 100
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 20
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 30
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 4
                     }
                 },
                 {
                     "file_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 2
                     },
                     "process": {
@@ -199,37 +268,56 @@
                         "executable": "C:\\Windows\\System32\\lsass.exe"
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 3
                     },
                     "registry_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 83
                     },
                     "overall": {
-                        "week_ms": 4981
+                        "week_idle_ms": 0,
+                        "week_ms": 5000
                     },
                     "authentication_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 3177
                     },
                     "library_load_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 26
                     },
                     "cred_access_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 1350
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 120
                     },
                     "memory_scan": {
+                        "week_idle_ms": 0,
                         "week_ms": 10
                     },
                     "behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 100
                     },
                     "diagnostic_behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 100
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 10
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 10
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 9
                     }
                 },
                 {
@@ -245,29 +333,45 @@
                         "executable": "C:\\Windows\\System32\\conhost.exe"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 16
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 26
                     },
                     "registry_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 3
                     },
                     "overall": {
-                        "week_ms": 3561
+                        "week_idle_ms": 0,
+                        "week_ms": 3596
                     },
                     "library_load_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 2966
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 250
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 300
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 30
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 5
                     }
                 },
                 {
                     "file_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 51
                     },
                     "process": {
@@ -280,9 +384,11 @@
                         "executable": "System"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 1978
                     },
                     "overall": {
+                        "week_idle_ms": 0,
                         "week_ms": 2029
                     }
                 },
@@ -296,14 +402,17 @@
                         "executable": "C:\\Windows\\assembly\\NativeImages_v4.0.30319_64\\System.Web\\e266326169887aa7cb26b9e2aa421ee4\\System.Web.ni.dll"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 1015
                     },
                     "overall": {
+                        "week_idle_ms": 0,
                         "week_ms": 1015
                     }
                 },
                 {
                     "file_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 8
                     },
                     "process": {
@@ -318,25 +427,40 @@
                         "executable": "C:\\Program Files\\Elastic\\Agent\\data\\elastic-agent-e80913\\install\\metricbeat-8.3.0-SNAPSHOT-windows-x86_64\\metricbeat.exe"
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 502
                     },
                     "dns_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 84
                     },
                     "network_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 1
                     },
                     "overall": {
-                        "week_ms": 1163
+                        "week_idle_ms": 0,
+                        "week_ms": 1198
                     },
                     "library_load_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 417
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 150
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 1
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 30
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 5
                     }
                 },
                 {
@@ -352,49 +476,72 @@
                         "executable": "C:\\Program Files\\Google\\Compute Engine\\agent\\GCEWindowsAgent.exe"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 627
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 89
                     },
                     "registry_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 2
                     },
                     "dns_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 7
                     },
                     "network_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 8
                     },
                     "overall": {
-                        "week_ms": 1260
+                        "week_idle_ms": 0,
+                        "week_ms": 1320
                     },
                     "library_load_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 85
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 250
                     },
                     "wmi_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 30
                     },
                     "ransomware": {
+                        "week_idle_ms": 0,
                         "week_ms": 2
                     },
                     "process_injection": {
+                        "week_idle_ms": 0,
                         "week_ms": 100
                     },
                     "memory_scan": {
+                        "week_idle_ms": 0,
                         "week_ms": 10
                     },
                     "behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 20
                     },
                     "diagnostic_behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 20
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 10
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 40
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 20
                     }
                 },
                 {
@@ -407,14 +554,17 @@
                         "executable": "C:\\Windows\\assembly\\NativeImages_v4.0.30319_64\\Microsoft.P521220ea#\\39ce4aafe1a3bc56fb1435f6550dd7a3\\Microsoft.PowerShell.Commands.Utility.ni.dll"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 760
                     },
                     "overall": {
+                        "week_idle_ms": 0,
                         "week_ms": 760
                     }
                 },
                 {
                     "file_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 15
                     },
                     "process": {
@@ -426,31 +576,48 @@
                         "executable": "C:\\Program Files\\metricbeat-7.10.0-windows-x86_64\\metricbeat.exe"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 29
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 634
                     },
                     "registry_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 1
                     },
                     "dns_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 8
                     },
                     "network_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 4
                     },
                     "overall": {
-                        "week_ms": 754
+                        "week_idle_ms": 0,
+                        "week_ms": 780
                     },
                     "library_load_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 3
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 50
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 10
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 6
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 20
                     }
                 },
                 {
@@ -466,27 +633,43 @@
                         "executable": "C:\\Windows\\System32\\spoolsv.exe"
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 8
                     },
                     "registry_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 40
                     },
                     "overall": {
-                        "week_ms": 810
+                        "week_idle_ms": 0,
+                        "week_ms": 870
                     },
                     "library_load_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 627
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 120
                     },
                     "ransomware": {
+                        "week_idle_ms": 0,
                         "week_ms": 5
                     },
                     "behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 20
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 10
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 50
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 10
                     }
                 },
@@ -503,32 +686,49 @@
                         "executable": "C:\\Program Files\\Packetbeat\\packetbeat.exe"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 74
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 432
                     },
                     "registry_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 1
                     },
                     "network_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 1
                     },
                     "overall": {
-                        "week_ms": 604
+                        "week_idle_ms": 0,
+                        "week_ms": 674
                     },
                     "library_load_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 61
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 30
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 5
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 50
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 20
                     }
                 },
                 {
                     "file_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 20
                     },
                     "process": {
@@ -549,38 +749,57 @@
                         "executable": "C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319\\csc.exe"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 350
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 19
                     },
                     "registry_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 1
                     },
                     "overall": {
-                        "week_ms": 580
+                        "week_idle_ms": 0,
+                        "week_ms": 600
                     },
                     "library_load_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 70
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 20
                     },
                     "ransomware": {
+                        "week_idle_ms": 0,
                         "week_ms": 20
                     },
                     "behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 61
                     },
                     "diagnostic_behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 9
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 10
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 10
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 10
                     }
                 },
                 {
                     "file_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 6
                     },
                     "process": {
@@ -595,22 +814,36 @@
                         "executable": "C:\\Program Files\\Elastic\\Agent\\data\\elastic-agent-e80913\\install\\filebeat-8.3.0-SNAPSHOT-windows-x86_64\\filebeat.exe"
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 395
                     },
                     "dns_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 51
                     },
                     "network_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 2
                     },
                     "overall": {
-                        "week_ms": 500
+                        "week_idle_ms": 0,
+                        "week_ms": 520
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 40
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 6
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 10
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 10
                     }
                 },
                 {
@@ -626,9 +859,11 @@
                         "executable": "C:\\Program Files\\Google\\Compute Engine\\vss\\GoogleVssProvider.dll"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 439
                     },
                     "overall": {
+                        "week_idle_ms": 0,
                         "week_ms": 439
                     }
                 },
@@ -645,40 +880,60 @@
                         "executable": "C:\\Windows\\System32\\VSSVC.exe"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 45
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 13
                     },
                     "registry_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 124
                     },
                     "overall": {
-                        "week_ms": 610
+                        "week_idle_ms": 0,
+                        "week_ms": 625
                     },
                     "authentication_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 8
                     },
                     "library_load_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 216
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 70
                     },
                     "process_injection": {
+                        "week_idle_ms": 0,
                         "week_ms": 100
                     },
                     "memory_scan": {
+                        "week_idle_ms": 0,
                         "week_ms": 20
                     },
                     "behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 4
                     },
                     "diagnostic_behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 9
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 1
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 5
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 10
                     }
                 },
                 {
@@ -694,9 +949,11 @@
                         "executable": "C:\\Windows\\SYSTEM32\\mispace.dll"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 353
                     },
                     "overall": {
+                        "week_idle_ms": 0,
                         "week_ms": 353
                     }
                 },
@@ -710,14 +967,17 @@
                         "executable": "C:\\Windows\\assembly\\NativeImages_v4.0.30319_64\\System.Web.28b9ef5a#\\b1cbeb46534d9974961496306f2f1a28\\System.Web.Extensions.ni.dll"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 305
                     },
                     "overall": {
+                        "week_idle_ms": 0,
                         "week_ms": 305
                     }
                 },
                 {
                     "file_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 25
                     },
                     "process": {
@@ -732,40 +992,60 @@
                         "executable": "C:\\Windows\\System32\\wbem\\WMIADAP.exe"
                     },
                     "malware": {
+                        "week_idle_ms": 0,
                         "week_ms": 247
                     },
                     "process_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 4
                     },
                     "registry_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 5
                     },
                     "overall": {
-                        "week_ms": 468
+                        "week_idle_ms": 0,
+                        "week_ms": 498
                     },
                     "library_load_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 14
                     },
                     "threat_intelligence_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 50
                     },
                     "wmi_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 30
                     },
                     "ransomware": {
+                        "week_idle_ms": 0,
                         "week_ms": 15
                     },
                     "memory_scan": {
+                        "week_idle_ms": 0,
                         "week_ms": 40
                     },
                     "behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 20
                     },
                     "diagnostic_behavior_protection": {
+                        "week_idle_ms": 0,
                         "week_ms": 10
                     },
                     "tcpip_events": {
+                        "week_idle_ms": 0,
                         "week_ms": 8
+                    },
+                    "volume_device_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 20
+                    },
+                    "attack_surface_events": {
+                        "week_idle_ms": 0,
+                        "week_ms": 10
                     }
                 }
             ],
@@ -837,11 +1117,35 @@
                     "sent_count": 1753,
                     "sent_bytes": 3479631
                 },
+                "volume_device_events": {
+                    "suppressed_count": 0,
+                    "suppressed_bytes": 0,
+                    "sent_count": 2,
+                    "sent_bytes": 3783
+                },
+                "alerts": {
+                    "suppressed_count": 0,
+                    "suppressed_bytes": 0,
+                    "sent_count": 123,
+                    "sent_bytes": 4584
+                },
+                "diagnostic_alerts": {
+                    "suppressed_count": 0,
+                    "suppressed_bytes": 0,
+                    "sent_count": 188,
+                    "sent_bytes": 6599
+                },
+                "api_events": {
+                    "suppressed_count": 0,
+                    "suppressed_bytes": 0,
+                    "sent_count": 2564,
+                    "sent_bytes": 12341
+                },
                 "overall": {
                     "suppressed_count": 0,
                     "suppressed_bytes": 0,
-                    "sent_count": 11667,
-                    "sent_bytes": 24748966
+                    "sent_count": 14634,
+                    "sent_bytes": 24776273
                 }
             },
             "cpu": {

--- a/package/endpoint/data_stream/metrics/sample_event.json
+++ b/package/endpoint/data_stream/metrics/sample_event.json
@@ -43,7 +43,7 @@
                         "week_ms": 8
                     },
                     "overall": {
-                        "week_ms": 11790
+                        "week_ms": 11920
                     },
                     "authentication_events": {
                         "week_ms": 155
@@ -68,6 +68,18 @@
                     },
                     "process_injection": {
                         "week_ms": 6
+                    },
+                    "memory_scan": {
+                        "week_ms": 20
+                    },
+                    "behavior_protection": {
+                        "week_ms": 40
+                    },
+                    "diagnostic_behavior_protection": {
+                        "week_ms": 50
+                    },
+                    "tcpip_events": {
+                        "week_ms": 20
                     }
                 },
                 {
@@ -95,7 +107,7 @@
                         "week_ms": 3
                     },
                     "overall": {
-                        "week_ms": 8400
+                        "week_ms": 8530
                     },
                     "library_load_events": {
                         "week_ms": 7890
@@ -114,6 +126,18 @@
                     },
                     "process_injection": {
                         "week_ms": 100
+                    },
+                    "memory_scan": {
+                        "week_ms": 30
+                    },
+                    "behavior_protection": {
+                        "week_ms": 40
+                    },
+                    "diagnostic_behavior_protection": {
+                        "week_ms": 50
+                    },
+                    "tcpip_events": {
+                        "week_ms": 10
                     }
                 },
                 {
@@ -144,13 +168,19 @@
                         "week_ms": 32
                     },
                     "overall": {
-                        "week_ms": 5046
+                        "week_ms": 5166
                     },
                     "library_load_events": {
                         "week_ms": 4
                     },
                     "threat_intelligence_events": {
                         "week_ms": 360
+                    },
+                    "memory_scan": {
+                        "week_ms": 100
+                    },
+                    "tcpip_events": {
+                        "week_ms": 20
                     }
                 },
                 {
@@ -175,7 +205,7 @@
                         "week_ms": 83
                     },
                     "overall": {
-                        "week_ms": 4761
+                        "week_ms": 4981
                     },
                     "authentication_events": {
                         "week_ms": 3177
@@ -188,6 +218,18 @@
                     },
                     "threat_intelligence_events": {
                         "week_ms": 120
+                    },
+                    "memory_scan": {
+                        "week_ms": 10
+                    },
+                    "behavior_protection": {
+                        "week_ms": 100
+                    },
+                    "diagnostic_behavior_protection": {
+                        "week_ms": 100
+                    },
+                    "tcpip_events": {
+                        "week_ms": 10
                     }
                 },
                 {
@@ -212,13 +254,16 @@
                         "week_ms": 3
                     },
                     "overall": {
-                        "week_ms": 3261
+                        "week_ms": 3561
                     },
                     "library_load_events": {
                         "week_ms": 2966
                     },
                     "threat_intelligence_events": {
                         "week_ms": 250
+                    },
+                    "tcpip_events": {
+                        "week_ms": 300
                     }
                 },
                 {
@@ -282,13 +327,16 @@
                         "week_ms": 1
                     },
                     "overall": {
-                        "week_ms": 1162
+                        "week_ms": 1163
                     },
                     "library_load_events": {
                         "week_ms": 417
                     },
                     "threat_intelligence_events": {
                         "week_ms": 150
+                    },
+                    "tcpip_events": {
+                        "week_ms": 1
                     }
                 },
                 {
@@ -319,7 +367,7 @@
                         "week_ms": 8
                     },
                     "overall": {
-                        "week_ms": 1200
+                        "week_ms": 1260
                     },
                     "library_load_events": {
                         "week_ms": 85
@@ -335,6 +383,18 @@
                     },
                     "process_injection": {
                         "week_ms": 100
+                    },
+                    "memory_scan": {
+                        "week_ms": 10
+                    },
+                    "behavior_protection": {
+                        "week_ms": 20
+                    },
+                    "diagnostic_behavior_protection": {
+                        "week_ms": 20
+                    },
+                    "tcpip_events": {
+                        "week_ms": 10
                     }
                 },
                 {
@@ -381,13 +441,16 @@
                         "week_ms": 4
                     },
                     "overall": {
-                        "week_ms": 744
+                        "week_ms": 754
                     },
                     "library_load_events": {
                         "week_ms": 3
                     },
                     "threat_intelligence_events": {
                         "week_ms": 50
+                    },
+                    "tcpip_events": {
+                        "week_ms": 10
                     }
                 },
                 {
@@ -409,7 +472,7 @@
                         "week_ms": 40
                     },
                     "overall": {
-                        "week_ms": 780
+                        "week_ms": 810
                     },
                     "library_load_events": {
                         "week_ms": 627
@@ -419,6 +482,12 @@
                     },
                     "ransomware": {
                         "week_ms": 5
+                    },
+                    "behavior_protection": {
+                        "week_ms": 20
+                    },
+                    "tcpip_events": {
+                        "week_ms": 10
                     }
                 },
                 {
@@ -446,13 +515,16 @@
                         "week_ms": 1
                     },
                     "overall": {
-                        "week_ms": 599
+                        "week_ms": 604
                     },
                     "library_load_events": {
                         "week_ms": 61
                     },
                     "threat_intelligence_events": {
                         "week_ms": 30
+                    },
+                    "tcpip_events": {
+                        "week_ms": 5
                     }
                 },
                 {
@@ -486,7 +558,7 @@
                         "week_ms": 1
                     },
                     "overall": {
-                        "week_ms": 500
+                        "week_ms": 580
                     },
                     "library_load_events": {
                         "week_ms": 70
@@ -496,6 +568,15 @@
                     },
                     "ransomware": {
                         "week_ms": 20
+                    },
+                    "behavior_protection": {
+                        "week_ms": 61
+                    },
+                    "diagnostic_behavior_protection": {
+                        "week_ms": 9
+                    },
+                    "tcpip_events": {
+                        "week_ms": 10
                     }
                 },
                 {
@@ -523,10 +604,13 @@
                         "week_ms": 2
                     },
                     "overall": {
-                        "week_ms": 494
+                        "week_ms": 500
                     },
                     "threat_intelligence_events": {
                         "week_ms": 40
+                    },
+                    "tcpip_events": {
+                        "week_ms": 6
                     }
                 },
                 {
@@ -570,7 +654,7 @@
                         "week_ms": 124
                     },
                     "overall": {
-                        "week_ms": 576
+                        "week_ms": 610
                     },
                     "authentication_events": {
                         "week_ms": 8
@@ -583,6 +667,18 @@
                     },
                     "process_injection": {
                         "week_ms": 100
+                    },
+                    "memory_scan": {
+                        "week_ms": 20
+                    },
+                    "behavior_protection": {
+                        "week_ms": 4
+                    },
+                    "diagnostic_behavior_protection": {
+                        "week_ms": 9
+                    },
+                    "tcpip_events": {
+                        "week_ms": 1
                     }
                 },
                 {
@@ -645,7 +741,7 @@
                         "week_ms": 5
                     },
                     "overall": {
-                        "week_ms": 390
+                        "week_ms": 468
                     },
                     "library_load_events": {
                         "week_ms": 14
@@ -658,6 +754,18 @@
                     },
                     "ransomware": {
                         "week_ms": 15
+                    },
+                    "memory_scan": {
+                        "week_ms": 40
+                    },
+                    "behavior_protection": {
+                        "week_ms": 20
+                    },
+                    "diagnostic_behavior_protection": {
+                        "week_ms": 10
+                    },
+                    "tcpip_events": {
+                        "week_ms": 8
                     }
                 }
             ],

--- a/package/endpoint/data_stream/metrics/sample_event.json
+++ b/package/endpoint/data_stream/metrics/sample_event.json
@@ -43,7 +43,7 @@
                         "week_ms": 8
                     },
                     "overall": {
-                        "week_ms": 11774
+                        "week_ms": 11790
                     },
                     "authentication_events": {
                         "week_ms": 155
@@ -61,7 +61,13 @@
                         "week_ms": 50
                     },
                     "wmi_events": {
-                        "week_ms": 30
+                        "week_ms": 10
+                    },
+                    "ransomware": {
+                        "week_ms": 50
+                    },
+                    "process_injection": {
+                        "week_ms": 6
                     }
                 },
                 {
@@ -89,7 +95,7 @@
                         "week_ms": 3
                     },
                     "overall": {
-                        "week_ms": 8300
+                        "week_ms": 8400
                     },
                     "library_load_events": {
                         "week_ms": 7890
@@ -105,6 +111,9 @@
                     },
                     "wmi_events": {
                         "week_ms": 10
+                    },
+                    "process_injection": {
+                        "week_ms": 100
                     }
                 },
                 {
@@ -310,7 +319,7 @@
                         "week_ms": 8
                     },
                     "overall": {
-                        "week_ms": 1098
+                        "week_ms": 1200
                     },
                     "library_load_events": {
                         "week_ms": 85
@@ -320,6 +329,12 @@
                     },
                     "wmi_events": {
                         "week_ms": 30
+                    },
+                    "ransomware": {
+                        "week_ms": 2
+                    },
+                    "process_injection": {
+                        "week_ms": 100
                     }
                 },
                 {
@@ -394,13 +409,16 @@
                         "week_ms": 40
                     },
                     "overall": {
-                        "week_ms": 795
+                        "week_ms": 780
                     },
                     "library_load_events": {
                         "week_ms": 627
                     },
                     "threat_intelligence_events": {
                         "week_ms": 120
+                    },
+                    "ransomware": {
+                        "week_ms": 5
                     }
                 },
                 {
@@ -468,12 +486,15 @@
                         "week_ms": 1
                     },
                     "overall": {
-                        "week_ms": 480
+                        "week_ms": 500
                     },
                     "library_load_events": {
                         "week_ms": 70
                     },
                     "threat_intelligence_events": {
+                        "week_ms": 20
+                    },
+                    "ransomware": {
                         "week_ms": 20
                     }
                 },
@@ -549,7 +570,7 @@
                         "week_ms": 124
                     },
                     "overall": {
-                        "week_ms": 476
+                        "week_ms": 576
                     },
                     "authentication_events": {
                         "week_ms": 8
@@ -559,6 +580,9 @@
                     },
                     "threat_intelligence_events": {
                         "week_ms": 70
+                    },
+                    "process_injection": {
+                        "week_ms": 100
                     }
                 },
                 {
@@ -621,7 +645,7 @@
                         "week_ms": 5
                     },
                     "overall": {
-                        "week_ms": 375
+                        "week_ms": 390
                     },
                     "library_load_events": {
                         "week_ms": 14
@@ -631,6 +655,9 @@
                     },
                     "wmi_events": {
                         "week_ms": 30
+                    },
+                    "ransomware": {
+                        "week_ms": 15
                     }
                 }
             ],

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2867,6 +2867,10 @@ Metrics documents contain performance information about the endpoint executable 
 | Endpoint.metrics.documents_volume.security_events.sent_count | Number of sent documents | long |
 | Endpoint.metrics.documents_volume.security_events.suppressed_bytes | Total size of suppressed documents | long |
 | Endpoint.metrics.documents_volume.security_events.suppressed_count | Number of suppressed documents | long |
+| Endpoint.metrics.documents_volume.volume_device_events.sent_bytes | Total size of sent documents | long |
+| Endpoint.metrics.documents_volume.volume_device_events.sent_count | Number of sent documents | long |
+| Endpoint.metrics.documents_volume.volume_device_events.suppressed_bytes | Total size of suppressed documents | long |
+| Endpoint.metrics.documents_volume.volume_device_events.suppressed_count | Number of suppressed documents | long |
 | Endpoint.metrics.event_filter.active_global_count | The number of active global event filters | long |
 | Endpoint.metrics.event_filter.active_user_count | The number of active user event filters | long |
 | Endpoint.metrics.memory | Memory statistics | object |

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -603,6 +603,42 @@ Endpoint.metrics.documents_volume.security_events.suppressed_count:
   normalize: []
   short: Number of suppressed documents
   type: long
+Endpoint.metrics.documents_volume.volume_device_events.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-volume-device-events-sent-bytes
+  description: Total size of sent documents
+  flat_name: Endpoint.metrics.documents_volume.volume_device_events.sent_bytes
+  level: custom
+  name: metrics.documents_volume.volume_device_events.sent_bytes
+  normalize: []
+  short: Total size of sent documents
+  type: long
+Endpoint.metrics.documents_volume.volume_device_events.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-volume-device-events-sent-count
+  description: Number of sent documents
+  flat_name: Endpoint.metrics.documents_volume.volume_device_events.sent_count
+  level: custom
+  name: metrics.documents_volume.volume_device_events.sent_count
+  normalize: []
+  short: Number of sent documents
+  type: long
+Endpoint.metrics.documents_volume.volume_device_events.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-volume-device-events-suppressed-bytes
+  description: Total size of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.volume_device_events.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.volume_device_events.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed documents
+  type: long
+Endpoint.metrics.documents_volume.volume_device_events.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-volume-device-events-suppressed-count
+  description: Number of suppressed documents
+  flat_name: Endpoint.metrics.documents_volume.volume_device_events.suppressed_count
+  level: custom
+  name: metrics.documents_volume.volume_device_events.suppressed_count
+  normalize: []
+  short: Number of suppressed documents
+  type: long
 Endpoint.metrics.event_filter.active_global_count:
   dashed_name: Endpoint-metrics-event-filter-active-global-count
   description: The number of active global event filters
@@ -714,6 +750,32 @@ Endpoint.metrics.system_impact:
   normalize: []
   short: An array of system impact information
   type: object
+Endpoint.metrics.system_impact.attack_surface_events.week_idle_ms:
+  dashed_name: Endpoint-metrics-system-impact-attack-surface-events-week-idle-ms
+  description: The total milliseconds spent queueing attack surface events for the
+    process over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.attack_surface_events.week_idle_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.attack_surface_events.week_idle_ms
+  normalize: []
+  short: The total milliseconds spent queueing attack surface events for the process
+    over the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.attack_surface_events.week_ms:
+  dashed_name: Endpoint-metrics-system-impact-attack-surface-events-week-ms
+  description: The total milliseconds spent on attack surface events for the process
+    over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.attack_surface_events.week_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.attack_surface_events.week_ms
+  normalize: []
+  short: The total milliseconds spent on attack surface events for the process over
+    the last week
+  type: unsigned_long
 Endpoint.metrics.system_impact.authentication_events.week_idle_ms:
   dashed_name: Endpoint-metrics-system-impact-authentication-events-week-idle-ms
   description: The total milliseconds spent queueing authentication events for the
@@ -1276,6 +1338,32 @@ Endpoint.metrics.system_impact.threat_intelligence_events.week_ms:
   normalize: []
   short: The total milliseconds spent on ETW Threat-Intelligence events for the process
     over the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.volume_device_events.week_idle_ms:
+  dashed_name: Endpoint-metrics-system-impact-volume-device-events-week-idle-ms
+  description: The total milliseconds spent queueing volume device events for the
+    process over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.volume_device_events.week_idle_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.volume_device_events.week_idle_ms
+  normalize: []
+  short: The total milliseconds spent queueing volume device events for the process
+    over the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.volume_device_events.week_ms:
+  dashed_name: Endpoint-metrics-system-impact-volume-device-events-week-ms
+  description: The total milliseconds spent on volume device events for the process
+    over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.volume_device_events.week_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.volume_device_events.week_ms
+  normalize: []
+  short: The total milliseconds spent on volume device events for the process over
+    the last week
   type: unsigned_long
 Endpoint.metrics.system_impact.win32k_events.week_idle_ms:
   dashed_name: Endpoint-metrics-system-impact-win32k-events-week-idle-ms

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -740,6 +740,32 @@ Endpoint.metrics.system_impact.authentication_events.week_ms:
   short: The total milliseconds spent on authentication events for the process over
     the last week
   type: unsigned_long
+Endpoint.metrics.system_impact.cred_access_events.week_idle_ms:
+  dashed_name: Endpoint-metrics-system-impact-cred-access-events-week-idle-ms
+  description: The total milliseconds spent queueing Credential Access events for
+    the process over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.cred_access_events.week_idle_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.cred_access_events.week_idle_ms
+  normalize: []
+  short: The total milliseconds spent queueing Credential Access events for the process
+    over the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.cred_access_events.week_ms:
+  dashed_name: Endpoint-metrics-system-impact-cred-access-events-week-ms
+  description: The total milliseconds spent on Credential Access events for the process
+    over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.cred_access_events.week_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.cred_access_events.week_ms
+  normalize: []
+  short: The total milliseconds spent on Credential Access events for the process
+    over the last week
+  type: unsigned_long
 Endpoint.metrics.system_impact.dns_events.week_idle_ms:
   dashed_name: Endpoint-metrics-system-impact-dns-events-week-idle-ms
   description: The total milliseconds spent queueing DNS events for the process over
@@ -1042,6 +1068,58 @@ Endpoint.metrics.system_impact.process_events.week_ms:
   normalize: []
   short: The total milliseconds spent on process events for the process over the last
     week
+  type: unsigned_long
+Endpoint.metrics.system_impact.process_injection.week_idle_ms:
+  dashed_name: Endpoint-metrics-system-impact-process-injection-week-idle-ms
+  description: The total milliseconds spent queueing Process Injection events for
+    the process over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.process_injection.week_idle_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.process_injection.week_idle_ms
+  normalize: []
+  short: The total milliseconds spent queueing Process Injection events for the process
+    over the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.process_injection.week_ms:
+  dashed_name: Endpoint-metrics-system-impact-process-injection-week-ms
+  description: The total milliseconds spent on Process Injection events for the process
+    over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.process_injection.week_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.process_injection.week_ms
+  normalize: []
+  short: The total milliseconds spent on Process Injection events for the process
+    over the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.ransomware.week_idle_ms:
+  dashed_name: Endpoint-metrics-system-impact-ransomware-week-idle-ms
+  description: The total milliseconds spent queueing Ransomware events for the process
+    over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.ransomware.week_idle_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.ransomware.week_idle_ms
+  normalize: []
+  short: The total milliseconds spent queueing Ransomware events for the process over
+    the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.ransomware.week_ms:
+  dashed_name: Endpoint-metrics-system-impact-ransomware-week-ms
+  description: The total milliseconds spent on Ransomware events for the process over
+    the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.ransomware.week_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.ransomware.week_ms
+  normalize: []
+  short: The total milliseconds spent on Ransomware events for the process over the
+    last week
   type: unsigned_long
 Endpoint.metrics.system_impact.registry_events.week_idle_ms:
   dashed_name: Endpoint-metrics-system-impact-registry-events-week-idle-ms

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -1121,6 +1121,32 @@ Endpoint.metrics.system_impact.win32k_events.week_ms:
   short: The total milliseconds spent on ETW Win32k events (currently, only keylogging
     events) for the process over the last week
   type: unsigned_long
+Endpoint.metrics.system_impact.wmi_events.week_idle_ms:
+  dashed_name: Endpoint-metrics-system-impact-wmi-events-week-idle-ms
+  description: The total milliseconds spent queueing ETW Activity events for the process
+    over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.wmi_events.week_idle_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.wmi_events.week_idle_ms
+  normalize: []
+  short: The total milliseconds spent queueing ETW Activity events for the process
+    over the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.wmi_events.week_ms:
+  dashed_name: Endpoint-metrics-system-impact-wmi-events-week-ms
+  description: The total milliseconds spent on ETW WMI Activity events for the process
+    over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.wmi_events.week_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.wmi_events.week_ms
+  normalize: []
+  short: The total milliseconds spent on ETW WMI Activity events for the process over
+    the last week
+  type: unsigned_long
 Endpoint.metrics.threads:
   dashed_name: Endpoint-metrics-threads
   description: Statistics about the individual Endpoint threads (array)

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -740,9 +740,35 @@ Endpoint.metrics.system_impact.authentication_events.week_ms:
   short: The total milliseconds spent on authentication events for the process over
     the last week
   type: unsigned_long
+Endpoint.metrics.system_impact.behavior_protection.week_idle_ms:
+  dashed_name: Endpoint-metrics-system-impact-behavior-protection-week-idle-ms
+  description: The total milliseconds spent queueing behavior protection events for
+    the process over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.behavior_protection.week_idle_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.behavior_protection.week_idle_ms
+  normalize: []
+  short: The total milliseconds spent queueing behavior protection events for the
+    process over the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.behavior_protection.week_ms:
+  dashed_name: Endpoint-metrics-system-impact-behavior-protection-week-ms
+  description: The total milliseconds spent on behavior protection events for the
+    process over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.behavior_protection.week_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.behavior_protection.week_ms
+  normalize: []
+  short: The total milliseconds spent on behavior protection events for the process
+    over the last week
+  type: unsigned_long
 Endpoint.metrics.system_impact.cred_access_events.week_idle_ms:
   dashed_name: Endpoint-metrics-system-impact-cred-access-events-week-idle-ms
-  description: The total milliseconds spent queueing Credential Access events for
+  description: The total milliseconds spent queueing credential access events for
     the process over the last week
   doc_values: false
   flat_name: Endpoint.metrics.system_impact.cred_access_events.week_idle_ms
@@ -750,12 +776,12 @@ Endpoint.metrics.system_impact.cred_access_events.week_idle_ms:
   level: custom
   name: metrics.system_impact.cred_access_events.week_idle_ms
   normalize: []
-  short: The total milliseconds spent queueing Credential Access events for the process
+  short: The total milliseconds spent queueing credential access events for the process
     over the last week
   type: unsigned_long
 Endpoint.metrics.system_impact.cred_access_events.week_ms:
   dashed_name: Endpoint-metrics-system-impact-cred-access-events-week-ms
-  description: The total milliseconds spent on Credential Access events for the process
+  description: The total milliseconds spent on credential access events for the process
     over the last week
   doc_values: false
   flat_name: Endpoint.metrics.system_impact.cred_access_events.week_ms
@@ -763,8 +789,34 @@ Endpoint.metrics.system_impact.cred_access_events.week_ms:
   level: custom
   name: metrics.system_impact.cred_access_events.week_ms
   normalize: []
-  short: The total milliseconds spent on Credential Access events for the process
+  short: The total milliseconds spent on credential access events for the process
     over the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.diagnostic_behavior_protection.week_idle_ms:
+  dashed_name: Endpoint-metrics-system-impact-diagnostic-behavior-protection-week-idle-ms
+  description: The total milliseconds spent queueing diagnostic behavior protection
+    for the process over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.diagnostic_behavior_protection.week_idle_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.diagnostic_behavior_protection.week_idle_ms
+  normalize: []
+  short: The total milliseconds spent queueing diagnostic behavior protection for
+    the process over the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.diagnostic_behavior_protection.week_ms:
+  dashed_name: Endpoint-metrics-system-impact-diagnostic-behavior-protection-week-ms
+  description: The total milliseconds spent on diagnostic behavior protection events
+    for the process over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.diagnostic_behavior_protection.week_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.diagnostic_behavior_protection.week_ms
+  normalize: []
+  short: The total milliseconds spent on diagnostic behavior protection events for
+    the process over the last week
   type: unsigned_long
 Endpoint.metrics.system_impact.dns_events.week_idle_ms:
   dashed_name: Endpoint-metrics-system-impact-dns-events-week-idle-ms
@@ -869,6 +921,32 @@ Endpoint.metrics.system_impact.malware.week_ms:
   normalize: []
   short: The total milliseconds spent on malware scanning due to the process over
     the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.memory_scan.week_idle_ms:
+  dashed_name: Endpoint-metrics-system-impact-memory-scan-week-idle-ms
+  description: The total milliseconds spent queueing memory scan events for the process
+    over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.memory_scan.week_idle_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.memory_scan.week_idle_ms
+  normalize: []
+  short: The total milliseconds spent queueing memory scan events for the process
+    over the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.memory_scan.week_ms:
+  dashed_name: Endpoint-metrics-system-impact-memory-scan-week-ms
+  description: The total milliseconds spent on memory scan events for the process
+    over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.memory_scan.week_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.memory_scan.week_ms
+  normalize: []
+  short: The total milliseconds spent on memory scan events for the process over the
+    last week
   type: unsigned_long
 Endpoint.metrics.system_impact.network_events.week_idle_ms:
   dashed_name: Endpoint-metrics-system-impact-network-events-week-idle-ms
@@ -1071,7 +1149,7 @@ Endpoint.metrics.system_impact.process_events.week_ms:
   type: unsigned_long
 Endpoint.metrics.system_impact.process_injection.week_idle_ms:
   dashed_name: Endpoint-metrics-system-impact-process-injection-week-idle-ms
-  description: The total milliseconds spent queueing Process Injection events for
+  description: The total milliseconds spent queueing process injection events for
     the process over the last week
   doc_values: false
   flat_name: Endpoint.metrics.system_impact.process_injection.week_idle_ms
@@ -1079,12 +1157,12 @@ Endpoint.metrics.system_impact.process_injection.week_idle_ms:
   level: custom
   name: metrics.system_impact.process_injection.week_idle_ms
   normalize: []
-  short: The total milliseconds spent queueing Process Injection events for the process
+  short: The total milliseconds spent queueing process injection events for the process
     over the last week
   type: unsigned_long
 Endpoint.metrics.system_impact.process_injection.week_ms:
   dashed_name: Endpoint-metrics-system-impact-process-injection-week-ms
-  description: The total milliseconds spent on Process Injection events for the process
+  description: The total milliseconds spent on process injection events for the process
     over the last week
   doc_values: false
   flat_name: Endpoint.metrics.system_impact.process_injection.week_ms
@@ -1092,12 +1170,12 @@ Endpoint.metrics.system_impact.process_injection.week_ms:
   level: custom
   name: metrics.system_impact.process_injection.week_ms
   normalize: []
-  short: The total milliseconds spent on Process Injection events for the process
+  short: The total milliseconds spent on process injection events for the process
     over the last week
   type: unsigned_long
 Endpoint.metrics.system_impact.ransomware.week_idle_ms:
   dashed_name: Endpoint-metrics-system-impact-ransomware-week-idle-ms
-  description: The total milliseconds spent queueing Ransomware events for the process
+  description: The total milliseconds spent queueing ransomware events for the process
     over the last week
   doc_values: false
   flat_name: Endpoint.metrics.system_impact.ransomware.week_idle_ms
@@ -1105,12 +1183,12 @@ Endpoint.metrics.system_impact.ransomware.week_idle_ms:
   level: custom
   name: metrics.system_impact.ransomware.week_idle_ms
   normalize: []
-  short: The total milliseconds spent queueing Ransomware events for the process over
+  short: The total milliseconds spent queueing ransomware events for the process over
     the last week
   type: unsigned_long
 Endpoint.metrics.system_impact.ransomware.week_ms:
   dashed_name: Endpoint-metrics-system-impact-ransomware-week-ms
-  description: The total milliseconds spent on Ransomware events for the process over
+  description: The total milliseconds spent on ransomware events for the process over
     the last week
   doc_values: false
   flat_name: Endpoint.metrics.system_impact.ransomware.week_ms
@@ -1118,7 +1196,7 @@ Endpoint.metrics.system_impact.ransomware.week_ms:
   level: custom
   name: metrics.system_impact.ransomware.week_ms
   normalize: []
-  short: The total milliseconds spent on Ransomware events for the process over the
+  short: The total milliseconds spent on ransomware events for the process over the
     last week
   type: unsigned_long
 Endpoint.metrics.system_impact.registry_events.week_idle_ms:
@@ -1145,6 +1223,32 @@ Endpoint.metrics.system_impact.registry_events.week_ms:
   name: metrics.system_impact.registry_events.week_ms
   normalize: []
   short: The total milliseconds spent on registry events for the process over the
+    last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.tcpip_events.week_idle_ms:
+  dashed_name: Endpoint-metrics-system-impact-tcpip-events-week-idle-ms
+  description: The total milliseconds spent queueing ETW TCP/IP events for the process
+    over the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.tcpip_events.week_idle_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.tcpip_events.week_idle_ms
+  normalize: []
+  short: The total milliseconds spent queueing ETW TCP/IP events for the process over
+    the last week
+  type: unsigned_long
+Endpoint.metrics.system_impact.tcpip_events.week_ms:
+  dashed_name: Endpoint-metrics-system-impact-tcpip-events-week-ms
+  description: The total milliseconds spent on ETW TCP/IP events for the process over
+    the last week
+  doc_values: false
+  flat_name: Endpoint.metrics.system_impact.tcpip_events.week_ms
+  index: false
+  level: custom
+  name: metrics.system_impact.tcpip_events.week_ms
+  normalize: []
+  short: The total milliseconds spent on ETW TCP/IP events for the process over the
     last week
   type: unsigned_long
 Endpoint.metrics.system_impact.threat_intelligence_events.week_idle_ms:
@@ -1201,15 +1305,15 @@ Endpoint.metrics.system_impact.win32k_events.week_ms:
   type: unsigned_long
 Endpoint.metrics.system_impact.wmi_events.week_idle_ms:
   dashed_name: Endpoint-metrics-system-impact-wmi-events-week-idle-ms
-  description: The total milliseconds spent queueing ETW Activity events for the process
-    over the last week
+  description: The total milliseconds spent queueing ETW WMI Activity events for the
+    process over the last week
   doc_values: false
   flat_name: Endpoint.metrics.system_impact.wmi_events.week_idle_ms
   index: false
   level: custom
   name: metrics.system_impact.wmi_events.week_idle_ms
   normalize: []
-  short: The total milliseconds spent queueing ETW Activity events for the process
+  short: The total milliseconds spent queueing ETW WMI Activity events for the process
     over the last week
   type: unsigned_long
 Endpoint.metrics.system_impact.wmi_events.week_ms:


### PR DESCRIPTION
## Change Summary

This PR adds new metrics fields for the following events. Furthermore, I added the missing fields to `sample_event.json`.

* **ETW WMI Activity Provider events**
  * `Endpoint.metrics.system_impact.wmi_events.week_idle_ms`
  * `Endpoint.metrics.system_impact.wmi_events.week_ms`
* **Credential access events**
  * `Endpoint.metrics.system_impact.cred_access_events.week_idle_ms`
  * `Endpoint.metrics.system_impact.cred_access_events.week_ms`
* **Ransomware events**
  * `Endpoint.metrics.system_impact.ransomware.week_idle_ms`
  * `Endpoint.metrics.system_impact.ransomware.week_ms`
* **Process Injection events**
  * `Endpoint.metrics.system_impact.process_injection.week_idle_ms`
  * `Endpoint.metrics.system_impact.process_injection.week_ms`
* **Memory scan events**
  * `Endpoint.metrics.system_impact.memory_scan.week_idle_ms`
  * `Endpoint.metrics.system_impact.memory_scan.week_ms`
* **Behavior protection events**
  * `Endpoint.metrics.system_impact.behavior_protection.week_idle_ms`
  * `Endpoint.metrics.system_impact.behavior_protection.week_ms`
* **Diagnostic behavior protection events**
  * `Endpoint.metrics.system_impact.diagnostic_behavior_protection.week_idle_ms`
  * `Endpoint.metrics.system_impact.diagnostic_behavior_protection.week_ms`
* **ETW TCP/IP Provider events**
  * `Endpoint.metrics.system_impact.tcpip_events.week_idle_ms`
  * `Endpoint.metrics.system_impact.tcpip_events.week_ms`
* **Attack surface events**
  * `Endpoint.metrics.system_impact.attack_surface_events.week_idle_ms`
  * `Endpoint.metrics.system_impact.attack_surface_events.week_ms`
* **Volume device events**　 (CC: @Trinity2019 )
  * `Endpoint.metrics.system_impact.volume_device_events.week_idle_ms`
  * `Endpoint.metrics.system_impact.volume_device_events.week_ms`
  * `Endpoint.metrics.documents_volume.volume_device_events.sent_bytes`
  * `Endpoint.metrics.documents_volume.volume_device_events.sent_count`
  * `Endpoint.metrics.documents_volume.volume_device_events.suppressed_bytes`
  * `Endpoint.metrics.documents_volume.volume_device_events.suppressed_count`

### Sample values (Example No.1)

```
                    "cred_access_events": {
                        "week_idle_ms": 0,
                        "week_ms": 20
                    },
                    "wmi_events": {
                        "week_idle_ms": 0,
                        "week_ms": 10
                    },
                    "process_injection": {
                        "week_idle_ms": 0,
                        "week_ms": 100
                    },
                    "memory_scan": {
                        "week_idle_ms": 0,
                        "week_ms": 30
                    },
                    "behavior_protection": {
                        "week_idle_ms": 0,
                        "week_ms": 40
                    },
                    "diagnostic_behavior_protection": {
                        "week_idle_ms": 0,
                        "week_ms": 50
                    },
                    "tcpip_events": {
                        "week_idle_ms": 0,
                        "week_ms": 10
                    },
                    "volume_device_events": {
                        "week_idle_ms": 0,
                        "week_ms": 20
                    },
                    "attack_surface_events": {
                        "week_idle_ms": 0,
                        "week_ms": 10
                    }
```

### Sample values (Example No.2)
```
                "volume_device_events": {
                    "suppressed_count": 0,
                    "suppressed_bytes": 0,
                    "sent_count": 2,
                    "sent_bytes": 3783
                },
```

## Release Target

8.15.


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match
