### PR TITLE
pull-forward 8.15.1 changelog

### DIFF
--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -3,6 +3,11 @@
     - description: TBD
       type: enhancement
       link: https://github.com/elastic/endpoint-package/pull/9999
+- version: "8.15.1"
+  changes:
+    - description: Add process.Ext.protection to Windows library events
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/528
 - version: "8.15.0"
   changes:
     - description: Add `file.origin_referrer_url` and `file.origin_url` to FileEvent


### PR DESCRIPTION
## Change Summary


What's the opposite of a backport? forward-port?

This pulls forward the changelog entry from the `8.15.1` release to the `main` branch, so changelog history is preserved