### PR TITLE
[8.18] Add new memory region field (region_start_bytes)

### DIFF
--- a/custom_documentation/doc/endpoint/alerts/windows/windows_memory_threat_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_memory_threat_alert.md
@@ -78,6 +78,7 @@ This alert is generated when a Memory Threat alert occurs.
 | process.Ext.memory_region.region_base |
 | process.Ext.memory_region.region_protection |
 | process.Ext.memory_region.region_size |
+| process.Ext.memory_region.region_start_bytes |
 | process.Ext.memory_region.region_state |
 | process.Ext.protection |
 | process.Ext.token.domain |

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_memory_threat_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_memory_threat_alert.yaml
@@ -83,6 +83,7 @@ fields:
   - process.Ext.memory_region.region_base
   - process.Ext.memory_region.region_protection
   - process.Ext.memory_region.region_size
+  - process.Ext.memory_region.region_start_bytes
   - process.Ext.memory_region.region_state
   - process.Ext.protection
   - process.Ext.token.domain

--- a/custom_schemas/custom_memory_region.yml
+++ b/custom_schemas/custom_memory_region.yml
@@ -113,7 +113,7 @@
       description: >
         Size of the memory region.
 
-    - name: region_start_byte
+    - name: region_start_bytes
       level: custom
       type: keyword
       example: "4d5a90000300000004000000ffff0000b8000000000000004000000000000000"

--- a/custom_schemas/custom_memory_region.yml
+++ b/custom_schemas/custom_memory_region.yml
@@ -118,7 +118,7 @@
       type: keyword
       example: "4d5a90000300000004000000ffff0000b8000000000000004000000000000000"
       description: >
-        A few (typically 32) raw bytes at the region base address.
+        First 32 bytes at the region base address.
         
     - name: region_state
       level: custom

--- a/custom_schemas/custom_memory_region.yml
+++ b/custom_schemas/custom_memory_region.yml
@@ -112,6 +112,13 @@
       example: 4096
       description: >
         Size of the memory region.
+
+    - name: region_start_byte
+      level: custom
+      type: keyword
+      example: "4d5a90000300000004000000ffff0000b8000000000000004000000000000000"
+      description: >
+        A few (typically 32) raw bytes at the region base address.
         
     - name: region_state
       level: custom

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -772,7 +772,7 @@
       level: custom
       type: keyword
       ignore_above: 1024
-      description: A few (typically 32) raw bytes at the region base address.
+      description: First 32 bytes at the region base address.
       example: 4d5a90000300000004000000ffff0000b8000000000000004000000000000000
       default_field: false
     - name: process.Ext.memory_region.region_state
@@ -2487,7 +2487,7 @@
       level: custom
       type: keyword
       ignore_above: 1024
-      description: A few (typically 32) raw bytes at the region base address.
+      description: First 32 bytes at the region base address.
       example: 4d5a90000300000004000000ffff0000b8000000000000004000000000000000
       default_field: false
     - name: Ext.memory_region.region_state

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -768,6 +768,13 @@
       description: Size of the memory region.
       example: 4096
       default_field: false
+    - name: process.Ext.memory_region.region_start_bytes
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: A few (typically 32) raw bytes at the region base address.
+      example: 4d5a90000300000004000000ffff0000b8000000000000004000000000000000
+      default_field: false
     - name: process.Ext.memory_region.region_state
       level: custom
       type: keyword
@@ -2475,6 +2482,13 @@
       type: unsigned_long
       description: Size of the memory region.
       example: 4096
+      default_field: false
+    - name: Ext.memory_region.region_start_bytes
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: A few (typically 32) raw bytes at the region base address.
+      example: 4d5a90000300000004000000ffff0000b8000000000000004000000000000000
       default_field: false
     - name: Ext.memory_region.region_state
       level: custom

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -1382,7 +1382,7 @@ Target.process.Ext.memory_region.region_size:
   type: unsigned_long
 Target.process.Ext.memory_region.region_start_bytes:
   dashed_name: Target-process-Ext-memory-region-region-start-bytes
-  description: A few (typically 32) raw bytes at the region base address.
+  description: First 32 bytes at the region base address.
   example: 4d5a90000300000004000000ffff0000b8000000000000004000000000000000
   flat_name: Target.process.Ext.memory_region.region_start_bytes
   ignore_above: 1024
@@ -1390,7 +1390,7 @@ Target.process.Ext.memory_region.region_start_bytes:
   name: region_start_bytes
   normalize: []
   original_fieldset: memory_region
-  short: A few (typically 32) raw bytes at the region base address.
+  short: First 32 bytes at the region base address.
   type: keyword
 Target.process.Ext.memory_region.region_state:
   dashed_name: Target-process-Ext-memory-region-region-state
@@ -4795,7 +4795,7 @@ process.Ext.memory_region.region_size:
   type: unsigned_long
 process.Ext.memory_region.region_start_bytes:
   dashed_name: process-Ext-memory-region-region-start-bytes
-  description: A few (typically 32) raw bytes at the region base address.
+  description: First 32 bytes at the region base address.
   example: 4d5a90000300000004000000ffff0000b8000000000000004000000000000000
   flat_name: process.Ext.memory_region.region_start_bytes
   ignore_above: 1024
@@ -4803,7 +4803,7 @@ process.Ext.memory_region.region_start_bytes:
   name: region_start_bytes
   normalize: []
   original_fieldset: memory_region
-  short: A few (typically 32) raw bytes at the region base address.
+  short: First 32 bytes at the region base address.
   type: keyword
 process.Ext.memory_region.region_state:
   dashed_name: process-Ext-memory-region-region-state

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -1380,6 +1380,18 @@ Target.process.Ext.memory_region.region_size:
   original_fieldset: memory_region
   short: Size of the memory region.
   type: unsigned_long
+Target.process.Ext.memory_region.region_start_bytes:
+  dashed_name: Target-process-Ext-memory-region-region-start-bytes
+  description: A few (typically 32) raw bytes at the region base address.
+  example: 4d5a90000300000004000000ffff0000b8000000000000004000000000000000
+  flat_name: Target.process.Ext.memory_region.region_start_bytes
+  ignore_above: 1024
+  level: custom
+  name: region_start_bytes
+  normalize: []
+  original_fieldset: memory_region
+  short: A few (typically 32) raw bytes at the region base address.
+  type: keyword
 Target.process.Ext.memory_region.region_state:
   dashed_name: Target-process-Ext-memory-region-region-state
   description: State of the memory region. Example values include "RESERVE", "COMMIT",
@@ -4781,6 +4793,18 @@ process.Ext.memory_region.region_size:
   original_fieldset: memory_region
   short: Size of the memory region.
   type: unsigned_long
+process.Ext.memory_region.region_start_bytes:
+  dashed_name: process-Ext-memory-region-region-start-bytes
+  description: A few (typically 32) raw bytes at the region base address.
+  example: 4d5a90000300000004000000ffff0000b8000000000000004000000000000000
+  flat_name: process.Ext.memory_region.region_start_bytes
+  ignore_above: 1024
+  level: custom
+  name: region_start_bytes
+  normalize: []
+  original_fieldset: memory_region
+  short: A few (typically 32) raw bytes at the region base address.
+  type: keyword
 process.Ext.memory_region.region_state:
   dashed_name: process-Ext-memory-region-region-state
   description: State of the memory region. Example values include "RESERVE", "COMMIT",


### PR DESCRIPTION
## Change Summary

This PR adds the following fileds.

* process.Ext.memory_region.region_start_bytes

This field is intended for use within Windows memory signature alerts

### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->

```
    "message": "Memory Threat Detection Alert: Multi.EICAR.Not-a-virus",
    "process": {
        "Ext": {
            "ancestry": [
                "pPVZfPJXb3LwUZ6tFZ8cNA",
                "zkRe4BMHSS5W62hRN/nEhw",
                "oMfl23/bSjrkV8n+vJdWKQ",
                "/kph1ryYQOxMtjxrL99sxQ",
                "tfZhGzm7UQh2y/dLc5PM5g"
            ],
            "architecture": "x86_64",
            "code_signature": [
                {
                    "exists": false
                }
            ],
            "memory_region": {
                "allocation_base": 6442450944,
                "allocation_protection": "RW-",
                "allocation_size": 110592,
                "allocation_type": "PRIVATE",
                "bytes_address": 6442450944,
                "bytes_allocation_offset": 0,
                "bytes_compressed_present": false,
                "malware_signature": {
                    "all_names": "Multi.EICAR.Not-a-virus",
                    "identifier": "diagnostic-malware-signature-v1-windows",
                    "primary": {
                        "matches": [
                            "WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5EQVJELUFOVElWSVJVUy1URVNULUZJTEUhJEgrSCo="
                        ],
                        "signature": {
                            "hash": {
                                "sha256": "bb0e0bdf70ec65d98f652e2428e3567013d5413f2725a2905b372fd18da8b9dd"
                            },
                            "id": "ac8f42d6-52da-46ec-8db1-5a5f69222a38",
                            "name": "Multi.EICAR.Not-a-virus"
                        }
                    },
                    "secondary": [],
                    "version": "1.0.70"
                },
                "region_base": 6442536960,
                "region_protection": "RW-",
                "region_size": 8192,
                "region_start_bytes": "58354f2150254041505b345c505a58353428505e2937434329377d2445494341",
                "region_state": "COMMIT"
            },
```

## Release Target

8.18

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
<s>- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))</s> -> `process.Ext.memory_region` is already included in the kibana filter list.  https://github.com/elastic/kibana/blob/main/x-pack/solutions/security/plugins/security_solution/server/lib/telemetry/filterlists/endpoint_alerts.ts