### PR TITLE
Add custom documentation for ASM events

### DIFF
--- a/custom_documentation/doc/endpoint/api/windows/windows_api_asm.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_asm.md
@@ -1,0 +1,75 @@
+# Windows API
+
+- OS: Windows
+- Data Stream: `logs-endpoint.events.api-*`
+- KQL: `event.dataset : "endpoint.events.api" and event.module : "endpoint" and event.provider : "AttackSurfaceMonitor" and host.os.type : "windows"`
+
+This event is generated when ETW AttackSurfaceMonitor events are generated.
+
+| Field |
+|---|
+| @timestamp |
+| agent.id |
+| agent.type |
+| agent.version |
+| data_stream.dataset |
+| data_stream.namespace |
+| data_stream.type |
+| dll.Ext.code_signature.exists |
+| dll.Ext.code_signature.status |
+| dll.Ext.code_signature.subject_name |
+| dll.Ext.code_signature.trusted |
+| dll.hash.sha256 |
+| dll.path |
+| ecs.version |
+| elastic.agent.id |
+| event.category |
+| event.created |
+| event.dataset |
+| event.id |
+| event.kind |
+| event.module |
+| event.outcome |
+| event.provider |
+| event.sequence |
+| event.type |
+| host.architecture |
+| host.hostname |
+| host.id |
+| host.ip |
+| host.mac |
+| host.name |
+| host.os.Ext.variant |
+| host.os.family |
+| host.os.full |
+| host.os.kernel |
+| host.os.name |
+| host.os.platform |
+| host.os.type |
+| host.os.version |
+| message |
+| process.Ext.api.behaviors |
+| process.Ext.api.name |
+| process.Ext.api.parameters.device |
+| process.Ext.api.parameters.io_control_code |
+| process.Ext.api.summary |
+| process.Ext.code_signature.exists |
+| process.Ext.code_signature.status |
+| process.Ext.code_signature.subject_name |
+| process.Ext.code_signature.trusted |
+| process.Ext.token.integrity_level_name |
+| process.code_signature.exists |
+| process.code_signature.status |
+| process.code_signature.subject_name |
+| process.code_signature.trusted |
+| process.command_line |
+| process.entity_id |
+| process.executable |
+| process.name |
+| process.parent.executable |
+| process.pid |
+| process.thread.id |
+| user.domain |
+| user.id |
+| user.name |
+

--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -95,6 +95,8 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.malicious_behavior_rules.id |
 | Endpoint.metrics.memory.endpoint.private.latest |
 | Endpoint.metrics.memory.endpoint.private.mean |
+| Endpoint.metrics.system_impact.amsi_events.week_idle_ms |
+| Endpoint.metrics.system_impact.amsi_events.week_ms |
 | Endpoint.metrics.system_impact.attack_surface_events.week_idle_ms |
 | Endpoint.metrics.system_impact.attack_surface_events.week_ms |
 | Endpoint.metrics.system_impact.authentication_events.week_idle_ms |

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_asm.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_asm.yaml
@@ -1,0 +1,78 @@
+overview:
+  name: Windows API
+  description: This event is generated when ETW AttackSurfaceMonitor events are generated.
+identification:
+  filter:
+    event.dataset: endpoint.events.api
+    event.module: endpoint
+    event.provider: AttackSurfaceMonitor
+    host.os.type: windows
+  os:
+  - windows
+  data_stream: logs-endpoint.events.api-*
+fields:
+  endpoint:
+  - '@timestamp'
+  - agent.id
+  - agent.type
+  - agent.version
+  - data_stream.dataset
+  - data_stream.namespace
+  - data_stream.type
+  - dll.Ext.code_signature.exists
+  - dll.Ext.code_signature.status
+  - dll.Ext.code_signature.subject_name
+  - dll.Ext.code_signature.trusted
+  - dll.hash.sha256
+  - dll.path
+  - ecs.version
+  - elastic.agent.id
+  - event.category
+  - event.created
+  - event.dataset
+  - event.id
+  - event.kind
+  - event.module
+  - event.outcome
+  - event.provider
+  - event.sequence
+  - event.type
+  - host.architecture
+  - host.hostname
+  - host.id
+  - host.ip
+  - host.mac
+  - host.name
+  - host.os.Ext.variant
+  - host.os.family
+  - host.os.full
+  - host.os.kernel
+  - host.os.name
+  - host.os.platform
+  - host.os.type
+  - host.os.version
+  - message
+  - process.Ext.api.behaviors
+  - process.Ext.api.name
+  - process.Ext.api.parameters.device
+  - process.Ext.api.parameters.io_control_code
+  - process.Ext.api.summary
+  - process.Ext.code_signature.exists
+  - process.Ext.code_signature.status
+  - process.Ext.code_signature.subject_name
+  - process.Ext.code_signature.trusted
+  - process.Ext.token.integrity_level_name
+  - process.code_signature.exists
+  - process.code_signature.status
+  - process.code_signature.subject_name
+  - process.code_signature.trusted
+  - process.command_line
+  - process.entity_id
+  - process.executable
+  - process.name
+  - process.parent.executable
+  - process.pid
+  - process.thread.id
+  - user.domain
+  - user.id
+  - user.name

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -102,6 +102,8 @@ fields:
   - Endpoint.metrics.malicious_behavior_rules.id
   - Endpoint.metrics.memory.endpoint.private.latest
   - Endpoint.metrics.memory.endpoint.private.mean
+  - Endpoint.metrics.system_impact.amsi_events.week_idle_ms
+  - Endpoint.metrics.system_impact.amsi_events.week_ms
   - Endpoint.metrics.system_impact.attack_surface_events.week_idle_ms
   - Endpoint.metrics.system_impact.attack_surface_events.week_ms
   - Endpoint.metrics.system_impact.authentication_events.week_idle_ms


### PR DESCRIPTION
## Change Summary

Adds custom documentation for ETW AttackSurfaceMonitor based events.
This PR also adds the followings to the metric custom documentation.

* `Endpoint.metrics.system_impact.amsi_events.week_idle_ms`
* `Endpoint.metrics.system_impact.amsi_events.week_ms`

## Release Target

8.16

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
