### PR TITLE
Add `file.origin_referrer_url` and `file.origin_url` to FileEvent

### DIFF
--- a/custom_documentation/doc/endpoint/file/windows/windows_file_open.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_open.md
@@ -63,6 +63,7 @@ This event is generated when a file is opened.
 | process.code_signature.status |
 | process.code_signature.subject_name |
 | process.code_signature.trusted |
+| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_schemas/custom_file.yml
+++ b/custom_schemas/custom_file.yml
@@ -437,6 +437,7 @@
       type: keyword
       description: >
         The url where the file is hosted.
+
     - name: pe
       level: custom
       type: object

--- a/custom_schemas/custom_file.yml
+++ b/custom_schemas/custom_file.yml
@@ -429,12 +429,14 @@
     - name: origin_referrer_url
       level: extended
       type: keyword
+      ignore_above: 8192
       description: >
         The url of the webpage that linked to the file.
 
     - name: origin_url
       level: extended
       type: keyword
+      ignore_above: 8192
       description: >
         The url where the file is hosted.
 

--- a/custom_schemas/custom_file.yml
+++ b/custom_schemas/custom_file.yml
@@ -426,6 +426,17 @@
         relevant to Apple *OS only.'
       example: EQHXZ8M8AV
 
+    - name: origin_referrer_url
+      level: extended
+      type: keyword
+      description: >
+        The url of the webpage that linked to the file.
+
+    - name: origin_url
+      level: extended
+      type: keyword
+      description: >
+        The url where the file is hosted.
     - name: pe
       level: custom
       type: object

--- a/custom_subsets/elastic_endpoint/file/file.yaml
+++ b/custom_subsets/elastic_endpoint/file/file.yaml
@@ -200,6 +200,8 @@ fields:
       name: {}
       owner: {}
       path: {}
+      origin_referrer_url: {}
+      origin_url: {}
       pe:
         fields:
           company: {}

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -753,6 +753,18 @@
       ignore_above: 1024
       description: Name of the file including the extension, without the directory.
       example: example.png
+    - name: origin_referrer_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url of the webpage that linked to the file.
+      default_field: false
+    - name: origin_url
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: The url where the file is hosted.
+      default_field: false
     - name: owner
       level: extended
       type: keyword

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -775,6 +775,20 @@
           default_field: false
       description: Full path to the file, including the file name. It should include the drive letter, when appropriate.
       example: /home/alice/example.png
+    - name: origin_referrer_url
+      level: custom
+      type: keyword
+      ignore_above: 8192
+      description: The url of the webpage that linked to the file.
+      example: https://example.com
+      default_field: false
+    - name: origin_url
+      level: custom
+      type: keyword
+      ignore_above: 8192
+      description: The url where the file is hosted.
+      example: https://example.com/file.zip
+      default_field: false
     - name: pe.company
       level: extended
       type: keyword

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -775,20 +775,6 @@
           default_field: false
       description: Full path to the file, including the file name. It should include the drive letter, when appropriate.
       example: /home/alice/example.png
-    - name: origin_referrer_url
-      level: custom
-      type: keyword
-      ignore_above: 8192
-      description: The url of the webpage that linked to the file.
-      example: https://example.com
-      default_field: false
-    - name: origin_url
-      level: custom
-      type: keyword
-      ignore_above: 8192
-      description: The url where the file is hosted.
-      example: https://example.com/file.zip
-      default_field: false
     - name: pe.company
       level: extended
       type: keyword

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -758,13 +758,13 @@
       type: keyword
       ignore_above: 8192
       description: The url of the webpage that linked to the file.
-      default_field: true
+      default_field: false
     - name: origin_url
       level: extended
       type: keyword
       ignore_above: 8192
       description: The url where the file is hosted.
-      default_field: true
+      default_field: false
     - name: owner
       level: extended
       type: keyword

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -756,15 +756,15 @@
     - name: origin_referrer_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url of the webpage that linked to the file.
-      default_field: false
+      default_field: true
     - name: origin_url
       level: extended
       type: keyword
-      ignore_above: 1024
+      ignore_above: 8192
       description: The url where the file is hosted.
-      default_field: false
+      default_field: true
     - name: owner
       level: extended
       type: keyword

--- a/package/endpoint/data_stream/file/sample_event.json
+++ b/package/endpoint/data_stream/file/sample_event.json
@@ -90,7 +90,9 @@
         "path": "C:\\ProgramData\\winlogbeat\\.winlogbeat.yml.new",
         "extension": "new",
         "size": 1406,
-        "name": ".winlogbeat.yml.new"
+        "name": ".winlogbeat.yml.new",
+        "origin_referrer_url": "https://example.com",
+        "origin_url": "https://example.com/file.zip"
     },
     "ecs": {
         "version": "1.11.0"

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1599,6 +1599,8 @@ sent by the endpoint.
 | file.mode | Mode of the file in octal representation. | keyword |
 | file.mtime | Last time the file content was modified. | date |
 | file.name | Name of the file including the extension, without the directory. | keyword |
+| file.origin_referrer_url | The url of the webpage that linked to the file. | keyword |
+| file.origin_url | The url where the file is hosted. | keyword |
 | file.owner | File owner's username. | keyword |
 | file.path | Full path to the file, including the file name. It should include the drive letter, when appropriate. | keyword |
 | file.pe.company | Internal company name of the file, provided at compile-time. | keyword |

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -1612,6 +1612,26 @@ file.name:
   normalize: []
   short: Name of the file including the extension, without the directory.
   type: keyword
+file.origin_referrer_url:
+  dashed_name: file-origin-referrer-url
+  description: The url of the webpage that linked to the file.
+  flat_name: file.origin_referrer_url
+  ignore_above: 1024
+  level: extended
+  name: origin_referrer_url
+  normalize: []
+  short: The url of the webpage that linked to the file.
+  type: keyword
+file.origin_url:
+  dashed_name: file-origin-url
+  description: The url where the file is hosted.
+  flat_name: file.origin_url
+  ignore_above: 1024
+  level: extended
+  name: origin_url
+  normalize: []
+  short: The url where the file is hosted.
+  type: keyword
 file.owner:
   dashed_name: file-owner
   description: File owner's username.

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -1616,7 +1616,7 @@ file.origin_referrer_url:
   dashed_name: file-origin-referrer-url
   description: The url of the webpage that linked to the file.
   flat_name: file.origin_referrer_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_referrer_url
   normalize: []
@@ -1626,7 +1626,7 @@ file.origin_url:
   dashed_name: file-origin-url
   description: The url where the file is hosted.
   flat_name: file.origin_url
-  ignore_above: 1024
+  ignore_above: 8192
   level: extended
   name: origin_url
   normalize: []


### PR DESCRIPTION
## Change Summary

This PR adds new `file.origin_referrer_url` and `file.origin_url` to the file event mapping. These fields will also be added to the ECS. (level: extended). The following is the ECS side PR. 

* [Add new fields file.origin_referrer_url & file.origin_url](https://github.com/elastic/ecs/pull/2348)

## To reviewers

**Size of the fields**
The two fields added in this PR are intended to store URL. Therefore, the default field size of 1024 bytes is insufficient. As a result, we want to set ignore_above to 8k bytes, if possible.

* `ignore_above: 8192`

**Default Field**
This field will not necessarily be included in all file events. 
Therefore, I set it as `default_field: false`, but please let me know if this is incorrect.

**About [windows_file_open.md](https://github.com/elastic/endpoint-package/pull/514/files#diff-01a8434f3dab7b0a4176d5e984db8b91bc80f363c3a75d8f9d34ef2b24a73be8)**

As a result of running `make`, process.command_line was added to `windows_file_open.md`. If this behavior is unexpected, please let me know.

### Sample values

* file.origin_referrer_url : https://example.com
* file.origin_url : https://example.com/file.zip

## Release Target
8.15
## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
