### PR TITLE
correct branch in publishing pipeline

### DIFF
--- a/.buildkite/sign_and_publish.yml.py
+++ b/.buildkite/sign_and_publish.yml.py
@@ -19,7 +19,7 @@ def main():
     # This only gets triggered when the branch is either main or 7.\d or 8.\d
     # So, dry_run is true for non main branch
     branch = os.getenv("BUILDKITE_BRANCH")
-    dry_run = branch != "main"
+    dry_run = branch != "8.15"
     pipeline = {}
     steps = [
         {


### PR DESCRIPTION
## Change Summary

Turns out there is another branch name check, that sets `DRY_RUN=true` if not "main". So `8.15.1` did not get pushed after merging #530 

Manually updating this on `8.15` branch for now, but will be included in the future release branch PRs to do this automatically