### PR TITLE
[8.16] API - DeviceIoControl events and new final_user_module fields

### DIFF
--- a/custom_schemas/custom_api.yml
+++ b/custom_schemas/custom_api.yml
@@ -501,3 +501,18 @@
       description: >
          WMI namespace to which the connection is made.
       example: "root\\Microsoft\\Windows\\DeviceGuard"
+
+    - name: parameters.io_control_code
+      level: custom
+      type: unsigned_long
+      description: >
+         The I/O control code for the requested device operation.
+      example: 27365
+
+    - name: metadata.security_descriptor
+      level: custom
+      description: >
+        The security descriptor of the device.
+      type: keyword
+      example: "O:BAG:SYD:P(A;;FA;;;SY)(A;;FA;;;BA)S:AI(ML;;NW;;;LW)"    
+    

--- a/custom_schemas/custom_api.yml
+++ b/custom_schemas/custom_api.yml
@@ -60,7 +60,7 @@
           "rapid_background_polling" - a suspicious process which does rapid input polling via GetAsyncKeyState API was observed
           "multiple_polling_processes" - multiple suspicious processes which do rapid input polling via the GetAsyncKeyState API were observed
           "pid_spoofing" - WMI client proceess passed a forged process ID to the WMI server to spoof their origin
-      example: [ "cross-process", "rapid_background_polling", "multiple_polling_processes", "native_api", "shellcode" ]
+      example: "[ \"cross-process\", \"rapid_background_polling\", \"multiple_polling_processes\", \"native_api\", \"shellcode\" ]"
 
     - name: metadata
       level: custom
@@ -135,14 +135,15 @@
       level: custom
       type: unsigned_long
       description: >
-        This parameter indicates an elapsed time in milliseconds between the last GetAsyncKeyState event.
+        This field indicates the elapsed time in milliseconds since the last GetAsyncKeyState event.
       example: 94
 
     - name: metadata.background_callcount
       level: custom
       type: unsigned_long
+      short: The number of api calls since the last successful call.
       description: >
-        This parameter indicates a number of all GetAsyncKeyState api calls, including unsuccessfull calls, between the last successfull GetAsyncKeyState call.
+        This field indicates a number of all GetAsyncKeyState api calls, including unsuccessful calls, between the last successful GetAsyncKeyState call.
       example: 6021
 
     - name: metadata.client_machine
@@ -169,6 +170,7 @@
     - name: metadata.client_is_local
       level: custom
       type: boolean
+      short: Indicates whether a method was called locally or from a remote host.
       description: >
         Indicates whether a method was called locally or remotely. It will be true if called locally, and false if called remotely.
       example: 'true'
@@ -439,6 +441,7 @@
     - name: parameters.flags
       level: custom
       type: keyword
+      short: Mode flag that specifies how to interpret the information provided by UsagePage and Usage.
       description: >
         Mode flag that specifies how to interpret the information provided by UsagePage and Usage. Third member RAWINPUTDEVICE structure.
       example: "INPUTSINK"
@@ -480,6 +483,7 @@
     - name: parameters.consumer_type
       level: custom
       type: keyword
+      short: WMI event consumer type.
       description: |
         An example list of consumer type.
           "ActiveScriptEventConsumer" - Executes a predefined script in an arbitrary scripting language when an event is delivered to it.
@@ -492,6 +496,7 @@
     - name: parameters.consumer_details
       level: custom
       type: keyword
+      short: WMI Event consumer details.
       description: >
         Provides specific information about an event consumer, including its configuration, such as the command it executes, associated SID, and the consumer's name.
 

--- a/custom_schemas/custom_call_stack.yml
+++ b/custom_schemas/custom_call_stack.yml
@@ -89,6 +89,7 @@
     - name: allocation_private_bytes
       level: custom
       type: unsigned_long
+      short: The number of bytes in this memory allocation/image that are both +X and non-shareable.
       description:  >
         The number of bytes in this memory allocation/image that are both +X and non-shareable.
         Non-zero values can indicate code hooking, patching, or hollowing.

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -921,12 +921,14 @@
       level: custom
       type: unsigned_long
       index: false
+      short: The total milliseconds spent on ETW Win32k events for the process over the last week
       description: The total milliseconds spent on ETW Win32k events (currently, only keylogging events) for the process over the last week
 
     - name: metrics.system_impact.win32k_events.week_idle_ms
       level: custom
       type: unsigned_long
       index: false
+      short:  The total milliseconds spent queueing ETW Win32k events for the process over the last week
       description: The total milliseconds spent queueing ETW Win32k events (currently, only keylogging events) for the process over the last week
 
     - name: metrics.system_impact.process.executable
@@ -1038,6 +1040,7 @@
     - name: configuration
       level: custom
       type: object
+      short: The intended and applied setting for fields not part of a Policy setting
       description:
         Configuration fields represent the intended and applied setting for fields not part of a Policy setting
         This reflects what a given field is configured to do. The actual state of that same field is found in Endpoint.state
@@ -1050,6 +1053,7 @@
     - name: state
       level: custom
       type: object
+      short: The current state of a non-policy setting
       description:
         Represents the current state of a non-policy setting
         These fields reflect the current status of a field, which may differ from what it is configured to be (see Endpoint.configuration)

--- a/custom_schemas/custom_memory_protection.yml
+++ b/custom_schemas/custom_memory_protection.yml
@@ -16,6 +16,7 @@
     - name: thread_count
       level: custom
       type: long
+      short: The number of threads that this alert applies to.
       description: The number of threads that this alert applies to. If several alerts occur in a short period of time, they can be combined into a single alert with thread_count > 1.
     
     - name: self_injection

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -146,6 +146,7 @@
     - name: thread.Ext.call_stack_final_user_module.allocation_private_bytes
       level: custom
       type: unsigned_long
+      short: The number of bytes in this memory region that are both +X and non-shareable.
       description:  >
         The number of bytes in this memory region that are both +X and non-shareable.
         Non-zero values can indicate code hooking, patching, or hollowing.
@@ -161,6 +162,7 @@
       level: custom
       type: keyword
       example: "third_party_hook.dll"
+      short: The name of the memory region that caused the last modification of the protection of this page.
       description: >
         The name of the memory region that caused the last modification of the protection of this page. "Unbacked" may indicate shellcode.
 
@@ -169,7 +171,7 @@
       type: keyword
       example: "C:\\Program Files\\Hook Inc\\third_party_hook.dll"
       description: >
-        The path of the module that caused the last modification the protection of this page. "Unbacked" may indicate shellcode.
+        The path of the module that caused the last modification the protection of this page.
 
     - name: thread.Ext.call_stack_final_user_module.reason
       level: custom
@@ -286,6 +288,7 @@
       level: custom
       type: keyword
       example: "aacb1c801f9030f799e2f7350f053ebb760d42cbe81cd65021063c1c4d1a9c9c"
+      short: The hash of the disassembled code at the thread start_address.
       description: >
         The bytes at the thread start address, with immediate values capped to 0x100, disassembled into human-readable assembly code, then hashed.
 
@@ -313,29 +316,33 @@
       level: custom
       type: unsigned_long
       example: 0
+      short: The offset of original_start_address from the allocation base.
       description: >
-        When a trampoline was detected, this indicates the original content for the offset of original_start_address to the allocation base.
+        When a trampoline was detected, this indicates the offset of original_start_address from the allocation base.
 
     - name: thread.Ext.original_start_address_bytes
       level: custom
       type: keyword
       example: "48b84141414141414141ffe000ccccccccccccccccccccccccccccccccccccccc"
+      short: The hex-encoded bytes at the original_start_address.
       description: >
-        When a trampoline was detected, this holds the original content of the hex-encoded bytes at the original thread start address.
+        When a trampoline was detected, this holds the hex-encoded bytes at the original thread start address.
 
     - name: thread.Ext.original_start_address_bytes_disasm
       level: custom
       type: keyword
       example: "mov rax, 0x4141414141414141\\njmp rax"
