### PR TITLE
Add dns.resolved_ip to Windows custom docs to address recent regression.

### DIFF
--- a/custom_documentation/doc/endpoint/network/windows/windows_network_dns_lookup_result.md
+++ b/custom_documentation/doc/endpoint/network/windows/windows_network_dns_lookup_result.md
@@ -20,6 +20,7 @@ This event is generated when results are returned for a DNS lookup request.
 | dns.Ext.options |
 | dns.Ext.status |
 | dns.question.name |
+| dns.resolved_ip |
 | ecs.version |
 | elastic.agent.id |
 | event.action |

--- a/custom_documentation/src/endpoint/data_stream/network/windows/windows_network_dns_lookup_result.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/windows/windows_network_dns_lookup_result.yaml
@@ -26,6 +26,7 @@ fields:
   - dns.Ext.options
   - dns.Ext.status
   - dns.question.name
+  - dns.resolved_ip
   - ecs.version
   - elastic.agent.id
   - event.action

--- a/package/endpoint/data_stream/network/sample_event.json
+++ b/package/endpoint/data_stream/network/sample_event.json
@@ -75,6 +75,20 @@
         "bytes": 498,
         "ip": "10.201.0.32"
     },
+    "dns": {
+        "Ext": {
+            "status": 123,
+            "options": 9223372036854775808
+        },
+        "resolved_ip": [
+            "10.10.10.10",
+            "10.10.10.11"
+        ],
+        "question": {
+            "name": "foo",
+            "type": "A"
+        }
+    },
     "message": "Endpoint network event",
     "network": {
         "transport": "tcp",


### PR DESCRIPTION
## Change Summary

Add `dns.resolved_ip` to Windows custom docs to address recent regression.  Also, we didn't have any DNS fields in the sample network event.

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes