### PR TITLE
custom documentation wasn't properly rendered

### DIFF
--- a/custom_documentation/doc/endpoint/alerts/windows/windows_malware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_malware_alert.md
@@ -75,6 +75,10 @@ This alert is generated when a Malware alert occurs.
 | file.Ext.malware_signature.primary.signature.hash.sha256 |
 | file.Ext.malware_signature.primary.signature.id |
 | file.Ext.malware_signature.primary.signature.name |
+| file.Ext.malware_signature.secondary.matches |
+| file.Ext.malware_signature.secondary.signature.hash.sha256 |
+| file.Ext.malware_signature.secondary.signature.id |
+| file.Ext.malware_signature.secondary.signature.name |
 | file.Ext.malware_signature.version |
 | file.Ext.quarantine_message |
 | file.Ext.quarantine_path |

--- a/custom_documentation/doc/endpoint/security/windows/windows_security_log_off.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_log_off.md
@@ -10,6 +10,7 @@ This event is generated when a user logs off of the computer.
 | Field |
 |---|
 | @timestamp |
+| Target.process.Ext.authentication_id |
 | agent.id |
 | agent.type |
 | agent.version |

--- a/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
@@ -10,6 +10,7 @@ This event is generated when a user logs on to the computer.
 | Field |
 |---|
 | @timestamp |
+| Target.process.Ext.authentication_id |
 | agent.id |
 | agent.type |
 | agent.version |
@@ -45,6 +46,7 @@ This event is generated when a user logs on to the computer.
 | host.os.version |
 | message |
 | process.Ext.ancestry |
+| process.Ext.authentication_id |
 | process.Ext.code_signature.exists |
 | process.Ext.code_signature.status |
 | process.Ext.code_signature.subject_name |


### PR DESCRIPTION
## Change Summary

Update custom documentation. There was discrepancy between `custom_docucmentation/src/` and `custom_documentation/doc`. The latter didn't include latest updates.

It turns out that it was caused by running `make` instead of `make clean all`


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
