### PR TITLE
8.15 add reputation lookups metrics fields

### DIFF
--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -656,6 +656,96 @@
       type: long
       description: Total size of suppressed API Event documents from source
 
+    - name: metrics.cloud_services.reputation_lookups.reputation_rule.rtt
+      level: custom
+      type: object
+      index: false
+      description: 
+        Reputation lookup round trip time seconds for reputation rules (array)
+        Each index contains count of lookups done within i seconds
+      short: Reputation lookup RTT for reputation rules
+
+    - name: metrics.cloud_services.reputation_lookups.reputation_rule.timeout_count
+      level: custom
+      type: unsigned_long
+      index: false
+      description: Reputation lookup timeouts count for reputation rules
+
+    - name: metrics.cloud_services.reputation_lookups.behavior.rtt
+      level: custom
+      type: object
+      index: false
+      description: 
+        Reputation lookup round trip time seconds for behavior rules (array)
+        Each index contains count of lookups done within i seconds
+      short: Reputation lookup RTT for reputation rules
+
+    - name: metrics.cloud_services.reputation_lookups.behavior.timeout_count
+      level: custom
+      type: unsigned_long
+      index: false
+      description: Reputation lookup timeouts count for behavior rules
+
+    - name: metrics.cloud_services.reputation_lookups.shell_code.rtt
+      level: custom
+      type: object
+      index: false
+      description: 
+        Reputation lookup round trip time seconds for shell code (array)
+        Each index contains count of lookups done within i seconds
+      short: Reputation lookup RTT for reputation rules
+
+    - name: metrics.cloud_services.reputation_lookups.shell_code.timeout_count
+      level: custom
+      type: unsigned_long
+      index: false
+      description: Reputation lookup timeouts count for shell code
+
+    - name: metrics.cloud_services.reputation_lookups.ransomware.rtt
+      level: custom
+      type: object
+      index: false
+      description: 
+        Reputation lookup round trip time seconds for ransomware (array)
+        Each index contains count of lookups done within i seconds
+      short: Reputation lookup RTT for reputation rules
+
+    - name: metrics.cloud_services.reputation_lookups.ransomware.timeout_count
+      level: custom
+      type: unsigned_long
+      index: false
+      description: Reputation lookup timeouts count for ransomware
+
+    - name: metrics.cloud_services.reputation_lookups.memory_signature.rtt
+      level: custom
+      type: object
+      index: false
+      description: 
+        Reputation lookup round trip time seconds for memory signature (array)
+        Each index contains count of lookups done within i seconds
+      short: Reputation lookup RTT for reputation rules
+
+    - name: metrics.cloud_services.reputation_lookups.memory_signature.timeout_count
+      level: custom
+      type: unsigned_long
+      index: false
+      description: Reputation lookup timeouts count for memory signature
+
+    - name: metrics.cloud_services.reputation_lookups.malware_score.rtt
+      level: custom
+      type: object
+      index: false
+      description: 
+        Reputation lookup round trip time seconds for malware score (array)
+        Each index contains count of lookups done within i seconds
+      short: Reputation lookup RTT for reputation rules
+
+    - name: metrics.cloud_services.reputation_lookups.malware_score.timeout_count
+      level: custom
+      type: unsigned_long
+      index: false
+      description: Reputation lookup timeouts count for malware score
+
     - name: metrics.uptime
       level: custom
       type: object

--- a/package/endpoint/data_stream/metrics/sample_event.json
+++ b/package/endpoint/data_stream/metrics/sample_event.json
@@ -1041,6 +1041,100 @@
             "uptime": {
                 "endpoint": 21930,
                 "system": 21992
+            },
+            "cloud_services": {
+                "reputation_lookups": {
+                    "behavior": {
+                        "rtt": [
+                            1,
+                            1,
+                            0,
+                            0,
+                            2,
+                            0,
+                            0,
+                            0,
+                            0,
+                            3
+                        ],
+                        "timeout_count": 3
+                    },
+                    "malware_score": {
+                        "rtt": [
+                            0,
+                            1,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0
+                        ],
+                        "timeout_count": 0
+                    },
+                    "memory_signature": {
+                        "rtt": [
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0
+                        ],
+                        "timeout_count": 0
+                    },
+                    "ransomware": {
+                        "rtt": [
+                            0,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0
+                        ],
+                        "timeout_count": 0
+                    },
+                    "reputation_rule": {
+                        "rtt": [
+                            0,
+                            0,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                            0,
+                            0,
+                            0
+                        ],
+                        "timeout_count": 0
+                    },
+                    "shell_code": {
+                        "rtt": [
+                            0,
+                            0,
+                            0,
+                            0,
+                            0,
+                            1,
+                            0,
+                            0,
+                            0,
+                            0
+                        ],
+                        "timeout_count": 0
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
## Change Summary

Adds new endpoint metrics fields:
```
metrics.cloud_services.reputation_lookups.reputation_rule.rtt
metrics.cloud_services.reputation_lookups.reputation_rule.timeout_count
metrics.cloud_services.reputation_lookups.behavior.rtt
metrics.cloud_services.reputation_lookups.behavior.timeout_count
metrics.cloud_services.reputation_lookups.shell_code.rtt
metrics.cloud_services.reputation_lookups.shell_code.timeout_count
metrics.cloud_services.reputation_lookups.ransomware.rtt
metrics.cloud_services.reputation_lookups.ransomware.timeout_count
metrics.cloud_services.reputation_lookups.memory_signature.rtt
metrics.cloud_services.reputation_lookups.memory_signature.timeout_count
metrics.cloud_services.reputation_lookups.malware_score.rtt
metrics.cloud_services.reputation_lookups.malware_score.timeout_count
```

## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
