### PR TITLE
Secondary Malware Signature Fields

### DIFF
--- a/custom_documentation/doc/endpoint/alerts/linux/linux_malware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/linux/linux_malware_alert.md
@@ -50,6 +50,10 @@ This alert is generated when a Malware alert occurs.
 | file.Ext.malware_signature.primary.signature.hash.sha256 |
 | file.Ext.malware_signature.primary.signature.id |
 | file.Ext.malware_signature.primary.signature.name |
+| file.Ext.malware_signature.secondary.matches |
+| file.Ext.malware_signature.secondary.signature.hash.sha256 |
+| file.Ext.malware_signature.secondary.signature.id |
+| file.Ext.malware_signature.secondary.signature.name |
 | file.Ext.malware_signature.version |
 | file.Ext.quarantine_message |
 | file.Ext.quarantine_path |

--- a/custom_documentation/doc/endpoint/alerts/macos/macos_malware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/macos/macos_malware_alert.md
@@ -50,6 +50,10 @@ This alert is generated when a macOS Malware alert occurs.
 | file.Ext.malware_signature.primary.signature.hash.sha256 |
 | file.Ext.malware_signature.primary.signature.id |
 | file.Ext.malware_signature.primary.signature.name |
+| file.Ext.malware_signature.secondary.matches |
+| file.Ext.malware_signature.secondary.signature.hash.sha256 |
+| file.Ext.malware_signature.secondary.signature.id |
+| file.Ext.malware_signature.secondary.signature.name |
 | file.Ext.malware_signature.version |
 | file.Ext.quarantine_message |
 | file.Ext.quarantine_path |

--- a/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malware_alert.yaml
@@ -55,6 +55,10 @@ fields:
   - file.Ext.malware_signature.primary.signature.hash.sha256
   - file.Ext.malware_signature.primary.signature.id
   - file.Ext.malware_signature.primary.signature.name
+  - file.Ext.malware_signature.secondary.matches
+  - file.Ext.malware_signature.secondary.signature.hash.sha256
+  - file.Ext.malware_signature.secondary.signature.id
+  - file.Ext.malware_signature.secondary.signature.name
   - file.Ext.malware_signature.version
   - file.Ext.quarantine_message
   - file.Ext.quarantine_path

--- a/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malware_alert.yaml
@@ -55,6 +55,10 @@ fields:
   - file.Ext.malware_signature.primary.signature.hash.sha256
   - file.Ext.malware_signature.primary.signature.id
   - file.Ext.malware_signature.primary.signature.name
+  - file.Ext.malware_signature.secondary.matches
+  - file.Ext.malware_signature.secondary.signature.hash.sha256
+  - file.Ext.malware_signature.secondary.signature.id
+  - file.Ext.malware_signature.secondary.signature.name
   - file.Ext.malware_signature.version
   - file.Ext.quarantine_message
   - file.Ext.quarantine_path

--- a/custom_schemas/custom_malware_signature.yml
+++ b/custom_schemas/custom_malware_signature.yml
@@ -65,3 +65,33 @@
       type: nested
       enabled: false
       description: Additional matching details if available.
+
+    - name: secondary.matches
+      level: custom
+      type: keyword
+      enabled: false
+      description: The second matching details.
+
+    - name: secondary.signature.id
+      level: custom
+      type: keyword
+      enabled: false
+      description: The id of the second yara rule matched.
+
+    - name: secondary.signature.name
+      level: custom
+      type: keyword
+      enabled: false
+      description: The name of the second yara rule matched.
+
+    - name: secondary.signature.hash
+      level: custom
+      type: nested
+      enabled: false
+      description: hash of second file matching signature.
+
+    - name: secondary.signature.hash.sha256
+      level: custom
+      type: keyword
+      enabled: false
+      description: sha256 hash of second file matching signature.

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -154,6 +154,40 @@
       description: Additional matching details if available.
       enabled: false
       default_field: false
+    - name: process.Ext.memory_region.malware_signature.secondary.matches
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The second matching details.
+      enabled: false
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.secondary.signature.hash
+      level: custom
+      type: nested
+      description: hash of second file matching signature.
+      enabled: false
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.secondary.signature.hash.sha256
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: sha256 hash of second file matching signature.
+      enabled: false
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.secondary.signature.id
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The id of the second yara rule matched.
+      enabled: false
+      default_field: false
+    - name: process.Ext.memory_region.malware_signature.secondary.signature.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The name of the second yara rule matched.
+      enabled: false
+      default_field: false
     - name: process.Ext.memory_region.malware_signature.version
       level: custom
       type: keyword
@@ -1676,6 +1710,40 @@
       level: custom
       type: nested
       description: Additional matching details if available.
+      enabled: false
+      default_field: false
+    - name: Ext.memory_region.malware_signature.secondary.matches
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The second matching details.
+      enabled: false
+      default_field: false
+    - name: Ext.memory_region.malware_signature.secondary.signature.hash
+      level: custom
+      type: nested
+      description: hash of second file matching signature.
+      enabled: false
+      default_field: false
+    - name: Ext.memory_region.malware_signature.secondary.signature.hash.sha256
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: sha256 hash of second file matching signature.
+      enabled: false
+      default_field: false
+    - name: Ext.memory_region.malware_signature.secondary.signature.id
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The id of the second yara rule matched.
+      enabled: false
+      default_field: false
+    - name: Ext.memory_region.malware_signature.secondary.signature.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The name of the second yara rule matched.
       enabled: false
       default_field: false
     - name: Ext.memory_region.malware_signature.version

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -250,6 +250,65 @@ Target.process.Ext.memory_region.malware_signature.secondary:
   original_fieldset: malware_signature
   short: Additional matching details if available.
   type: nested
+Target.process.Ext.memory_region.malware_signature.secondary.matches:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-secondary-matches
+  description: The second matching details.
+  enabled: false
+  flat_name: Target.process.Ext.memory_region.malware_signature.secondary.matches
+  ignore_above: 1024
+  level: custom
+  name: secondary.matches
+  normalize: []
+  original_fieldset: malware_signature
+  short: The second matching details.
+  type: keyword
+Target.process.Ext.memory_region.malware_signature.secondary.signature.hash:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-secondary-signature-hash
+  description: hash of second file matching signature.
+  enabled: false
+  flat_name: Target.process.Ext.memory_region.malware_signature.secondary.signature.hash
+  level: custom
+  name: secondary.signature.hash
+  normalize: []
+  original_fieldset: malware_signature
+  short: hash of second file matching signature.
+  type: nested
+Target.process.Ext.memory_region.malware_signature.secondary.signature.hash.sha256:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-secondary-signature-hash-sha256
+  description: sha256 hash of second file matching signature.
+  enabled: false
+  flat_name: Target.process.Ext.memory_region.malware_signature.secondary.signature.hash.sha256
+  ignore_above: 1024
+  level: custom
+  name: secondary.signature.hash.sha256
+  normalize: []
+  original_fieldset: malware_signature
+  short: sha256 hash of second file matching signature.
+  type: keyword
+Target.process.Ext.memory_region.malware_signature.secondary.signature.id:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-secondary-signature-id
+  description: The id of the second yara rule matched.
+  enabled: false
+  flat_name: Target.process.Ext.memory_region.malware_signature.secondary.signature.id
+  ignore_above: 1024
+  level: custom
+  name: secondary.signature.id
+  normalize: []
+  original_fieldset: malware_signature
+  short: The id of the second yara rule matched.
+  type: keyword
+Target.process.Ext.memory_region.malware_signature.secondary.signature.name:
+  dashed_name: Target-process-Ext-memory-region-malware-signature-secondary-signature-name
+  description: The name of the second yara rule matched.
+  enabled: false
+  flat_name: Target.process.Ext.memory_region.malware_signature.secondary.signature.name
+  ignore_above: 1024
+  level: custom
+  name: secondary.signature.name
+  normalize: []
+  original_fieldset: malware_signature
+  short: The name of the second yara rule matched.
+  type: keyword
 Target.process.Ext.memory_region.malware_signature.version:
   dashed_name: Target-process-Ext-memory-region-malware-signature-version
   description: malware signature version
@@ -3337,6 +3396,65 @@ process.Ext.memory_region.malware_signature.secondary:
   original_fieldset: malware_signature
   short: Additional matching details if available.
   type: nested
+process.Ext.memory_region.malware_signature.secondary.matches:
+  dashed_name: process-Ext-memory-region-malware-signature-secondary-matches
+  description: The second matching details.
+  enabled: false
+  flat_name: process.Ext.memory_region.malware_signature.secondary.matches
+  ignore_above: 1024
+  level: custom
+  name: secondary.matches
+  normalize: []
+  original_fieldset: malware_signature
+  short: The second matching details.
+  type: keyword
+process.Ext.memory_region.malware_signature.secondary.signature.hash:
+  dashed_name: process-Ext-memory-region-malware-signature-secondary-signature-hash
+  description: hash of second file matching signature.
+  enabled: false
+  flat_name: process.Ext.memory_region.malware_signature.secondary.signature.hash
+  level: custom
+  name: secondary.signature.hash
+  normalize: []
+  original_fieldset: malware_signature
+  short: hash of second file matching signature.
+  type: nested
+process.Ext.memory_region.malware_signature.secondary.signature.hash.sha256:
+  dashed_name: process-Ext-memory-region-malware-signature-secondary-signature-hash-sha256
+  description: sha256 hash of second file matching signature.
+  enabled: false
+  flat_name: process.Ext.memory_region.malware_signature.secondary.signature.hash.sha256
+  ignore_above: 1024
+  level: custom
+  name: secondary.signature.hash.sha256
+  normalize: []
+  original_fieldset: malware_signature
+  short: sha256 hash of second file matching signature.
+  type: keyword
+process.Ext.memory_region.malware_signature.secondary.signature.id:
+  dashed_name: process-Ext-memory-region-malware-signature-secondary-signature-id
+  description: The id of the second yara rule matched.
+  enabled: false
+  flat_name: process.Ext.memory_region.malware_signature.secondary.signature.id
+  ignore_above: 1024
+  level: custom
+  name: secondary.signature.id
+  normalize: []
+  original_fieldset: malware_signature
+  short: The id of the second yara rule matched.
+  type: keyword
+process.Ext.memory_region.malware_signature.secondary.signature.name:
+  dashed_name: process-Ext-memory-region-malware-signature-secondary-signature-name
+  description: The name of the second yara rule matched.
+  enabled: false
+  flat_name: process.Ext.memory_region.malware_signature.secondary.signature.name
+  ignore_above: 1024
+  level: custom
+  name: secondary.signature.name
+  normalize: []
+  original_fieldset: malware_signature
+  short: The name of the second yara rule matched.
+  type: keyword
 process.Ext.memory_region.malware_signature.version:
   dashed_name: process-Ext-memory-region-malware-signature-version
   description: malware signature version


### PR DESCRIPTION
## Change Summary

We're getting some EAF errors in `8.15` due to missing schema and custom docs for `file.Ext.malware_signature.secondary`:

> E       AssertionError: Found documents not complying with ECS, count: 1, schema violation keys: {'file.Ext.malware_signature.secondary'}, check log for details. Documents written to ecs_schema_violations.ndjson
>
> E       Found documents with fields missing custom documentation, count: 1, undocumented keys: {'file.Ext.malware_signature.secondary.signature.id', 'file.Ext.malware_signature.secondary.matches', 'file.Ext.malware_signature.secondary.signature.hash.sha256', 'file.Ext.malware_signature.secondary.signature.name'}. Documents written to custom_documentation_violations.ndjson

The tests are failing in `8.15` too, so we should backport these changes.  We still have a lot of 8.15.X releases ahead of us.  I'd be happy to do the backport if it's just a cherry-pick.

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes