### PR TITLE
Add process.Ext.protection to Windows library events

### DIFF
--- a/custom_documentation/doc/endpoint/library/windows/windows_library_load.md
+++ b/custom_documentation/doc/endpoint/library/windows/windows_library_load.md
@@ -69,6 +69,7 @@ This event is generated when a DLL or driver is loaded.
 | process.Ext.code_signature.status |
 | process.Ext.code_signature.subject_name |
 | process.Ext.code_signature.trusted |
+| process.Ext.protection |
 | process.code_signature.exists |
 | process.code_signature.status |
 | process.code_signature.subject_name |

--- a/custom_documentation/src/endpoint/data_stream/library/windows/windows_library_load.yaml
+++ b/custom_documentation/src/endpoint/data_stream/library/windows/windows_library_load.yaml
@@ -74,6 +74,7 @@ fields:
   - process.Ext.code_signature.status
   - process.Ext.code_signature.subject_name
   - process.Ext.code_signature.trusted
+  - process.Ext.protection
   - process.code_signature.exists
   - process.code_signature.status
   - process.code_signature.subject_name

--- a/custom_subsets/elastic_endpoint/library/library.yaml
+++ b/custom_subsets/elastic_endpoint/library/library.yaml
@@ -140,6 +140,7 @@ fields:
               subject_name: {}
               trusted: {}
               valid: {}
+          protection: {}
   file:
     fields:
       pe:

--- a/package/endpoint/data_stream/library/fields/fields.yml
+++ b/package/endpoint/data_stream/library/fields/fields.yml
@@ -1100,6 +1100,12 @@
         Leave unpopulated if a certificate was unchecked.'
       example: 'true'
       default_field: false
+    - name: Ext.protection
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light.
+      default_field: false
     - name: code_signature.exists
       level: core
       type: boolean

--- a/package/endpoint/data_stream/library/sample_event.json
+++ b/package/endpoint/data_stream/library/sample_event.json
@@ -17,7 +17,8 @@
                     "exists": true,
                     "status": "trusted"
                 }
-            ]
+            ],
+            "protection": "PsProtectedSignerAntimalware-Light"
         },
         "code_signature": {
             "trusted": true,

--- a/package/endpoint/data_stream/process/sample_event.json
+++ b/package/endpoint/data_stream/process/sample_event.json
@@ -78,6 +78,7 @@
                 "CET dynamic APIs can only be called out of proc",
                 "CF Guard"
             ],
+            "protection": "PsProtectedSignerAntimalware-Light",
             "device": {
                 "volume_device_type": "Disk File System"
             },

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1863,6 +1863,7 @@ sent by the endpoint.
 | process.Ext.code_signature.subject_name | Subject name of the code signer | keyword |
 | process.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | process.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
+| process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | process.code_signature.exists | Boolean to capture if a signature is present. | boolean |
 | process.code_signature.signing_id | The identifier used to sign the process. This is used to identify the application manufactured by a software vendor. The field is relevant to Apple *OS only. | keyword |
 | process.code_signature.status | Additional information about the certificate status. This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked. | keyword |

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -2198,6 +2198,18 @@ process.Ext.code_signature.valid:
   short: Boolean to capture if the digital signature is verified against the binary
     content.
   type: boolean
+process.Ext.protection:
+  dashed_name: process-Ext-protection
+  description: Indicates the protection level of this process.  Uses the same syntax
+    as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light,
+    and PsProtectedSignerWindows-Light.
+  flat_name: process.Ext.protection
+  ignore_above: 1024
+  level: custom
+  name: Ext.protection
+  normalize: []
+  short: OS-level protections granted to this process
+  type: keyword
 process.code_signature.exists:
   dashed_name: process-code-signature-exists
   description: Boolean to capture if a signature is present.


### PR DESCRIPTION
## Change Summary

Add `process.Ext.protection` to Windows library events - added in 8.15.1.

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match
