### PR TITLE
Optional File Event Hashes

### DIFF
--- a/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
@@ -32,7 +32,6 @@ This event is generated when a file is created.
 | file.hash.sha256 |
 | file.name |
 | file.path |
-| file.hash.sha256 |
 | group.Ext.real.id |
 | group.Ext.real.name |
 | group.id |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
@@ -29,8 +29,10 @@ This event is generated when a file is created.
 | event.sequence |
 | event.type |
 | file.extension |
+| file.hash.sha256 |
 | file.name |
 | file.path |
+| file.hash.sha256 |
 | group.Ext.real.id |
 | group.Ext.real.name |
 | group.id |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_rename.md
@@ -32,6 +32,7 @@ This event is generated when a file is renamed.
 | file.Ext.original.name |
 | file.Ext.original.path |
 | file.extension |
+| file.hash.sha256 |
 | file.name |
 | file.path |
 | group.Ext.real.id |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_access.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_access.md
@@ -32,6 +32,7 @@ This event is generated when a file is accessed.
 | event.outcome |
 | event.sequence |
 | event.type |
+| file.hash.sha256 |
 | file.inode |
 | file.name |
 | file.path |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_extended_attributes_delete.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_extended_attributes_delete.md
@@ -33,6 +33,7 @@ This event is generated when extended file attributes are deleted.
 | event.sequence |
 | event.type |
 | file.attributes |
+| file.hash.sha256 |
 | file.inode |
 | file.name |
 | file.path |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_modification.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_modification.md
@@ -34,6 +34,7 @@ This event is generated when a file is modified.
 | event.type |
 | file.Ext.header_bytes |
 | file.extension |
+| file.hash.sha256 |
 | file.inode |
 | file.name |
 | file.path |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_rename.md
@@ -35,6 +35,7 @@ This event is generated when a file is renamed.
 | file.Ext.original.extension |
 | file.Ext.original.path |
 | file.extension |
+| file.hash.sha256 |
 | file.inode |
 | file.name |
 | file.path |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_create.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_create.md
@@ -37,6 +37,7 @@ This event is generated when a file is created.
 | file.Ext.monotonic_id |
 | file.Ext.windows.zone_identifier |
 | file.extension |
+| file.hash.sha256 |
 | file.name |
 | file.path |
 | file.size |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_modification.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_modification.md
@@ -36,6 +36,7 @@ This event is generated when a file is modified.
 | file.Ext.header_bytes |
 | file.Ext.monotonic_id |
 | file.extension |
+| file.hash.sha256 |
 | file.name |
 | file.path |
 | file.size |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_open.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_open.md
@@ -36,6 +36,7 @@ This event is generated when a file is opened.
 | file.Ext.header_bytes |
 | file.Ext.monotonic_id |
 | file.extension |
+| file.hash.sha256 |
 | file.name |
 | file.path |
 | file.size |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_overwrite.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_overwrite.md
@@ -36,6 +36,7 @@ This event is generated when a file is overwritten
 | file.Ext.header_bytes |
 | file.Ext.monotonic_id |
 | file.extension |
+| file.hash.sha256 |
 | file.name |
 | file.path |
 | file.size |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_rename.md
@@ -39,6 +39,7 @@ This event is generated when a file is renamed.
 | file.Ext.original.name |
 | file.Ext.original.path |
 | file.extension |
+| file.hash.sha256 |
 | file.name |
 | file.path |
 | file.size |

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
@@ -37,7 +37,6 @@ fields:
   - file.hash.sha256
   - file.name
   - file.path
-  - file.hash.sha256
   - group.Ext.real.id
   - group.Ext.real.name
   - group.id

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
@@ -34,6 +34,7 @@ fields:
   - event.sequence
   - event.type
   - file.extension
+  - file.hash.sha256
   - file.name
   - file.path
   - file.hash.sha256

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
@@ -36,6 +36,7 @@ fields:
   - file.extension
   - file.name
   - file.path
+  - file.hash.sha256
   - group.Ext.real.id
   - group.Ext.real.name
   - group.id

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_rename.yaml
@@ -37,6 +37,7 @@ fields:
   - file.Ext.original.name
   - file.Ext.original.path
   - file.extension
+  - file.hash.sha256
   - file.name
   - file.path
   - group.Ext.real.id

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_access.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_access.yaml
@@ -37,6 +37,7 @@ fields:
   - event.outcome
   - event.sequence
   - event.type
+  - file.hash.sha256
   - file.inode
   - file.name
   - file.path

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_delete.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_delete.yaml
@@ -38,6 +38,7 @@ fields:
   - event.sequence
   - event.type
   - file.extension
+  - file.hash.sha256
   - file.inode
   - file.name
   - file.path

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_delete.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_delete.yaml
@@ -38,7 +38,6 @@ fields:
   - event.sequence
   - event.type
   - file.extension
-  - file.hash.sha256
   - file.inode
   - file.name
   - file.path

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_extended_attributes_delete.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_extended_attributes_delete.yaml
@@ -38,6 +38,7 @@ fields:
   - event.sequence
   - event.type
   - file.attributes
+  - file.hash.sha256
   - file.inode
   - file.name
   - file.path

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_modification.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_modification.yaml
@@ -39,6 +39,7 @@ fields:
   - event.type
   - file.Ext.header_bytes
   - file.extension
+  - file.hash.sha256
   - file.inode
   - file.name
   - file.path

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_rename.yaml
@@ -40,6 +40,7 @@ fields:
   - file.Ext.original.extension
   - file.Ext.original.path
   - file.extension
+  - file.hash.sha256
   - file.inode
   - file.name
   - file.path

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_create.yaml
@@ -42,6 +42,7 @@ fields:
   - file.Ext.monotonic_id
   - file.Ext.windows.zone_identifier
   - file.extension
+  - file.hash.sha256
   - file.name
   - file.path
   - file.size

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_modification.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_modification.yaml
@@ -41,6 +41,7 @@ fields:
   - file.Ext.header_bytes
   - file.Ext.monotonic_id
   - file.extension
+  - file.hash.sha256
   - file.name
   - file.path
   - file.size

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_open.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_open.yaml
@@ -41,6 +41,7 @@ fields:
   - file.Ext.header_bytes
   - file.Ext.monotonic_id
   - file.extension
+  - file.hash.sha256
   - file.name
   - file.path
   - file.size

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_overwrite.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_overwrite.yaml
@@ -41,6 +41,7 @@ fields:
   - file.Ext.header_bytes
   - file.Ext.monotonic_id
   - file.extension
+  - file.hash.sha256
   - file.name
   - file.path
   - file.size

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_rename.yaml
@@ -44,6 +44,7 @@ fields:
   - file.Ext.original.name
   - file.Ext.original.path
   - file.extension
+  - file.hash.sha256
   - file.name
   - file.path
   - file.size


### PR DESCRIPTION
## Change Summary

- https://github.com/elastic/endpoint/issues/78

This is not a schema change.

Users will be able to opt into `file.hash.sha256` in additional types of file events.  It's already in our schema.  This PR adds it to `custom_documentation`.