+      short: The disassembled code at the original_start_address.
       description: >
-        When a trampoline was detected, this indicates the original content for the disassembled code pointed by the thread start address.
+        When a trampoline was detected, this holds the disassembled code at the original thread start address.
 
     - name: thread.Ext.original_start_address_bytes_disasm_hash
       level: custom
       type: keyword
       example: "aacb1c801f9030f799e2f7350f053ebb760d42cbe81cd65021063c1c4d1a9c9c"
+      short: The hash of the disassembled code at the original_start_address.
       description: >
-        When a trampoline was detected, this indicates the hash of original content for the disassembled code pointed by the thread start address.
+        When a trampoline was detected, this holds the bytes at the original thread start address, with immediate values capped to 0x100, disassembled into human-readable assembly code, then hashed.
 
     - name: thread.Ext.original_start_address_module
       level: custom
@@ -373,6 +380,7 @@
       level: custom
       type: keyword
       index: false
+      short: Up to 512KB of raw data from the thread parameter.
       description: >
         Up to 512KB of raw data from the thread parameter, if it is a valid pointer. This is compressed with zlib. To reduce data volume, this is de-duplicated on the endpoint, and may be missing from many alerts if the same data would be sent multiple times.
 
@@ -446,6 +454,7 @@
     - name: Ext.created_suspended
       level: custom
       type: boolean
+      short: A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32 CreateProcess API.
       description: A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32 CreateProcess API. Not valid for direct syscalls.
       example: "true"
 

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -143,12 +143,40 @@
       description: >
         The file path of the call_stack_final_user_module.
 
+    - name: thread.Ext.call_stack_final_user_module.allocation_private_bytes
+      level: custom
+      type: unsigned_long
+      description:  >
+        The number of bytes in this memory region that are both +X and non-shareable.
+        Non-zero values can indicate code hooking, patching, or hollowing.
+
+    - name: thread.Ext.call_stack_final_user_module.protection
+      level: custom
+      type: keyword
+      example: "RWX"
+      description: >
+        The memory protection for the acting region of pages. Corresponds to `MEMORY_BASIC_INFORMATION.Protect`
+
     - name: thread.Ext.call_stack_final_user_module.protection_provenance
       level: custom
       type: keyword
       example: "third_party_hook.dll"
       description: >
-        The name of the memory region that last modified the protection of this page. "Unbacked" may indicate shellcode.
+        The name of the memory region that caused the last modification of the protection of this page. "Unbacked" may indicate shellcode.
+
+    - name: thread.Ext.call_stack_final_user_module.protection_provenance_path
+      level: custom
+      type: keyword
+      example: "C:\\Program Files\\Hook Inc\\third_party_hook.dll"
+      description: >
+        The path of the module that caused the last modification the protection of this page. "Unbacked" may indicate shellcode.
+
+    - name: thread.Ext.call_stack_final_user_module.reason
+      level: custom
+      type: keyword
+      example: "ntdll.dll|kernelbase.dll"
+      description: >
+        The unexpected call_stack_summary that led to an "Undetermined" protection_provenance.
 
     - name: thread.Ext.call_stack_final_user_module.code_signature
       level: custom

--- a/custom_subsets/elastic_endpoint/api/api.yaml
+++ b/custom_subsets/elastic_endpoint/api/api.yaml
@@ -11,6 +11,20 @@ fields:
     fields:
       ip: {}
       port: {}
+  dll:
+    fields:
+      path: {}
+      hash:
+        fields:
+          sha256: {}
+      Ext:
+        fields:
+          code_signature:
+            fields:
+              exists: {}
+              status: {}
+              subject_name: {}
+              trusted: {}
   ecs:
     fields:
       version: {}

--- a/custom_subsets/elastic_endpoint/api/api.yaml
+++ b/custom_subsets/elastic_endpoint/api/api.yaml
@@ -153,7 +153,11 @@ fields:
                 fields:
                   name: {}
                   path: {}
+                  allocation_private_bytes: {}
+                  protection: {}
                   protection_provenance: {}
+                  protection_provenance_path: {}
+                  reason: {}
                   code_signature:
                     fields:
                       exists: {}

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -2484,28 +2484,28 @@
     - name: process.thread.Ext.original_start_address_allocation_offset
       level: custom
       type: unsigned_long
-      description: When a trampoline was detected, this indicates the original content for the offset of original_start_address to the allocation base.
+      description: When a trampoline was detected, this indicates the offset of original_start_address from the allocation base.
       example: 0
       default_field: false
     - name: process.thread.Ext.original_start_address_bytes
       level: custom
       type: keyword
       ignore_above: 1024
-      description: When a trampoline was detected, this holds the original content of the hex-encoded bytes at the original thread start address.
+      description: When a trampoline was detected, this holds the hex-encoded bytes at the original thread start address.
       example: 48b84141414141414141ffe000ccccccccccccccccccccccccccccccccccccccc
       default_field: false
     - name: process.thread.Ext.original_start_address_bytes_disasm
       level: custom
       type: keyword
       ignore_above: 1024
-      description: When a trampoline was detected, this indicates the original content for the disassembled code pointed by the thread start address.
+      description: When a trampoline was detected, this holds the disassembled code at the original thread start address.
       example: mov rax, 0x4141414141414141\njmp rax
       default_field: false
     - name: process.thread.Ext.original_start_address_bytes_disasm_hash
       level: custom
       type: keyword
       ignore_above: 1024
-      description: When a trampoline was detected, this indicates the hash of original content for the disassembled code pointed by the thread start address.
+      description: When a trampoline was detected, this holds the bytes at the original thread start address, with immediate values capped to 0x100, disassembled into human-readable assembly code, then hashed.
       example: aacb1c801f9030f799e2f7350f053ebb760d42cbe81cd65021063c1c4d1a9c9c
       default_field: false
     - name: process.thread.Ext.original_start_address_module
@@ -7321,28 +7321,28 @@
     - name: thread.Ext.original_start_address_allocation_offset
       level: custom
       type: unsigned_long
-      description: When a trampoline was detected, this indicates the original content for the offset of original_start_address to the allocation base.
+      description: When a trampoline was detected, this indicates the offset of original_start_address from the allocation base.
       example: 0
       default_field: false
     - name: thread.Ext.original_start_address_bytes
       level: custom
       type: keyword
       ignore_above: 1024
-      description: When a trampoline was detected, this holds the original content of the hex-encoded bytes at the original thread start address.
+      description: When a trampoline was detected, this holds the hex-encoded bytes at the original thread start address.
       example: 48b84141414141414141ffe000ccccccccccccccccccccccccccccccccccccccc
       default_field: false
     - name: thread.Ext.original_start_address_bytes_disasm
       level: custom
       type: keyword
       ignore_above: 1024
-      description: When a trampoline was detected, this indicates the original content for the disassembled code pointed by the thread start address.
+      description: When a trampoline was detected, this holds the disassembled code at the original thread start address.
       example: mov rax, 0x4141414141414141\njmp rax
       default_field: false
     - name: thread.Ext.original_start_address_bytes_disasm_hash
       level: custom
       type: keyword
       ignore_above: 1024
-      description: When a trampoline was detected, this indicates the hash of original content for the disassembled code pointed by the thread start address.
+      description: When a trampoline was detected, this holds the bytes at the original thread start address, with immediate values capped to 0x100, disassembled into human-readable assembly code, then hashed.
       example: aacb1c801f9030f799e2f7350f053ebb760d42cbe81cd65021063c1c4d1a9c9c
       default_field: false
     - name: thread.Ext.original_start_address_module

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -888,6 +888,75 @@
       type: long
       format: string
       description: Port of the destination.
