### PR TITLE
index call_stack_summary in API events

### DIFF
--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -114,7 +114,7 @@
     - name: thread.Ext.call_stack_summary
       level: custom
       type: keyword
-      example: "ntdll.dll, example.exe, kernel32.dll, ntdll.dll"
+      example: "ntdll.dll|example.exe|kernel32.dll|ntdll.dll"
       description: >
         Concatentation of the non-repeated modules in the call stack.
 

--- a/custom_subsets/elastic_endpoint/api/api.yaml
+++ b/custom_subsets/elastic_endpoint/api/api.yaml
@@ -150,3 +150,4 @@ fields:
                   hash:
                     fields:
                       sha256: {}
+              call_stack_summary: {}

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -2468,7 +2468,7 @@
       type: keyword
       ignore_above: 1024
       description: Concatentation of the non-repeated modules in the call stack.
-      example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+      example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
       default_field: false
     - name: process.thread.Ext.hardware_breakpoint_set
       level: custom
@@ -7305,7 +7305,7 @@
       type: keyword
       ignore_above: 1024
       description: Concatentation of the non-repeated modules in the call stack.
-      example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+      example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
       default_field: false
     - name: thread.Ext.hardware_breakpoint_set
       level: custom

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -2526,6 +2526,13 @@
       description: The name of the memory region that last modified the protection of this page. "Unbacked" may indicate shellcode.
       example: third_party_hook.dll
       default_field: false
+    - name: thread.Ext.call_stack_summary
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Concatentation of the non-repeated modules in the call stack.
+      example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
+      default_field: false
     - name: thread.id
       level: extended
       type: long

--- a/package/endpoint/data_stream/api/sample_event.json
+++ b/package/endpoint/data_stream/api/sample_event.json
@@ -241,7 +241,8 @@
                     "name": "dabapi.dll",
                     "path": "c:\\windows\\system32\\dabapi.dll",
                     "protection_provenance": "eventstests.exe"
-                }
+                },
+                "call_stack_summary": "ntdll.dll|kernelbase.dll|kernel32.dll|cmd.exe|kernel32.dll|ntdll.dll"
             },
             "id": 11628
         }

--- a/package/endpoint/data_stream/file/fields/fields.yml
+++ b/package/endpoint/data_stream/file/fields/fields.yml
@@ -1360,7 +1360,7 @@
       type: keyword
       ignore_above: 1024
       description: Concatentation of the non-repeated modules in the call stack.
-      example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+      example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
       default_field: false
     - name: thread.Ext.hardware_breakpoint_set
       level: custom

--- a/package/endpoint/data_stream/library/fields/fields.yml
+++ b/package/endpoint/data_stream/library/fields/fields.yml
@@ -1252,7 +1252,7 @@
       type: keyword
       ignore_above: 1024
       description: Concatentation of the non-repeated modules in the call stack.
-      example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+      example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
       default_field: false
     - name: thread.Ext.hardware_breakpoint_set
       level: custom

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -2275,7 +2275,7 @@
       type: keyword
       ignore_above: 1024
       description: Concatentation of the non-repeated modules in the call stack.
-      example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+      example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
       default_field: false
     - name: parent.thread.Ext.hardware_breakpoint_set
       level: custom

--- a/package/endpoint/data_stream/registry/fields/fields.yml
+++ b/package/endpoint/data_stream/registry/fields/fields.yml
@@ -769,7 +769,7 @@
       type: keyword
       ignore_above: 1024
       description: Concatentation of the non-repeated modules in the call stack.
-      example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+      example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
       default_field: false
     - name: thread.Ext.hardware_breakpoint_set
       level: custom

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -3181,7 +3181,7 @@ Target.process.thread.Ext.call_stack_final_user_module.path:
 Target.process.thread.Ext.call_stack_summary:
   dashed_name: Target-process-thread-Ext-call-stack-summary
   description: Concatentation of the non-repeated modules in the call stack.
-  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
   flat_name: Target.process.thread.Ext.call_stack_summary
   ignore_above: 1024
   level: custom
@@ -8530,7 +8530,7 @@ process.thread.Ext.call_stack_final_user_module.path:
 process.thread.Ext.call_stack_summary:
   dashed_name: process-thread-Ext-call-stack-summary
   description: Concatentation of the non-repeated modules in the call stack.
-  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
   flat_name: process.thread.Ext.call_stack_summary
   ignore_above: 1024
   level: custom

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -4869,6 +4869,17 @@ process.thread.Ext.call_stack_final_user_module.protection_provenance:
   short: The name of the memory region that last modified the protection of this page.
     "Unbacked" may indicate shellcode.
   type: keyword
+process.thread.Ext.call_stack_summary:
+  dashed_name: process-thread-Ext-call-stack-summary
+  description: Concatentation of the non-repeated modules in the call stack.
+  example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
+  flat_name: process.thread.Ext.call_stack_summary
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_summary
+  normalize: []
+  short: Concatentation of the non-repeated modules in the call stack.
+  type: keyword
 process.thread.id:
   dashed_name: process-thread-id
   description: Thread ID.

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -2639,7 +2639,7 @@ process.thread.Ext.call_stack.symbol_info:
 process.thread.Ext.call_stack_summary:
   dashed_name: process-thread-Ext-call-stack-summary
   description: Concatentation of the non-repeated modules in the call stack.
-  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
   flat_name: process.thread.Ext.call_stack_summary
   ignore_above: 1024
   level: custom

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -2452,7 +2452,7 @@ process.thread.Ext.call_stack.symbol_info:
 process.thread.Ext.call_stack_summary:
   dashed_name: process-thread-Ext-call-stack-summary
   description: Concatentation of the non-repeated modules in the call stack.
-  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
   flat_name: process.thread.Ext.call_stack_summary
   ignore_above: 1024
   level: custom

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -2747,7 +2747,7 @@ process.parent.thread.Ext.call_stack_contains_unbacked:
 process.parent.thread.Ext.call_stack_summary:
   dashed_name: process-parent-thread-Ext-call-stack-summary
   description: Concatentation of the non-repeated modules in the call stack.
-  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
   flat_name: process.parent.thread.Ext.call_stack_summary
   ignore_above: 1024
   level: custom

--- a/schemas/v1/registry/registry.yaml
+++ b/schemas/v1/registry/registry.yaml
@@ -1654,7 +1654,7 @@ process.thread.Ext.call_stack.symbol_info:
 process.thread.Ext.call_stack_summary:
   dashed_name: process-thread-Ext-call-stack-summary
   description: Concatentation of the non-repeated modules in the call stack.
-  example: ntdll.dll, example.exe, kernel32.dll, ntdll.dll
+  example: ntdll.dll|example.exe|kernel32.dll|ntdll.dll
   flat_name: process.thread.Ext.call_stack_summary
   ignore_above: 1024
   level: custom


### PR DESCRIPTION
## Change Summary

Add call_stack_summary to API events. This field is indexed for other event types.

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
