### PR TITLE
Add winlog.event_data.PrivilegeList to security events

### DIFF
--- a/custom_schemas/custom_winlog.yml
+++ b/custom_schemas/custom_winlog.yml
@@ -1,0 +1,27 @@
+---
+- name: winlog
+  title: Winlog
+  group: 2
+  short: These fields contain information about the Windows Event Log.
+  description: >
+    These fields provide detailed information regarding events logged in the
+    Windows Event Log. The Windows Event Log is a centralized system used by
+    Windows to record events related to system, application, and security
+    activities. Each event log entry is categorized by a specific event type,
+    and contains relevant metadata that can include the event source, event ID,
+    timestamp, user details, and other associated data.
+  type: group
+  fields:
+    - name: event_data
+      level: custom
+      type : object
+      description: >
+        The event-specific data. This is a non-exhaustive list of parameters
+        that are used in Windows events.
+
+    - name: event_data.PrivilegeList
+      level: custom
+      type : keyword
+      description: >
+        An array of sensitive privileges, assigned to the new logon.
+      example: SeTcbPrivilege, SeSecurityPrivilege

--- a/custom_subsets/elastic_endpoint/security/security.yaml
+++ b/custom_subsets/elastic_endpoint/security/security.yaml
@@ -144,3 +144,8 @@ fields:
           Ext:
             fields:
               authentication_id: {}
+  winlog:
+    fields:
+      event_data:
+        fields:
+          PrivilegeList: {}

--- a/package/endpoint/data_stream/security/fields/fields.yml
+++ b/package/endpoint/data_stream/security/fields/fields.yml
@@ -961,3 +961,22 @@
           default_field: false
       description: Short name or login of the user.
       example: a.einstein
+- name: winlog
+  title: Winlog
+  group: 2
+  description: These fields provide detailed information regarding events logged in the Windows Event Log. The Windows Event Log is a centralized system used by Windows to record events related to system, application, and security activities. Each event log entry is categorized by a specific event type, and contains relevant metadata that can include the event source, event ID, timestamp, user details, and other associated data.
+  type: group
+  default_field: true
+  fields:
+    - name: event_data
+      level: custom
+      type: object
+      description: The event-specific data. This is a non-exhaustive list of parameters that are used in Windows events.
+      default_field: false
+    - name: event_data.PrivilegeList
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: An array of sensitive privileges, assigned to the new logon.
+      example: SeTcbPrivilege, SeSecurityPrivilege
+      default_field: false

--- a/package/endpoint/data_stream/security/sample_event.json
+++ b/package/endpoint/data_stream/security/sample_event.json
@@ -104,5 +104,20 @@
         },
         "id": "S-1-5-21-1749029863-1064264096-968553628-1001",
         "name": "Default"
+    },
+    "winlog": {
+        "event_data": {
+            "PrivilegeList": [
+                "SeSecurityPrivilege",
+                "SeTakeOwnershipPrivilege",
+                "SeLoadDriverPrivilege",
+                "SeBackupPrivilege",
+                "SeRestorePrivilege",
+                "SeDebugPrivilege",
+                "SeSystemEnvironmentPrivilege",
+                "SeImpersonatePrivilege",
+                "SeDelegateSessionUserImpersonatePrivilege"
+            ]
+        }
     }
 }

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2750,6 +2750,8 @@ sent by the endpoint.
 | user.hash | Unique user hash to correlate information for a user in anonymized form. Useful if `user.id` or `user.name` contain confidential information and cannot be used. | keyword |
 | user.id | Unique identifier of the user. | keyword |
 | user.name | Short name or login of the user. | keyword |
+| winlog.event_data | The event-specific data. This is a non-exhaustive list of parameters that are used in Windows events. | object |
+| winlog.event_data.PrivilegeList | An array of sensitive privileges, assigned to the new logon. | keyword |
 
 
 ## Metrics

--- a/schemas/v1/security/security.yaml
+++ b/schemas/v1/security/security.yaml
@@ -1985,3 +1985,25 @@ user.name:
   normalize: []
   short: Short name or login of the user.
   type: keyword
+winlog.event_data:
+  dashed_name: winlog-event-data
+  description: The event-specific data. This is a non-exhaustive list of parameters
+    that are used in Windows events.
+  flat_name: winlog.event_data
+  level: custom
+  name: event_data
+  normalize: []
+  short: The event-specific data. This is a non-exhaustive list of parameters that
+    are used in Windows events.
+  type: object
+winlog.event_data.PrivilegeList:
+  dashed_name: winlog-event-data-PrivilegeList
+  description: An array of sensitive privileges, assigned to the new logon.
+  example: SeTcbPrivilege, SeSecurityPrivilege
+  flat_name: winlog.event_data.PrivilegeList
+  ignore_above: 1024
+  level: custom
+  name: event_data.PrivilegeList
+  normalize: []
+  short: An array of sensitive privileges, assigned to the new logon.
+  type: keyword


### PR DESCRIPTION
## Change Summary

This PR adds a custom schema for `winlog` that the security auditing provider produces.

The reason for the uncommon casing is that we're trying to match the field that are defined in `winlogbeat`: https://www.elastic.co/guide/en/beats/winlogbeat/current/exported-fields-winlog.html

## Sample values

Here is an example of the  (`winlog.event_data.PrivilegeList`) that will be added by this PR. 
```json
    "winlog": {
        "event_data": {
            "PrivilegeList": [
                "SeSecurityPrivilege",
                "SeTakeOwnershipPrivilege",
                "SeLoadDriverPrivilege",
                "SeBackupPrivilege",
                "SeRestorePrivilege",
                "SeDebugPrivilege",
                "SeSystemEnvironmentPrivilege",
                "SeImpersonatePrivilege",
                "SeDelegateSessionUserImpersonatePrivilege"
            ]
        }
    }
```

## Release Target

8.16

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes