### PR TITLE
[WIP] add file.Ext.windows.referrer_url and file.Ext.windows.host_url

### DIFF
--- a/custom_schemas/custom_file.yml
+++ b/custom_schemas/custom_file.yml
@@ -73,6 +73,18 @@
       description: >
         Windows zone identifier for a file
 
+    - name: Ext.windows.referrer_url
+      level: custom
+      type: keyword
+      description: >
+        The url of the webpage that linked to the file
+
+    - name: Ext.windows.host_url
+      level: custom
+      type: keyword
+      description: >
+        The url where the file is hosted
+
     - name: Ext.original
       level: custom
       type: object

--- a/custom_subsets/elastic_endpoint/file/file.yaml
+++ b/custom_subsets/elastic_endpoint/file/file.yaml
@@ -221,6 +221,8 @@ fields:
           windows:
             fields:
               zone_identifier: {}
+              referrer_url: {}
+              host_url: {}
           original:
             fields:
               name: {}

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -631,6 +631,18 @@
       type: object
       description: Platform-specific Windows fields
       default_field: false
+    - name: Ext.windows.host_url
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The url where the file is hosted
+      default_field: false
+    - name: Ext.windows.referrer_url
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The url of the webpage that linked to the file
+      default_field: false
     - name: Ext.windows.zone_identifier
       level: custom
       type: keyword

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1579,6 +1579,8 @@ sent by the endpoint.
 | file.Ext.original.path | Original file path prior to a modification event | keyword |
 | file.Ext.original.uid | The user ID (UID) or security identifier (SID) of the file owner. | keyword |
 | file.Ext.windows | Platform-specific Windows fields | object |
+| file.Ext.windows.host_url | The url where the file is hosted | keyword |
+| file.Ext.windows.referrer_url | The url of the webpage that linked to the file | keyword |
 | file.Ext.windows.zone_identifier | Windows zone identifier for a file | keyword |
 | file.accessed | Last time the file was accessed. Note that not all filesystems keep track of access time. | date |
 | file.attributes | Array of file attributes. Attributes names will vary by platform. Here's a non-exhaustive list of values that are expected in this field: archive, compressed, directory, encrypted, execute, hidden, read, readonly, system, write. | keyword |

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -1380,6 +1380,26 @@ file.Ext.windows:
   normalize: []
   short: Platform-specific Windows fields
   type: object
+file.Ext.windows.host_url:
+  dashed_name: file-Ext-windows-host-url
+  description: The url where the file is hosted
+  flat_name: file.Ext.windows.host_url
+  ignore_above: 1024
+  level: custom
+  name: Ext.windows.host_url
+  normalize: []
+  short: The url where the file is hosted
+  type: keyword
+file.Ext.windows.referrer_url:
+  dashed_name: file-Ext-windows-referrer-url
+  description: The url of the webpage that linked to the file
+  flat_name: file.Ext.windows.referrer_url
+  ignore_above: 1024
+  level: custom
+  name: Ext.windows.referrer_url
+  normalize: []
+  short: The url of the webpage that linked to the file
+  type: keyword
 file.Ext.windows.zone_identifier:
   dashed_name: file-Ext-windows-zone-identifier
   description: Windows zone identifier for a file


### PR DESCRIPTION
## Change Summary

Adds new files `file.Ext.windows.referrer_url` and `file.Ext.windows.host_url` to the file event mapping. 


### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json


```


## Release Target

8.15


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