+- name: dll
+  title: DLL
+  group: 2
+  description: 'These fields contain information about code libraries dynamically loaded into processes.
+
+
+    Many operating systems refer to "shared code libraries" with different names, but this field set refers to all of the following:
+
+    * Dynamic-link library (`.dll`) commonly used on Windows
+
+    * Shared Object (`.so`) commonly used on Unix-like operating systems
+
+    * Dynamic library (`.dylib`) commonly used on macOS'
+  type: group
+  default_field: true
+  fields:
+    - name: Ext
+      level: custom
+      type: object
+      description: Object for all custom defined fields to live in.
+      default_field: false
+    - name: Ext.code_signature
+      level: custom
+      type: nested
+      description: Nested version of ECS code_signature fieldset.
+      default_field: false
+    - name: Ext.code_signature.exists
+      level: custom
+      type: boolean
+      description: Boolean to capture if a signature is present.
+      example: 'true'
+      default_field: false
+    - name: Ext.code_signature.status
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: 'Additional information about the certificate status.
+
+        This is useful for logging cryptographic errors with the certificate validity or trust status. Leave unpopulated if the validity or trust of the certificate was unchecked.'
+      example: ERROR_UNTRUSTED_ROOT
+      default_field: false
+    - name: Ext.code_signature.subject_name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Subject name of the code signer
+      example: Microsoft Corporation
+      default_field: false
+    - name: Ext.code_signature.trusted
+      level: custom
+      type: boolean
+      description: 'Stores the trust status of the certificate chain.
+
+        Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status.'
+      example: 'true'
+      default_field: false
+    - name: hash.sha256
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: SHA256 hash.
+      default_field: false
+    - name: path
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Full file path of the library.
+      example: C:\Windows\System32\kernel32.dll
+      default_field: false
 - name: ecs
   title: ECS
   group: 2
@@ -1204,12 +1273,7 @@
       type: keyword
       ignore_above: 1024
       description: "A list of observed behaviors.\n  \"cross-process\" - the observed activity was between two processes\n  \"parent-child\" - the observed activity was between a parent process and its child\n  \"native_api\" - a call was made directly to the Native API rather than the Win32 API\n  \"direct_syscall\" - a syscall instruction originated outside of the Native API layer\n  \"proxy_call\" - the call stack may indicate of a proxied API call to mask the true source\n  \"sensitive_api\" - executable non-image memory is unexpectedly calling a sensitive API\n  \"shellcode\" - suspicious executable non-image memory is calling a sensitive API\n  \"image_hooked\" - an entry in the callstack appears to have been hooked\n  \"image_indirect_call\" - an entry in the callstack was preceded by a call to a dynamically resolved function\n  \"image_rop\" - no call instruction preceded an entry in the call stack\n  \"image_rwx\" - an entry in the callstack is writable\n  \"unbacked_rwx\" - an entry in the callstack is non-image and writable\n  \"truncated_stack\" - call stack is unexpected truncated due to malicious tampering or system load\n  \"allocate_shellcode\" - a region of non-image executable memory allocated more executable memory\n  \"execute_fluctuation\" - the PAGE_EXECUTE protection is unexpectedly fluctuating\n  \"write_fluctuation\" - the PAGE_WRITE protection of executable memory is unexpectedly fluctuating\n  \"hook_api\" - a change to the memory protection of a small executable image memory region was made\n  \"hollow_image\" - a change to the memory protection of a large executable image memory region was made\n  \"hook_unbacked\" - a change to the memory protection of a small executable non-image memory was made\n  \"hollow_unbacked\" - a change to the memory protection of a large executable non-image memory was made\n  \"guarded_code\" - executable memory was unexpectedly marked as PAGE_GUARD\n  \"hidden_code\" - executable memory was unexpectedly marked as PAGE_NOACCESS\n  \"execute_shellcode\" - a region of non-image executable memory was unexpectedly transferred control\n  \"hardware_breakpoint_set\" - a hardware breakpoint was set\n  \"rapid_background_polling\" - a suspicious process which does rapid input polling via GetAsyncKeyState API was observed\n  \"multiple_polling_processes\" - multiple suspicious processes which do rapid input polling via the GetAsyncKeyState API were observed\n  \"pid_spoofing\" - WMI client proceess passed a forged process ID to the WMI server to spoof their origin"
-      example:
-        - cross-process
-        - rapid_background_polling
-        - multiple_polling_processes
-        - native_api
-        - shellcode
+      example: '[ "cross-process", "rapid_background_polling", "multiple_polling_processes", "native_api", "shellcode" ]'
       default_field: false
     - name: Ext.api.metadata
       level: custom
@@ -1219,7 +1283,7 @@
     - name: Ext.api.metadata.background_callcount
       level: custom
       type: unsigned_long
-      description: This parameter indicates a number of all GetAsyncKeyState api calls, including unsuccessfull calls, between the last successfull GetAsyncKeyState call.
+      description: This field indicates a number of all GetAsyncKeyState api calls, including unsuccessful calls, between the last successful GetAsyncKeyState call.
       example: 6021
       default_field: false
     - name: Ext.api.metadata.client_is_local
@@ -1251,7 +1315,7 @@
     - name: Ext.api.metadata.ms_since_last_keyevent
       level: custom
       type: unsigned_long
-      description: This parameter indicates an elapsed time in milliseconds between the last GetAsyncKeyState event.
+      description: This field indicates the elapsed time in milliseconds since the last GetAsyncKeyState event.
       example: 94
       default_field: false
     - name: Ext.api.metadata.procedure_symbol
@@ -1266,6 +1330,13 @@
       type: unsigned_long
       description: Return value of RegisterRawInputDevices API call.
       example: 1
+      default_field: false
+    - name: Ext.api.metadata.security_descriptor
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The security descriptor of the device.
+      example: O:BAG:SYD:P(A;;FA;;;SY)(A;;FA;;;BA)S:AI(ML;;NW;;;LW)
       default_field: false
     - name: Ext.api.metadata.start_address_allocation_protection
       level: custom
@@ -1501,6 +1572,12 @@
       ignore_above: 1024
       description: Type of hook procedure to be installed.
       example: WH_KEYBOARD_LL
+      default_field: false
+    - name: Ext.api.parameters.io_control_code
+      level: custom
+      type: unsigned_long
+      description: The I/O control code for the requested device operation.
+      example: 27365
       default_field: false
     - name: Ext.api.parameters.namespace
       level: custom
@@ -2584,6 +2661,11 @@
       type: nested
       description: The final non-win32 module in the call stack.
       default_field: false
+    - name: thread.Ext.call_stack_final_user_module.allocation_private_bytes
+      level: custom
+      type: unsigned_long
+      description: The number of bytes in this memory region that are both +X and non-shareable. Non-zero values can indicate code hooking, patching, or hollowing.
+      default_field: false
     - name: thread.Ext.call_stack_final_user_module.code_signature
       level: custom
       type: nested
@@ -2653,12 +2735,33 @@
       description: The file path of the call_stack_final_user_module.
       example: C:\Program Files\Example\example.dll
       default_field: false
+    - name: thread.Ext.call_stack_final_user_module.protection
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The memory protection for the acting region of pages. Corresponds to `MEMORY_BASIC_INFORMATION.Protect`
+      example: RWX
+      default_field: false
     - name: thread.Ext.call_stack_final_user_module.protection_provenance
       level: custom
       type: keyword
       ignore_above: 1024
-      description: The name of the memory region that last modified the protection of this page. "Unbacked" may indicate shellcode.
+      description: The name of the memory region that caused the last modification of the protection of this page. "Unbacked" may indicate shellcode.
       example: third_party_hook.dll
+      default_field: false
+    - name: thread.Ext.call_stack_final_user_module.protection_provenance_path
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The path of the module that caused the last modification the protection of this page.
+      example: C:\Program Files\Hook Inc\third_party_hook.dll
+      default_field: false
+    - name: thread.Ext.call_stack_final_user_module.reason
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The unexpected call_stack_summary that led to an "Undetermined" protection_provenance.
+      example: ntdll.dll|kernelbase.dll
       default_field: false
     - name: thread.Ext.call_stack_summary
       level: custom

