### PR TITLE
add heartbeat `billable` field

### DIFF
--- a/custom_schemas/custom_base.yml
+++ b/custom_schemas/custom_base.yml
@@ -17,7 +17,7 @@
         events array
 
     # endpoint action and responses fields
-    # that are at the root level    
+    # that are at the root level
     - name: action_id
       type: alias
       path: EndpointActions.action_id
@@ -83,7 +83,7 @@
       short: expiration
       description: >
         Request expiration timestamp
-    
+
     # most likely redundant
     - name: input_type
       type: alias
@@ -134,7 +134,7 @@
       short: completed at
       description: >
         Request completion timestamp when the response is done executing. Usually matches with @timestamp.
-    
+
     - name: status
       type: alias
       path: EndpointActions.status
@@ -149,4 +149,11 @@
       level: custom
       short: started at
       description:
-        Timestamp of start of request         
+        Timestamp of start of request
+
+    - name: billable
+      type: boolean
+      level: custom
+      short: billable
+      description: >
+        Whether document should be included in billing calculations

--- a/custom_subsets/elastic_endpoint/heartbeat/heartbeat.yaml
+++ b/custom_subsets/elastic_endpoint/heartbeat/heartbeat.yaml
@@ -5,6 +5,7 @@ fields:
     fields:
       "@timestamp": {}
       message: {}
+      billable: {}
   agent:
     fields:
       id: {}

--- a/package/endpoint/data_stream/heartbeat/fields/fields.yml
+++ b/package/endpoint/data_stream/heartbeat/fields/fields.yml
@@ -11,6 +11,10 @@
     Required field for all events.'
   example: '2016-05-23T08:05:34.853Z'
   default_field: true
+- name: billable
+  level: custom
+  type: boolean
+  description: Whether document should be included in billing calculations
 - name: message
   level: core
   type: match_only_text

--- a/package/endpoint/data_stream/heartbeat/sample_event.json
+++ b/package/endpoint/data_stream/heartbeat/sample_event.json
@@ -11,5 +11,6 @@
     "message": "Endpoint heartbeat",
     "event": {
         "ingested": "2023-07-18T20:40:09.279939Z"
-    }
+    },
+    "billable": true
 }

--- a/schemas/v1/heartbeat/heartbeat.yaml
+++ b/schemas/v1/heartbeat/heartbeat.yaml
@@ -30,6 +30,15 @@ agent.id:
   normalize: []
   short: Unique identifier of this agent.
   type: keyword
+billable:
+  dashed_name: billable
+  description: Whether document should be included in billing calculations
+  flat_name: billable
+  level: custom
+  name: billable
+  normalize: []
+  short: billable
+  type: boolean
 data_stream.dataset:
   dashed_name: data-stream-dataset
   description: Data stream dataset name.


### PR DESCRIPTION
## Change Summary

Adds a new boolean field `billable` to the heartbeat mapping. This field is used to determine whether a particular heartbeat document should be included in billing calculations.


### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json
{
    "@timestamp": "2023-07-18T20:40:09.279939Z",
    "agent": {
        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
    },
    "data_stream": {
        "dataset": "endpoint.heartbeat",
        "namespace": "default",
        "type": ".logs"
    },
    "message": "Endpoint heartbeat",
    "event": {
        "ingested": "2023-07-18T20:40:09.279939Z"
    },
    "billable": true
}

```


## Release Target

`8.15`


### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