--- a/package/endpoint/data_stream/api/sample_event.json
+++ b/package/endpoint/data_stream/api/sample_event.json
@@ -37,6 +37,22 @@
             "pid": 25732
         }
     },
+    "dll": {
+        "Ext": {
+            "code_signature": [
+                {
+                    "exists": true,
+                    "status": "trusted",
+                    "subject_name": "Microsoft Windows",
+                    "trusted": true
+                }
+            ]
+        },
+        "hash": {
+            "sha256": "8b9731a4b83e801cda7b918f8194608e91f86b3a86ffb6bb24230b1cc28e1a54"
+        },
+        "path": "c:\\windows\\system32\\drivers\\pktmon.sys"
+    },
     "destination": {
         "ip": "2001:4860:4860::8844",
         "port": 139
@@ -123,6 +139,7 @@
                     "procedure_symbol": "taskbar.dll",
                     "ms_since_last_keyevent": 94,
                     "background_callcount": 6021,
+                    "security_descriptor": "O:BAG:SYD:P(A;;FA;;;SY)(A;;FA;;;BA)S:AI(ML;;NW;;;LW)",
                     "client_machine": "DESKTOP-EXAMPLE",
                     "client_machine_fqdn": "DESKTOP-EXAMPLE",
                     "client_process_id": 3600,
@@ -171,6 +188,8 @@
                     "flags": "INPUTSINK",
                     "hook_type": "WH_KEYBOARD_LL",
                     "hook_module": "c:\\windows\\system32\\taskbar.dll",
+                    "device": "\\Device\\PktMonDev",
+                    "io_control_code": 27365,
                     "event_filter_name": "ExampleFilter",
                     "event_filter_details": "__EventFilter{EventNamespace = \"root\\CimV2\"; Name = \"ExampleFilter\";};",
                     "consumer_name": "ExampleConsumer",

--- a/package/endpoint/data_stream/api/sample_event.json
+++ b/package/endpoint/data_stream/api/sample_event.json
@@ -257,6 +257,7 @@
                     }
                 ],
                 "call_stack_final_user_module": {
+                    "allocation_private_bytes": 4096,
                     "code_signature": [
                         {
                             "exists": true,
@@ -270,7 +271,10 @@
                     },
                     "name": "dabapi.dll",
                     "path": "c:\\windows\\system32\\dabapi.dll",
-                    "protection_provenance": "eventstests.exe"
+                    "protection": "RWX",
+                    "protection_provenance": "eventstests.exe",
+                    "protection_provenance_path": "c:\\dev\\eventstests.exe",
+                    "reason": "ntdll.dll"
                 },
                 "call_stack_summary": "ntdll.dll|kernelbase.dll|kernel32.dll|cmd.exe|kernel32.dll|ntdll.dll"
             },

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -361,10 +361,10 @@ sent by the endpoint.
 | Target.process.thread.Ext | Object for all custom defined fields to live in. | object |
 | Target.process.thread.Ext.hardware_breakpoint_set | Whether a hardware breakpoint was set for the thread. This field is omitted if false. | boolean |
 | Target.process.thread.Ext.original_start_address | When a trampoline was detected, this indicates the original content for the thread start address in memory. | unsigned_long |
-| Target.process.thread.Ext.original_start_address_allocation_offset | When a trampoline was detected, this indicates the original content for the offset of original_start_address to the allocation base. | unsigned_long |
-| Target.process.thread.Ext.original_start_address_bytes | When a trampoline was detected, this holds the original content of the hex-encoded bytes at the original thread start address. | keyword |
-| Target.process.thread.Ext.original_start_address_bytes_disasm | When a trampoline was detected, this indicates the original content for the disassembled code pointed by the thread start address. | keyword |
-| Target.process.thread.Ext.original_start_address_bytes_disasm_hash | When a trampoline was detected, this indicates the hash of original content for the disassembled code pointed by the thread start address. | keyword |
+| Target.process.thread.Ext.original_start_address_allocation_offset | When a trampoline was detected, this indicates the offset of original_start_address from the allocation base. | unsigned_long |
+| Target.process.thread.Ext.original_start_address_bytes | When a trampoline was detected, this holds the hex-encoded bytes at the original thread start address. | keyword |
+| Target.process.thread.Ext.original_start_address_bytes_disasm | When a trampoline was detected, this holds the disassembled code at the original thread start address. | keyword |
+| Target.process.thread.Ext.original_start_address_bytes_disasm_hash | When a trampoline was detected, this holds the bytes at the original thread start address, with immediate values capped to 0x100, disassembled into human-readable assembly code, then hashed. | keyword |
 | Target.process.thread.Ext.original_start_address_module | When a trampoline was detected, this indicates the original content for the dll/module where the thread began execution. | keyword |
 | Target.process.thread.Ext.parameter | When a thread is created, this is the raw numerical value of its parameter. | unsigned_long |
 | Target.process.thread.Ext.parameter_bytes_compressed | Up to 512KB of raw data from the thread parameter, if it is a valid pointer. This is compressed with zlib. To reduce data volume, this is de-duplicated on the endpoint, and may be missing from many alerts if the same data would be sent multiple times. | keyword |
@@ -990,10 +990,10 @@ sent by the endpoint.
 | process.thread.Ext | Object for all custom defined fields to live in. | object |
 | process.thread.Ext.hardware_breakpoint_set | Whether a hardware breakpoint was set for the thread. This field is omitted if false. | boolean |
 | process.thread.Ext.original_start_address | When a trampoline was detected, this indicates the original content for the thread start address in memory. | unsigned_long |
-| process.thread.Ext.original_start_address_allocation_offset | When a trampoline was detected, this indicates the original content for the offset of original_start_address to the allocation base. | unsigned_long |
-| process.thread.Ext.original_start_address_bytes | When a trampoline was detected, this holds the original content of the hex-encoded bytes at the original thread start address. | keyword |
-| process.thread.Ext.original_start_address_bytes_disasm | When a trampoline was detected, this indicates the original content for the disassembled code pointed by the thread start address. | keyword |
-| process.thread.Ext.original_start_address_bytes_disasm_hash | When a trampoline was detected, this indicates the hash of original content for the disassembled code pointed by the thread start address. | keyword |
+| process.thread.Ext.original_start_address_allocation_offset | When a trampoline was detected, this indicates the offset of original_start_address from the allocation base. | unsigned_long |
+| process.thread.Ext.original_start_address_bytes | When a trampoline was detected, this holds the hex-encoded bytes at the original thread start address. | keyword |
+| process.thread.Ext.original_start_address_bytes_disasm | When a trampoline was detected, this holds the disassembled code at the original thread start address. | keyword |
+| process.thread.Ext.original_start_address_bytes_disasm_hash | When a trampoline was detected, this holds the bytes at the original thread start address, with immediate values capped to 0x100, disassembled into human-readable assembly code, then hashed. | keyword |
 | process.thread.Ext.original_start_address_module | When a trampoline was detected, this indicates the original content for the dll/module where the thread began execution. | keyword |
 | process.thread.Ext.parameter | When a thread is created, this is the raw numerical value of its parameter. | unsigned_long |
 | process.thread.Ext.parameter_bytes_compressed | Up to 512KB of raw data from the thread parameter, if it is a valid pointer. This is compressed with zlib. To reduce data volume, this is de-duplicated on the endpoint, and may be missing from many alerts if the same data would be sent multiple times. | keyword |

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -246,9 +246,7 @@ Memory_protection.thread_count:
   level: custom
   name: thread_count
   normalize: []
-  short: The number of threads that this alert applies to. If several alerts occur
-    in a short period of time, they can be combined into a single alert with thread_count
-    > 1.
+  short: The number of threads that this alert applies to.
   type: long
 Memory_protection.unique_key_v1:
   dashed_name: Memory-protection-unique-key-v1
@@ -3216,21 +3214,20 @@ Target.process.thread.Ext.original_start_address:
   type: unsigned_long
 Target.process.thread.Ext.original_start_address_allocation_offset:
   dashed_name: Target-process-thread-Ext-original-start-address-allocation-offset
-  description: When a trampoline was detected, this indicates the original content
-    for the offset of original_start_address to the allocation base.
+  description: When a trampoline was detected, this indicates the offset of original_start_address
+    from the allocation base.
   example: 0
   flat_name: Target.process.thread.Ext.original_start_address_allocation_offset
   level: custom
   name: thread.Ext.original_start_address_allocation_offset
   normalize: []
   original_fieldset: process
-  short: When a trampoline was detected, this indicates the original content for the
-    offset of original_start_address to the allocation base.
+  short: The offset of original_start_address from the allocation base.
   type: unsigned_long
 Target.process.thread.Ext.original_start_address_bytes:
   dashed_name: Target-process-thread-Ext-original-start-address-bytes
-  description: When a trampoline was detected, this holds the original content of
-    the hex-encoded bytes at the original thread start address.
+  description: When a trampoline was detected, this holds the hex-encoded bytes at
+    the original thread start address.
   example: 48b84141414141414141ffe000ccccccccccccccccccccccccccccccccccccccc
   flat_name: Target.process.thread.Ext.original_start_address_bytes
   ignore_above: 1024
@@ -3238,13 +3235,12 @@ Target.process.thread.Ext.original_start_address_bytes:
   name: thread.Ext.original_start_address_bytes
   normalize: []
   original_fieldset: process
-  short: When a trampoline was detected, this holds the original content of the hex-encoded
-    bytes at the original thread start address.
+  short: The hex-encoded bytes at the original_start_address.
   type: keyword
 Target.process.thread.Ext.original_start_address_bytes_disasm:
   dashed_name: Target-process-thread-Ext-original-start-address-bytes-disasm
-  description: When a trampoline was detected, this indicates the original content
-    for the disassembled code pointed by the thread start address.
+  description: When a trampoline was detected, this holds the disassembled code at
+    the original thread start address.
   example: mov rax, 0x4141414141414141\njmp rax
   flat_name: Target.process.thread.Ext.original_start_address_bytes_disasm
   ignore_above: 1024
@@ -3252,13 +3248,13 @@ Target.process.thread.Ext.original_start_address_bytes_disasm:
   name: thread.Ext.original_start_address_bytes_disasm
   normalize: []
   original_fieldset: process
-  short: When a trampoline was detected, this indicates the original content for the
-    disassembled code pointed by the thread start address.
+  short: The disassembled code at the original_start_address.
   type: keyword
 Target.process.thread.Ext.original_start_address_bytes_disasm_hash:
   dashed_name: Target-process-thread-Ext-original-start-address-bytes-disasm-hash
-  description: When a trampoline was detected, this indicates the hash of original
-    content for the disassembled code pointed by the thread start address.
+  description: When a trampoline was detected, this holds the bytes at the original
+    thread start address, with immediate values capped to 0x100, disassembled into
+    human-readable assembly code, then hashed.
   example: aacb1c801f9030f799e2f7350f053ebb760d42cbe81cd65021063c1c4d1a9c9c
   flat_name: Target.process.thread.Ext.original_start_address_bytes_disasm_hash
   ignore_above: 1024
@@ -3266,8 +3262,7 @@ Target.process.thread.Ext.original_start_address_bytes_disasm_hash:
   name: thread.Ext.original_start_address_bytes_disasm_hash
   normalize: []
   original_fieldset: process
-  short: When a trampoline was detected, this indicates the hash of original content
-    for the disassembled code pointed by the thread start address.
+  short: The hash of the disassembled code at the original_start_address.
   type: keyword
 Target.process.thread.Ext.original_start_address_module:
   dashed_name: Target-process-thread-Ext-original-start-address-module
@@ -3306,10 +3301,7 @@ Target.process.thread.Ext.parameter_bytes_compressed:
   name: thread.Ext.parameter_bytes_compressed
   normalize: []
   original_fieldset: process
-  short: Up to 512KB of raw data from the thread parameter, if it is a valid pointer.
-    This is compressed with zlib. To reduce data volume, this is de-duplicated on
-    the endpoint, and may be missing from many alerts if the same data would be sent
-    multiple times.
+  short: Up to 512KB of raw data from the thread parameter.
   type: keyword
 Target.process.thread.Ext.parameter_bytes_compressed_present:
   dashed_name: Target-process-thread-Ext-parameter-bytes-compressed-present
@@ -3406,8 +3398,7 @@ Target.process.thread.Ext.start_address_bytes_disasm_hash:
   name: thread.Ext.start_address_bytes_disasm_hash
   normalize: []
   original_fieldset: process
-  short: The bytes at the thread start address, with immediate values capped to 0x100,
-    disassembled into human-readable assembly code, then hashed.
+  short: The hash of the disassembled code at the thread start_address.
   type: keyword
 Target.process.thread.Ext.start_address_module:
   dashed_name: Target-process-thread-Ext-start-address-module
@@ -8562,54 +8553,51 @@ process.thread.Ext.original_start_address:
   type: unsigned_long
 process.thread.Ext.original_start_address_allocation_offset:
   dashed_name: process-thread-Ext-original-start-address-allocation-offset
-  description: When a trampoline was detected, this indicates the original content
-    for the offset of original_start_address to the allocation base.
+  description: When a trampoline was detected, this indicates the offset of original_start_address
+    from the allocation base.
   example: 0
   flat_name: process.thread.Ext.original_start_address_allocation_offset
   level: custom
   name: thread.Ext.original_start_address_allocation_offset
   normalize: []
-  short: When a trampoline was detected, this indicates the original content for the
-    offset of original_start_address to the allocation base.
+  short: The offset of original_start_address from the allocation base.
   type: unsigned_long
 process.thread.Ext.original_start_address_bytes:
   dashed_name: process-thread-Ext-original-start-address-bytes
-  description: When a trampoline was detected, this holds the original content of
-    the hex-encoded bytes at the original thread start address.
+  description: When a trampoline was detected, this holds the hex-encoded bytes at
+    the original thread start address.
   example: 48b84141414141414141ffe000ccccccccccccccccccccccccccccccccccccccc
   flat_name: process.thread.Ext.original_start_address_bytes
   ignore_above: 1024
   level: custom
   name: thread.Ext.original_start_address_bytes
   normalize: []
-  short: When a trampoline was detected, this holds the original content of the hex-encoded
-    bytes at the original thread start address.
+  short: The hex-encoded bytes at the original_start_address.
   type: keyword
 process.thread.Ext.original_start_address_bytes_disasm:
   dashed_name: process-thread-Ext-original-start-address-bytes-disasm
-  description: When a trampoline was detected, this indicates the original content
-    for the disassembled code pointed by the thread start address.
+  description: When a trampoline was detected, this holds the disassembled code at
+    the original thread start address.
   example: mov rax, 0x4141414141414141\njmp rax
   flat_name: process.thread.Ext.original_start_address_bytes_disasm
   ignore_above: 1024
   level: custom
   name: thread.Ext.original_start_address_bytes_disasm
   normalize: []
-  short: When a trampoline was detected, this indicates the original content for the
-    disassembled code pointed by the thread start address.
+  short: The disassembled code at the original_start_address.
   type: keyword
 process.thread.Ext.original_start_address_bytes_disasm_hash:
   dashed_name: process-thread-Ext-original-start-address-bytes-disasm-hash
-  description: When a trampoline was detected, this indicates the hash of original
-    content for the disassembled code pointed by the thread start address.
+  description: When a trampoline was detected, this holds the bytes at the original
+    thread start address, with immediate values capped to 0x100, disassembled into
+    human-readable assembly code, then hashed.
   example: aacb1c801f9030f799e2f7350f053ebb760d42cbe81cd65021063c1c4d1a9c9c
   flat_name: process.thread.Ext.original_start_address_bytes_disasm_hash
   ignore_above: 1024
   level: custom
   name: thread.Ext.original_start_address_bytes_disasm_hash
   normalize: []
-  short: When a trampoline was detected, this indicates the hash of original content
-    for the disassembled code pointed by the thread start address.
+  short: The hash of the disassembled code at the original_start_address.
   type: keyword
 process.thread.Ext.original_start_address_module:
   dashed_name: process-thread-Ext-original-start-address-module
@@ -8645,10 +8633,7 @@ process.thread.Ext.parameter_bytes_compressed:
   level: custom
   name: thread.Ext.parameter_bytes_compressed
   normalize: []
-  short: Up to 512KB of raw data from the thread parameter, if it is a valid pointer.
-    This is compressed with zlib. To reduce data volume, this is de-duplicated on
-    the endpoint, and may be missing from many alerts if the same data would be sent
-    multiple times.
+  short: Up to 512KB of raw data from the thread parameter.
   type: keyword
 process.thread.Ext.parameter_bytes_compressed_present:
   dashed_name: process-thread-Ext-parameter-bytes-compressed-present
@@ -8737,8 +8722,7 @@ process.thread.Ext.start_address_bytes_disasm_hash:
   level: custom
   name: thread.Ext.start_address_bytes_disasm_hash
   normalize: []
-  short: The bytes at the thread start address, with immediate values capped to 0x100,
-    disassembled into human-readable assembly code, then hashed.
+  short: The hash of the disassembled code at the thread start_address.
   type: keyword
 process.thread.Ext.start_address_module:
   dashed_name: process-thread-Ext-start-address-module

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -38,7 +38,7 @@ Target.process.Ext.created_suspended:
   normalize: []
   original_fieldset: process
   short: A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32
-    CreateProcess API. Not valid for direct syscalls.
+    CreateProcess API.
   type: boolean
 Target.process.Ext.memory_region.allocation_base:
   dashed_name: Target-process-Ext-memory-region-allocation-base
@@ -1559,6 +1559,95 @@ destination.port:
   normalize: []
   short: Port of the destination.
   type: long
+dll.Ext:
+  dashed_name: dll-Ext
+  description: Object for all custom defined fields to live in.
+  flat_name: dll.Ext
+  level: custom
+  name: Ext
+  normalize: []
+  short: Object for all custom defined fields to live in.
+  type: object
+dll.Ext.code_signature:
+  dashed_name: dll-Ext-code-signature
+  description: Nested version of ECS code_signature fieldset.
+  flat_name: dll.Ext.code_signature
+  level: custom
+  name: Ext.code_signature
+  normalize: []
+  short: Nested version of ECS code_signature fieldset.
+  type: nested
+dll.Ext.code_signature.exists:
+  dashed_name: dll-Ext-code-signature-exists
+  description: Boolean to capture if a signature is present.
+  example: 'true'
+  flat_name: dll.Ext.code_signature.exists
+  level: custom
+  name: Ext.code_signature.exists
+  normalize: []
+  short: Boolean to capture if a signature is present.
+  type: boolean
+dll.Ext.code_signature.status:
+  dashed_name: dll-Ext-code-signature-status
+  description: 'Additional information about the certificate status.
+
+    This is useful for logging cryptographic errors with the certificate validity
+    or trust status. Leave unpopulated if the validity or trust of the certificate
+    was unchecked.'
+  example: ERROR_UNTRUSTED_ROOT
+  flat_name: dll.Ext.code_signature.status
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.status
+  normalize: []
+  short: Additional information about the certificate status.
+  type: keyword
+dll.Ext.code_signature.subject_name:
+  dashed_name: dll-Ext-code-signature-subject-name
+  description: Subject name of the code signer
+  example: Microsoft Corporation
+  flat_name: dll.Ext.code_signature.subject_name
+  ignore_above: 1024
+  level: custom
+  name: Ext.code_signature.subject_name
+  normalize: []
+  short: Subject name of the code signer
+  type: keyword
+dll.Ext.code_signature.trusted:
+  dashed_name: dll-Ext-code-signature-trusted
+  description: 'Stores the trust status of the certificate chain.
+
+    Validating the trust of the certificate chain may be complicated, and this field
+    should only be populated by tools that actively check the status.'
+  example: 'true'
+  flat_name: dll.Ext.code_signature.trusted
+  level: custom
+  name: Ext.code_signature.trusted
+  normalize: []
+  short: Stores the trust status of the certificate chain.
+  type: boolean
+dll.hash.sha256:
+  dashed_name: dll-hash-sha256
+  description: SHA256 hash.
+  flat_name: dll.hash.sha256
+  ignore_above: 1024
+  level: extended
+  name: sha256
+  normalize: []
+  original_fieldset: hash
+  short: SHA256 hash.
+  type: keyword
+dll.path:
+  dashed_name: dll-path
+  description: Full file path of the library.
+  example: C:\Windows\System32\kernel32.dll
+  flat_name: dll.path
+  ignore_above: 1024
+  level: extended
+  name: path
+  normalize: []
+  short: Full file path of the library.
+  type: keyword
 ecs.version:
   dashed_name: ecs-version
   description: 'ECS version this event conforms to. `ecs.version` is a required field
@@ -2459,12 +2548,8 @@ process.Ext.api.behaviors:
     \ - multiple suspicious processes which do rapid input polling via the GetAsyncKeyState\
     \ API were observed\n  \"pid_spoofing\" - WMI client proceess passed a forged\
     \ process ID to the WMI server to spoof their origin"
-  example:
-  - cross-process
-  - rapid_background_polling
-  - multiple_polling_processes
-  - native_api
-  - shellcode
+  example: '[ "cross-process", "rapid_background_polling", "multiple_polling_processes",
+    "native_api", "shellcode" ]'
   flat_name: process.Ext.api.behaviors
   ignore_above: 1024
   level: custom
@@ -2485,16 +2570,15 @@ process.Ext.api.metadata:
   type: object
 process.Ext.api.metadata.background_callcount:
   dashed_name: process-Ext-api-metadata-background-callcount
-  description: This parameter indicates a number of all GetAsyncKeyState api calls,
-    including unsuccessfull calls, between the last successfull GetAsyncKeyState call.
+  description: This field indicates a number of all GetAsyncKeyState api calls, including
+    unsuccessful calls, between the last successful GetAsyncKeyState call.
   example: 6021
   flat_name: process.Ext.api.metadata.background_callcount
   level: custom
   name: metadata.background_callcount
   normalize: []
   original_fieldset: api
-  short: This parameter indicates a number of all GetAsyncKeyState api calls, including
-    unsuccessfull calls, between the last successfull GetAsyncKeyState call.
+  short: The number of api calls since the last successful call.
   type: unsigned_long
 process.Ext.api.metadata.client_is_local:
   dashed_name: process-Ext-api-metadata-client-is-local
@@ -2506,8 +2590,7 @@ process.Ext.api.metadata.client_is_local:
   name: metadata.client_is_local
   normalize: []
   original_fieldset: api
-  short: Indicates whether a method was called locally or remotely. It will be true
-    if called locally, and false if called remotely.
+  short: Indicates whether a method was called locally or from a remote host.
   type: boolean
 process.Ext.api.metadata.client_machine:
   dashed_name: process-Ext-api-metadata-client-machine
@@ -2546,16 +2629,16 @@ process.Ext.api.metadata.client_process_id:
   type: unsigned_long
 process.Ext.api.metadata.ms_since_last_keyevent:
   dashed_name: process-Ext-api-metadata-ms-since-last-keyevent
-  description: This parameter indicates an elapsed time in milliseconds between the
-    last GetAsyncKeyState event.
+  description: This field indicates the elapsed time in milliseconds since the last
+    GetAsyncKeyState event.
   example: 94
   flat_name: process.Ext.api.metadata.ms_since_last_keyevent
   level: custom
   name: metadata.ms_since_last_keyevent
   normalize: []
   original_fieldset: api
-  short: This parameter indicates an elapsed time in milliseconds between the last
-    GetAsyncKeyState event.
+  short: This field indicates the elapsed time in milliseconds since the last GetAsyncKeyState
+    event.
   type: unsigned_long
 process.Ext.api.metadata.procedure_symbol:
   dashed_name: process-Ext-api-metadata-procedure-symbol
@@ -2580,6 +2663,18 @@ process.Ext.api.metadata.return_value:
   original_fieldset: api
   short: Return value of RegisterRawInputDevices API call.
   type: unsigned_long
+process.Ext.api.metadata.security_descriptor:
+  dashed_name: process-Ext-api-metadata-security-descriptor
+  description: The security descriptor of the device.
+  example: O:BAG:SYD:P(A;;FA;;;SY)(A;;FA;;;BA)S:AI(ML;;NW;;;LW)
+  flat_name: process.Ext.api.metadata.security_descriptor
+  ignore_above: 1024
+  level: custom
+  name: metadata.security_descriptor
+  normalize: []
+  original_fieldset: api
+  short: The security descriptor of the device.
+  type: keyword
 process.Ext.api.metadata.start_address_allocation_protection:
   dashed_name: process-Ext-api-metadata-start-address-allocation-protection
   description: Memory protection attributes associated with the starting address of
@@ -2751,8 +2846,7 @@ process.Ext.api.parameters.consumer_details:
   name: parameters.consumer_details
   normalize: []
   original_fieldset: api
-  short: Provides specific information about an event consumer, including its configuration,
-    such as the command it executes, associated SID, and the consumer's name.
+  short: WMI Event consumer details.
   type: keyword
 process.Ext.api.parameters.consumer_name:
   dashed_name: process-Ext-api-parameters-consumer-name
@@ -2785,14 +2879,7 @@ process.Ext.api.parameters.consumer_type:
   name: parameters.consumer_type
   normalize: []
   original_fieldset: api
-  short: "An example list of consumer type.\n  \"ActiveScriptEventConsumer\" - Executes\
-    \ a predefined script in an arbitrary scripting language when an event is delivered\
-    \ to it.\n  \"CommandLineEventConsumer\" - Launches an arbitrary process in the\
-    \ local system context when an event is delivered to it.\n  \"LogFileEventConsumer\"\
-    \ - Writes customized strings to a text log file when events are delivered to\
-    \ it.\n  \"NTEventLogEventConsumer\" - Logs a specific message to the Windows\
-    \ event log when an event is delivered to it.\n  \"SMTPEventConsumer\" - Sends\
-    \ an email message using SMTP each time an event is delivered to it."
+  short: WMI event consumer type.
   type: keyword
 process.Ext.api.parameters.context_flags:
   dashed_name: process-Ext-api-parameters-context-flags
@@ -2995,7 +3082,7 @@ process.Ext.api.parameters.flags:
   normalize: []
   original_fieldset: api
   short: Mode flag that specifies how to interpret the information provided by UsagePage
-    and Usage. Third member RAWINPUTDEVICE structure.
+    and Usage.
   type: keyword
 process.Ext.api.parameters.handle_type:
   dashed_name: process-Ext-api-parameters-handle-type
@@ -3035,6 +3122,17 @@ process.Ext.api.parameters.hook_type:
   original_fieldset: api
   short: Type of hook procedure to be installed.
   type: keyword
+process.Ext.api.parameters.io_control_code:
+  dashed_name: process-Ext-api-parameters-io-control-code
+  description: The I/O control code for the requested device operation.
+  example: 27365
+  flat_name: process.Ext.api.parameters.io_control_code
+  level: custom
+  name: parameters.io_control_code
+  normalize: []
+  original_fieldset: api
+  short: The I/O control code for the requested device operation.
+  type: unsigned_long
 process.Ext.api.parameters.namespace:
   dashed_name: process-Ext-api-parameters-namespace
   description: WMI namespace to which the connection is made.
@@ -3325,7 +3423,7 @@ process.Ext.created_suspended:
   name: Ext.created_suspended
   normalize: []
   short: A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32
-    CreateProcess API. Not valid for direct syscalls.
+    CreateProcess API.
   type: boolean
 process.Ext.memory_region.allocation_base:
   dashed_name: process-Ext-memory-region-allocation-base
@@ -4898,7 +4996,7 @@ process.thread.Ext.call_stack.allocation_private_bytes:
   normalize: []
   original_fieldset: call_stack
   short: The number of bytes in this memory allocation/image that are both +X and
-    non-shareable. Non-zero values can indicate code hooking, patching, or hollowing.
+    non-shareable.
   type: unsigned_long
 process.thread.Ext.call_stack.callsite_leading_bytes:
   dashed_name: process-thread-Ext-call-stack-callsite-leading-bytes
@@ -5001,6 +5099,16 @@ process.thread.Ext.call_stack_final_user_module:
   normalize: []
   short: The final non-win32 module in the call stack.
   type: nested
+process.thread.Ext.call_stack_final_user_module.allocation_private_bytes:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-allocation-private-bytes
+  description: The number of bytes in this memory region that are both +X and non-shareable.
+    Non-zero values can indicate code hooking, patching, or hollowing.
+  flat_name: process.thread.Ext.call_stack_final_user_module.allocation_private_bytes
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.allocation_private_bytes
+  normalize: []
+  short: The number of bytes in this memory region that are both +X and non-shareable.
+  type: unsigned_long
 process.thread.Ext.call_stack_final_user_module.code_signature:
   dashed_name: process-thread-Ext-call-stack-final-user-module-code-signature
   description: Code signature of the call_stack_final_user_module.
@@ -5115,18 +5223,54 @@ process.thread.Ext.call_stack_final_user_module.path:
   normalize: []
   short: The file path of the call_stack_final_user_module.
   type: keyword
+process.thread.Ext.call_stack_final_user_module.protection:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-protection
+  description: The memory protection for the acting region of pages. Corresponds to
+    `MEMORY_BASIC_INFORMATION.Protect`
+  example: RWX
+  flat_name: process.thread.Ext.call_stack_final_user_module.protection
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.protection
+  normalize: []
+  short: The memory protection for the acting region of pages. Corresponds to `MEMORY_BASIC_INFORMATION.Protect`
+  type: keyword
 process.thread.Ext.call_stack_final_user_module.protection_provenance:
   dashed_name: process-thread-Ext-call-stack-final-user-module-protection-provenance
-  description: The name of the memory region that last modified the protection of
-    this page. "Unbacked" may indicate shellcode.
+  description: The name of the memory region that caused the last modification of
+    the protection of this page. "Unbacked" may indicate shellcode.
   example: third_party_hook.dll
   flat_name: process.thread.Ext.call_stack_final_user_module.protection_provenance
   ignore_above: 1024
   level: custom
   name: thread.Ext.call_stack_final_user_module.protection_provenance
   normalize: []
-  short: The name of the memory region that last modified the protection of this page.
-    "Unbacked" may indicate shellcode.
+  short: The name of the memory region that caused the last modification of the protection
+    of this page.
+  type: keyword
+process.thread.Ext.call_stack_final_user_module.protection_provenance_path:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-protection-provenance-path
+  description: The path of the module that caused the last modification the protection
+    of this page.
+  example: C:\Program Files\Hook Inc\third_party_hook.dll
+  flat_name: process.thread.Ext.call_stack_final_user_module.protection_provenance_path
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.protection_provenance_path
+  normalize: []
+  short: The path of the module that caused the last modification the protection of
+    this page.
+  type: keyword
+process.thread.Ext.call_stack_final_user_module.reason:
+  dashed_name: process-thread-Ext-call-stack-final-user-module-reason
+  description: The unexpected call_stack_summary that led to an "Undetermined" protection_provenance.
+  example: ntdll.dll|kernelbase.dll
+  flat_name: process.thread.Ext.call_stack_final_user_module.reason
+  ignore_above: 1024
+  level: custom
+  name: thread.Ext.call_stack_final_user_module.reason
+  normalize: []
+  short: The unexpected call_stack_summary that led to an "Undetermined" protection_provenance.
   type: keyword
 process.thread.Ext.call_stack_summary:
   dashed_name: process-thread-Ext-call-stack-summary

--- a/schemas/v1/file/file.yaml
+++ b/schemas/v1/file/file.yaml
@@ -2588,7 +2588,7 @@ process.thread.Ext.call_stack.allocation_private_bytes:
   normalize: []
   original_fieldset: call_stack
   short: The number of bytes in this memory allocation/image that are both +X and
-    non-shareable. Non-zero values can indicate code hooking, patching, or hollowing.
+    non-shareable.
   type: unsigned_long
 process.thread.Ext.call_stack.callsite_leading_bytes:
   dashed_name: process-thread-Ext-call-stack-callsite-leading-bytes

--- a/schemas/v1/library/library.yaml
+++ b/schemas/v1/library/library.yaml
@@ -2413,7 +2413,7 @@ process.thread.Ext.call_stack.allocation_private_bytes:
   normalize: []
   original_fieldset: call_stack
   short: The number of bytes in this memory allocation/image that are both +X and
-    non-shareable. Non-zero values can indicate code hooking, patching, or hollowing.
+    non-shareable.
   type: unsigned_long
 process.thread.Ext.call_stack.callsite_leading_bytes:
   dashed_name: process-thread-Ext-call-stack-callsite-leading-bytes

--- a/schemas/v1/metadata/metadata.yaml
+++ b/schemas/v1/metadata/metadata.yaml
@@ -37,9 +37,7 @@ Endpoint.configuration:
   level: custom
   name: configuration
   normalize: []
-  short: Configuration fields represent the intended and applied setting for fields
-    not part of a Policy setting This reflects what a given field is configured to
-    do. The actual state of that same field is found in Endpoint.state
+  short: The intended and applied setting for fields not part of a Policy setting
   type: object
 Endpoint.configuration.isolation:
   dashed_name: Endpoint-configuration-isolation
@@ -107,9 +105,7 @@ Endpoint.state:
   level: custom
   name: state
   normalize: []
-  short: Represents the current state of a non-policy setting These fields reflect
-    the current status of a field, which may differ from what it is configured to
-    be (see Endpoint.configuration)
+  short: The current state of a non-policy setting
   type: object
 Endpoint.state.isolation:
   dashed_name: Endpoint-state-isolation

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -1105,8 +1105,8 @@ Endpoint.metrics.system_impact.win32k_events.week_idle_ms:
   level: custom
   name: metrics.system_impact.win32k_events.week_idle_ms
   normalize: []
-  short: The total milliseconds spent queueing ETW Win32k events (currently, only
-    keylogging events) for the process over the last week
+  short: The total milliseconds spent queueing ETW Win32k events for the process over
+    the last week
   type: unsigned_long
 Endpoint.metrics.system_impact.win32k_events.week_ms:
   dashed_name: Endpoint-metrics-system-impact-win32k-events-week-ms
@@ -1118,8 +1118,8 @@ Endpoint.metrics.system_impact.win32k_events.week_ms:
   level: custom
   name: metrics.system_impact.win32k_events.week_ms
   normalize: []
-  short: The total milliseconds spent on ETW Win32k events (currently, only keylogging
-    events) for the process over the last week
+  short: The total milliseconds spent on ETW Win32k events for the process over the
+    last week
   type: unsigned_long
 Endpoint.metrics.threads:
   dashed_name: Endpoint-metrics-threads

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -26,9 +26,7 @@ Endpoint.configuration:
   level: custom
   name: configuration
   normalize: []
-  short: Configuration fields represent the intended and applied setting for fields
-    not part of a Policy setting This reflects what a given field is configured to
-    do. The actual state of that same field is found in Endpoint.state
+  short: The intended and applied setting for fields not part of a Policy setting
   type: object
 Endpoint.configuration.isolation:
   dashed_name: Endpoint-configuration-isolation
@@ -716,9 +714,7 @@ Endpoint.state:
   level: custom
   name: state
   normalize: []
-  short: Represents the current state of a non-policy setting These fields reflect
-    the current status of a field, which may differ from what it is configured to
-    be (see Endpoint.configuration)
+  short: The current state of a non-policy setting
   type: object
 Endpoint.state.isolation:
   dashed_name: Endpoint-state-isolation

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1399,7 +1399,7 @@ process.Ext.created_suspended:
   name: Ext.created_suspended
   normalize: []
   short: A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32
-    CreateProcess API. Not valid for direct syscalls.
+    CreateProcess API.
   type: boolean
 process.Ext.defense_evasions:
   dashed_name: process-Ext-defense-evasions
@@ -2684,7 +2684,7 @@ process.parent.thread.Ext.call_stack.allocation_private_bytes:
   normalize: []
   original_fieldset: call_stack
   short: The number of bytes in this memory allocation/image that are both +X and
-    non-shareable. Non-zero values can indicate code hooking, patching, or hollowing.
+    non-shareable.
   type: unsigned_long
 process.parent.thread.Ext.call_stack.callsite_leading_bytes:
   dashed_name: process-parent-thread-Ext-call-stack-callsite-leading-bytes

--- a/schemas/v1/registry/registry.yaml
+++ b/schemas/v1/registry/registry.yaml
@@ -1603,7 +1603,7 @@ process.thread.Ext.call_stack.allocation_private_bytes:
   normalize: []
   original_fieldset: call_stack
   short: The number of bytes in this memory allocation/image that are both +X and
-    non-shareable. Non-zero values can indicate code hooking, patching, or hollowing.
+    non-shareable.
   type: unsigned_long
 process.thread.Ext.call_stack.callsite_leading_bytes:
   dashed_name: process-thread-Ext-call-stack-callsite-leading-bytes


### PR DESCRIPTION
## Change Summary

* Add new DeviceIoControl event fields
* Add new final_user_module fields
* Add short descriptions for all fields. 

Note - custom documentation has not yet been updated.

### Sample values

```json
{
    "dll": {
        "Ext": {
            "code_signature": [
                {
                    "exists": true,
                    "status": "trusted",
                    "subject_name": "Microsoft Windows",
                    "trusted": true
                }
            ]
        },
        "hash": {
            "sha256": "8b9731a4b83e801cda7b918f8194608e91f86b3a86ffb6bb24230b1cc28e1a54"
        },
        "path": "c:\\windows\\system32\\drivers\\pktmon.sys"
    },
    "message": "Endpoint API event - DeviceIoControl",
    "process": {
        "Ext": {
            "api": {
                "metadata": {
                    "security_descriptor": "O:BAG:SYD:P(A;;FA;;;SY)(A;;FA;;;BA)S:AI(ML;;NW;;;LW)"
                },
                "name": "DeviceIoControl",
                "parameters": {
                    "device": "\\Device\\PktMonDev",
                    "io_control_code": 27365
                },
                "summary": "DeviceIoControl( \\Device\\PktMonDev, 0x6ae5 )"
            }
        }
    }
}
```

```json
"call_stack_final_user_module": {
    "reason": "ntdll.dll|kernel32.dll|ntdll.dll",
    "name": "Undetermined"
}
```

```json
"call_stack_final_user_module": {
    "path": "c:\\program files (x86)\\trend micro\\officescan client\\amsi\\tmamsiprovider.dll",
    "code_signature": [
        {
            "exists": false
        }
    ],
    "protection_provenance_path": "c:\\windows\\assembly\\nativeimages_v4.0.30319_32\\system.core\\dbf5cd6944009aa6004829d5d50a7155\\system.core.ni.dll",
    "name": "tmamsiprovider.dll",
    "protection_provenance": "tmamsiprovider.dll",
    "allocation_private_bytes": 462848,
    "hash": {
        "sha256": "ed50be8e398faf3edb680247c51716807ef6abc1f5052e01354facfe2ecb9372"
    }
}
```

## Release Target

8.16

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
