### PR TITLE
global artifacts rollout channel

### DIFF
--- a/custom_documentation/doc/endpoint/alerts/linux/linux_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/linux/linux_malicious_behavior_alert.md
@@ -10,6 +10,7 @@ This alert is generated when a Malicious Behavior alert occurs.
 | Field |
 |---|
 | @timestamp |
+| Endpoint.policy.applied.artifacts.global.channel |
 | Endpoint.policy.applied.artifacts.global.identifiers.name |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.global.snapshot |

--- a/custom_documentation/doc/endpoint/alerts/linux/linux_malware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/linux/linux_malware_alert.md
@@ -10,6 +10,7 @@ This alert is generated when a Malware alert occurs.
 | Field |
 |---|
 | @timestamp |
+| Endpoint.policy.applied.artifacts.global.channel |
 | Endpoint.policy.applied.artifacts.global.identifiers.name |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.global.snapshot |

--- a/custom_documentation/doc/endpoint/alerts/linux/linux_memory_threat_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/linux/linux_memory_threat_alert.md
@@ -10,6 +10,7 @@ This alert is generated when a Memory Threat alert occurs.
 | Field |
 |---|
 | @timestamp |
+| Endpoint.policy.applied.artifacts.global.channel |
 | Endpoint.policy.applied.artifacts.global.identifiers.name |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.global.snapshot |

--- a/custom_documentation/doc/endpoint/alerts/macos/macos_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/macos/macos_malicious_behavior_alert.md
@@ -14,6 +14,7 @@ This alert is generated when a Malicious Behavior alert occurs.
 | Effective_process.executable |
 | Effective_process.name |
 | Effective_process.pid |
+| Endpoint.policy.applied.artifacts.global.channel |
 | Endpoint.policy.applied.artifacts.global.identifiers.name |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.global.snapshot |

--- a/custom_documentation/doc/endpoint/alerts/macos/macos_malware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/macos/macos_malware_alert.md
@@ -10,6 +10,7 @@ This alert is generated when a macOS Malware alert occurs.
 | Field |
 |---|
 | @timestamp |
+| Endpoint.policy.applied.artifacts.global.channel |
 | Endpoint.policy.applied.artifacts.global.identifiers.name |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.global.snapshot |

--- a/custom_documentation/doc/endpoint/alerts/macos/macos_memory_threat_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/macos/macos_memory_threat_alert.md
@@ -10,6 +10,7 @@ This alert is generated when a macOS Memory Thread alert occurs.
 | Field |
 |---|
 | @timestamp |
+| Endpoint.policy.applied.artifacts.global.channel |
 | Endpoint.policy.applied.artifacts.global.identifiers.name |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.global.snapshot |

--- a/custom_documentation/doc/endpoint/alerts/windows/windows_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_malicious_behavior_alert.md
@@ -10,6 +10,7 @@ This alert occurs when a Malicious Behavior alert occurs.
 | Field |
 |---|
 | @timestamp |
+| Endpoint.policy.applied.artifacts.global.channel |
 | Endpoint.policy.applied.artifacts.global.identifiers.name |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.global.snapshot |

--- a/custom_documentation/doc/endpoint/alerts/windows/windows_malware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_malware_alert.md
@@ -10,6 +10,7 @@ This alert is generated when a Malware alert occurs.
 | Field |
 |---|
 | @timestamp |
+| Endpoint.policy.applied.artifacts.global.channel |
 | Endpoint.policy.applied.artifacts.global.identifiers.name |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.global.snapshot |

--- a/custom_documentation/doc/endpoint/alerts/windows/windows_memory_threat_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_memory_threat_alert.md
@@ -10,6 +10,7 @@ This alert is generated when a Memory Threat alert occurs.
 | Field |
 |---|
 | @timestamp |
+| Endpoint.policy.applied.artifacts.global.channel |
 | Endpoint.policy.applied.artifacts.global.identifiers.name |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.global.snapshot |

--- a/custom_documentation/doc/endpoint/alerts/windows/windows_ransomware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_ransomware_alert.md
@@ -10,6 +10,7 @@ This alert is generated when a Ransomware alert occurs.
 | Field |
 |---|
 | @timestamp |
+| Endpoint.policy.applied.artifacts.global.channel |
 | Endpoint.policy.applied.artifacts.global.identifiers.name |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.global.snapshot |

--- a/custom_documentation/doc/endpoint/alerts/windows/windows_shellcode_thread.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_shellcode_thread.md
@@ -10,6 +10,7 @@ This alert is generated when a Shellcode Threat alert occurs.
 | Field |
 |---|
 | @timestamp |
+| Endpoint.policy.applied.artifacts.global.channel |
 | Endpoint.policy.applied.artifacts.global.identifiers.name |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.global.snapshot |

--- a/custom_documentation/doc/endpoint/network/macos/macos_network_connection_attempted_and_disconnect.md
+++ b/custom_documentation/doc/endpoint/network/macos/macos_network_connection_attempted_and_disconnect.md
@@ -18,9 +18,9 @@ This event is generated when a connection is attempted or a request to terminate
 | data_stream.type |
 | destination.address |
 | destination.bytes |
+| destination.domain |
 | destination.ip |
 | destination.port |
-| destination.domain |
 | ecs.version |
 | elastic.agent.id |
 | event.action |

--- a/custom_documentation/doc/endpoint/network/macos/macos_network_dns_lookup_result.md
+++ b/custom_documentation/doc/endpoint/network/macos/macos_network_dns_lookup_result.md
@@ -19,6 +19,11 @@ This event is generated when results are returned for a DNS lookup request.
 | destination.address |
 | destination.ip |
 | destination.port |
+| dns.Ext.options |
+| dns.Ext.status |
+| dns.question.name |
+| dns.question.type |
+| dns.resolved_ip |
 | ecs.version |
 | elastic.agent.id |
 | event.action |
@@ -50,9 +55,9 @@ This event is generated when results are returned for a DNS lookup request.
 | host.os.type |
 | host.os.version |
 | message |
+| network.protocol |
 | network.transport |
 | network.type |
-| network.protocol |
 | process.Ext.ancestry |
 | process.code_signature.exists |
 | process.code_signature.signing_id |
@@ -73,9 +78,4 @@ This event is generated when results are returned for a DNS lookup request.
 | user.Ext.real.name |
 | user.id |
 | user.name |
-| dns.Ext.options |
-| dns.Ext.status |
-| dns.question.name |
-| dns.resolved_ip |
-| dns.question.type |
 

--- a/custom_documentation/doc/endpoint/policy/policy_response.md
+++ b/custom_documentation/doc/endpoint/policy/policy_response.md
@@ -15,6 +15,7 @@ This is a state management document that is generated every time Endpoint refres
 | Endpoint.policy.applied.actions.name |
 | Endpoint.policy.applied.actions.status |
 | Endpoint.policy.applied.actions.status |
+| Endpoint.policy.applied.artifacts.global.channel |
 | Endpoint.policy.applied.artifacts.global.identifiers.name |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.global.snapshot |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_memfd_create.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_memfd_create.md
@@ -35,6 +35,13 @@ This event is generated when when a memfd anonymous file is created.
 | host.name |
 | host.os.type |
 | message |
+| process.Ext.memfd.flag_allow_seal |
+| process.Ext.memfd.flag_cloexec |
+| process.Ext.memfd.flag_exec |
+| process.Ext.memfd.flag_hugetlb |
+| process.Ext.memfd.flag_noexec_seal |
+| process.Ext.memfd.flags |
+| process.Ext.memfd.name |
 | process.args |
 | process.args_count |
 | process.command_line |
@@ -43,13 +50,6 @@ This event is generated when when a memfd anonymous file is created.
 | process.entry_leader.parent.pid |
 | process.entry_leader.parent.start |
 | process.executable |
-| process.Ext.memfd.flag_hugetlb |
-| process.Ext.memfd.flag_allow_seal |
-| process.Ext.memfd.flags |
-| process.Ext.memfd.name |
-| process.Ext.memfd.flag_exec |
-| process.Ext.memfd.flag_cloexec |
-| process.Ext.memfd.flag_noexec_seal |
 | process.group.id |
 | process.group.name |
 | process.group_leader.args |

--- a/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malicious_behavior_alert.yaml
@@ -15,6 +15,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Endpoint.policy.applied.artifacts.global.channel
   - Endpoint.policy.applied.artifacts.global.identifiers.name
   - Endpoint.policy.applied.artifacts.global.identifiers.sha256
   - Endpoint.policy.applied.artifacts.global.snapshot

--- a/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malware_alert.yaml
@@ -15,6 +15,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Endpoint.policy.applied.artifacts.global.channel
   - Endpoint.policy.applied.artifacts.global.identifiers.name
   - Endpoint.policy.applied.artifacts.global.identifiers.sha256
   - Endpoint.policy.applied.artifacts.global.snapshot

--- a/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_memory_threat_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_memory_threat_alert.yaml
@@ -15,6 +15,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Endpoint.policy.applied.artifacts.global.channel
   - Endpoint.policy.applied.artifacts.global.identifiers.name
   - Endpoint.policy.applied.artifacts.global.identifiers.sha256
   - Endpoint.policy.applied.artifacts.global.snapshot

--- a/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malicious_behavior_alert.yaml
@@ -19,6 +19,7 @@ fields:
   - Effective_process.executable
   - Effective_process.name
   - Effective_process.pid
+  - Endpoint.policy.applied.artifacts.global.channel
   - Endpoint.policy.applied.artifacts.global.identifiers.name
   - Endpoint.policy.applied.artifacts.global.identifiers.sha256
   - Endpoint.policy.applied.artifacts.global.snapshot

--- a/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malware_alert.yaml
@@ -15,6 +15,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Endpoint.policy.applied.artifacts.global.channel
   - Endpoint.policy.applied.artifacts.global.identifiers.name
   - Endpoint.policy.applied.artifacts.global.identifiers.sha256
   - Endpoint.policy.applied.artifacts.global.snapshot

--- a/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_memory_threat_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_memory_threat_alert.yaml
@@ -15,6 +15,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Endpoint.policy.applied.artifacts.global.channel
   - Endpoint.policy.applied.artifacts.global.identifiers.name
   - Endpoint.policy.applied.artifacts.global.identifiers.sha256
   - Endpoint.policy.applied.artifacts.global.snapshot

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malicious_behavior_alert.yaml
@@ -15,6 +15,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Endpoint.policy.applied.artifacts.global.channel
   - Endpoint.policy.applied.artifacts.global.identifiers.name
   - Endpoint.policy.applied.artifacts.global.identifiers.sha256
   - Endpoint.policy.applied.artifacts.global.snapshot

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malware_alert.yaml
@@ -15,6 +15,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Endpoint.policy.applied.artifacts.global.channel
   - Endpoint.policy.applied.artifacts.global.identifiers.name
   - Endpoint.policy.applied.artifacts.global.identifiers.sha256
   - Endpoint.policy.applied.artifacts.global.snapshot

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_memory_threat_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_memory_threat_alert.yaml
@@ -15,6 +15,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Endpoint.policy.applied.artifacts.global.channel
   - Endpoint.policy.applied.artifacts.global.identifiers.name
   - Endpoint.policy.applied.artifacts.global.identifiers.sha256
   - Endpoint.policy.applied.artifacts.global.snapshot

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_ransomware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_ransomware_alert.yaml
@@ -15,6 +15,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Endpoint.policy.applied.artifacts.global.channel
   - Endpoint.policy.applied.artifacts.global.identifiers.name
   - Endpoint.policy.applied.artifacts.global.identifiers.sha256
   - Endpoint.policy.applied.artifacts.global.snapshot

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_shellcode_thread.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_shellcode_thread.yaml
@@ -15,6 +15,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Endpoint.policy.applied.artifacts.global.channel
   - Endpoint.policy.applied.artifacts.global.identifiers.name
   - Endpoint.policy.applied.artifacts.global.identifiers.sha256
   - Endpoint.policy.applied.artifacts.global.snapshot

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_kernel_audit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_kernel_audit.yaml
@@ -1,6 +1,7 @@
 overview:
   name: Windows API
-  description: This event is generated when ETW Microsoft-Windows-Kernel-Audit-API-Calls events are generated.
+  description: This event is generated when ETW Microsoft-Windows-Kernel-Audit-API-Calls
+    events are generated.
 identification:
   filter:
     event.dataset: endpoint.events.api

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_tcpip.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_tcpip.yaml
@@ -1,6 +1,7 @@
 overview:
   name: Windows API
-  description: This event is generated when ETW Microsoft-Windows-TCPIP events are generated.
+  description: This event is generated when ETW Microsoft-Windows-TCPIP events are
+    generated.
 identification:
   filter:
     event.dataset: endpoint.events.api

--- a/custom_documentation/src/endpoint/data_stream/network/linux/linux_network_attempted_accepted_and_disconnect.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/linux/linux_network_attempted_accepted_and_disconnect.yaml
@@ -1,6 +1,7 @@
 overview:
   name: Linux Network Connection Attempted, Connection Accepted, and Disconnect
-  description: 'This event is generated when a network session is accepted, attempted or terminated.
+  description: 'This event is generated when a network session is accepted, attempted
+    or terminated.
 
     '
 identification:

--- a/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_connection_attempted_and_disconnect.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_connection_attempted_and_disconnect.yaml
@@ -1,7 +1,7 @@
 overview:
   name: macOS Network Connection Attempted and Disconnect Received
-  description: 'This event is generated when a connection is attempted or a request to terminate a network connection
-    occurs.
+  description: 'This event is generated when a connection is attempted or a request
+    to terminate a network connection occurs.
 
     '
 identification:
@@ -26,9 +26,9 @@ fields:
   - data_stream.type
   - destination.address
   - destination.bytes
+  - destination.domain
   - destination.ip
   - destination.port
-  - destination.domain
   - ecs.version
   - elastic.agent.id
   - event.action

--- a/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_dns_lookup_result.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_dns_lookup_result.yaml
@@ -25,6 +25,11 @@ fields:
   - destination.address
   - destination.ip
   - destination.port
+  - dns.Ext.options
+  - dns.Ext.status
+  - dns.question.name
+  - dns.question.type
+  - dns.resolved_ip
   - ecs.version
   - elastic.agent.id
   - event.action
@@ -56,9 +61,9 @@ fields:
   - host.os.type
   - host.os.version
   - message
+  - network.protocol
   - network.transport
   - network.type
-  - network.protocol
   - process.Ext.ancestry
   - process.code_signature.exists
   - process.code_signature.signing_id
@@ -79,8 +84,3 @@ fields:
   - user.Ext.real.name
   - user.id
   - user.name
-  - dns.Ext.options
-  - dns.Ext.status
-  - dns.question.name
-  - dns.resolved_ip
-  - dns.question.type

--- a/custom_documentation/src/endpoint/data_stream/network/windows/windows_network_attempted_accepted_and_disconnect.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/windows/windows_network_attempted_accepted_and_disconnect.yaml
@@ -1,7 +1,7 @@
 overview:
   name: Windows Network Connection Attempted, Connection Accepted and Disconnect Received
-  description: 'This event is generated when a connection is attempted, a connection is accepted, or a request to terminate a network session
-    is received.
+  description: 'This event is generated when a connection is attempted, a connection
+    is accepted, or a request to terminate a network session is received.
 
     '
 identification:

--- a/custom_documentation/src/endpoint/data_stream/policy/policy_response.yaml
+++ b/custom_documentation/src/endpoint/data_stream/policy/policy_response.yaml
@@ -23,6 +23,7 @@ fields:
   - Endpoint.policy.applied.actions.name
   - Endpoint.policy.applied.actions.status
   - Endpoint.policy.applied.actions.status
+  - Endpoint.policy.applied.artifacts.global.channel
   - Endpoint.policy.applied.artifacts.global.identifiers.name
   - Endpoint.policy.applied.artifacts.global.identifiers.sha256
   - Endpoint.policy.applied.artifacts.global.snapshot

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_fork_exec_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_fork_exec_exit.yaml
@@ -1,6 +1,7 @@
 overview:
   name: Linux Process Fork, Exec, and Exit
-  description: 'This event is generated when a process calls `fork()`, `exec()`, exits, or an aggregation of the previous.
+  description: 'This event is generated when a process calls `fork()`, `exec()`, exits,
+    or an aggregation of the previous.
 
     '
 identification:

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_memfd_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_memfd_create.yaml
@@ -1,6 +1,6 @@
 overview:
   name: Linux memfd Creation Events
-  description: 'This event is generated when when a memfd anonymous file is created.'
+  description: This event is generated when when a memfd anonymous file is created.
 identification:
   filter:
     event.action: memfd_create
@@ -12,8 +12,8 @@ identification:
   data_stream: logs-endpoint.events.process-*
 fields:
   endpoint:
-  - '@timestamp' 
-  - agent.id 
+  - '@timestamp'
+  - agent.id
   - agent.type
   - agent.version
   - data_stream.dataset
@@ -29,16 +29,23 @@ fields:
   - event.kind
   - event.module
   - event.outcome
-  - event.sequence 
+  - event.sequence
   - event.type
-  - group.Ext.real.id 
+  - group.Ext.real.id
   - group.Ext.real.name
   - group.id
-  - group.name 
+  - group.name
   - host.id
   - host.name
   - host.os.type
   - message
+  - process.Ext.memfd.flag_allow_seal
+  - process.Ext.memfd.flag_cloexec
+  - process.Ext.memfd.flag_exec
+  - process.Ext.memfd.flag_hugetlb
+  - process.Ext.memfd.flag_noexec_seal
+  - process.Ext.memfd.flags
+  - process.Ext.memfd.name
   - process.args
   - process.args_count
   - process.command_line
@@ -47,13 +54,6 @@ fields:
   - process.entry_leader.parent.pid
   - process.entry_leader.parent.start
   - process.executable
-  - process.Ext.memfd.flag_hugetlb
-  - process.Ext.memfd.flag_allow_seal
-  - process.Ext.memfd.flags
-  - process.Ext.memfd.name
-  - process.Ext.memfd.flag_exec
-  - process.Ext.memfd.flag_cloexec
-  - process.Ext.memfd.flag_noexec_seal
   - process.group.id
   - process.group.name
   - process.group_leader.args
@@ -75,24 +75,24 @@ fields:
   - process.group_leader.user.name
   - process.group_leader.working_directory
   - process.hash.sha256
-  - process.interactive 
-  - process.name 
-  - process.parent.args_count 
-  - process.parent.pid 
-  - process.pid 
-  - process.real_group.id 
-  - process.real_group.name 
+  - process.interactive
+  - process.name
+  - process.parent.args_count
+  - process.parent.pid
+  - process.pid
+  - process.real_group.id
+  - process.real_group.name
   - process.real_user.id
   - process.real_user.name
   - process.session_leader.args
   - process.session_leader.args_count
-  - process.session_leader.entity_id 
-  - process.session_leader.executable 
+  - process.session_leader.entity_id
+  - process.session_leader.executable
   - process.session_leader.group.id
   - process.session_leader.group.name
-  - process.session_leader.interactive 
+  - process.session_leader.interactive
   - process.session_leader.name
-  - process.session_leader.pid 
+  - process.session_leader.pid
   - process.session_leader.real_group.id
   - process.session_leader.real_group.name
   - process.session_leader.real_user.id
@@ -107,6 +107,6 @@ fields:
   - process.user.name
   - process.working_directory
   - user.Ext.real.id
-  - user.Ext.real.name 
+  - user.Ext.real.name
   - user.id
   - user.name

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork_exec_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork_exec_exit.yaml
@@ -1,6 +1,7 @@
 overview:
   name: macOS Process Fork, Exec, and Exit
-  description: 'This event is generated when a process calls `fork()`, `exec()`, or exits.
+  description: 'This event is generated when a process calls `fork()`, `exec()`, or
+    exits.
 
     '
 identification:

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create_and_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create_and_exit.yaml
@@ -6,8 +6,8 @@ overview:
 identification:
   filter:
     event.action:
-        - start
-        - end
+    - start
+    - end
     event.dataset: endpoint.events.process
     event.module: endpoint
     host.os.type: windows

--- a/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
@@ -74,4 +74,3 @@ fields:
   - user.id
   - user.name
   - winlog.event_data.PrivilegeList
-

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -335,6 +335,11 @@
       type: object
       description: information about global protection artifacts applied.
 
+    - name: policy.applied.artifacts.global.channel
+      level: custom
+      type: keyword
+      description: global artifacts rollout channel
+
     - name: policy.applied.artifacts.global.update_age
       level: custom
       type: unsigned_long

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -52,6 +52,12 @@
       type: object
       description: information about global protection artifacts applied.
       default_field: false
+    - name: policy.applied.artifacts.global.channel
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: global artifacts rollout channel
+      default_field: false
     - name: policy.applied.artifacts.global.identifiers
       level: custom
       type: nested

--- a/package/endpoint/data_stream/policy/fields/fields.yml
+++ b/package/endpoint/data_stream/policy/fields/fields.yml
@@ -82,6 +82,12 @@
       type: object
       description: information about global protection artifacts applied.
       default_field: false
+    - name: policy.applied.artifacts.global.channel
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: global artifacts rollout channel
+      default_field: false
     - name: policy.applied.artifacts.global.identifiers
       level: custom
       type: nested

--- a/package/endpoint/data_stream/policy/sample_event.json
+++ b/package/endpoint/data_stream/policy/sample_event.json
@@ -459,6 +459,7 @@
                 "version": "2",
                 "artifacts": {
                     "global": {
+                        "channel": "stable",
                         "identifiers": [
                             {
                                 "sha256": "e57a7d5638060e9655c64ac1d02f7949b87e5f5f27f2074329608db1e06d645b",

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -32,6 +32,7 @@ sent by the endpoint.
 | Endpoint.policy.applied | information about the policy that is applied | object |
 | Endpoint.policy.applied.artifacts | information about protection artifacts applied. | object |
 | Endpoint.policy.applied.artifacts.global | information about global protection artifacts applied. | object |
+| Endpoint.policy.applied.artifacts.global.channel | global artifacts rollout channel | keyword |
 | Endpoint.policy.applied.artifacts.global.identifiers | the identifiers of global artifacts applied. | nested |
 | Endpoint.policy.applied.artifacts.global.identifiers.name | the name of global artifact applied. | keyword |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 | the sha256 of global artifacts applied. | keyword |
@@ -2964,6 +2965,7 @@ Metrics documents contain performance information about the endpoint executable 
 | Endpoint.policy.applied | information about the policy that is applied | object |
 | Endpoint.policy.applied.artifacts | information about protection artifacts applied. | object |
 | Endpoint.policy.applied.artifacts.global | information about global protection artifacts applied. | object |
+| Endpoint.policy.applied.artifacts.global.channel | global artifacts rollout channel | keyword |
 | Endpoint.policy.applied.artifacts.global.identifiers | the identifiers of global artifacts applied. | nested |
 | Endpoint.policy.applied.artifacts.global.identifiers.name | the name of global artifact applied. | keyword |
 | Endpoint.policy.applied.artifacts.global.identifiers.sha256 | the sha256 of global artifacts applied. | keyword |

--- a/schemas/v1/alerts/malware_event.yaml
+++ b/schemas/v1/alerts/malware_event.yaml
@@ -53,6 +53,16 @@ Endpoint.policy.applied.artifacts.global:
   normalize: []
   short: information about global protection artifacts applied.
   type: object
+Endpoint.policy.applied.artifacts.global.channel:
+  dashed_name: Endpoint-policy-applied-artifacts-global-channel
+  description: global artifacts rollout channel
+  flat_name: Endpoint.policy.applied.artifacts.global.channel
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.artifacts.global.channel
+  normalize: []
+  short: global artifacts rollout channel
+  type: keyword
 Endpoint.policy.applied.artifacts.global.identifiers:
   dashed_name: Endpoint-policy-applied-artifacts-global-identifiers
   description: the identifiers of global artifacts applied.

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -53,6 +53,16 @@ Endpoint.policy.applied.artifacts.global:
   normalize: []
   short: information about global protection artifacts applied.
   type: object
+Endpoint.policy.applied.artifacts.global.channel:
+  dashed_name: Endpoint-policy-applied-artifacts-global-channel
+  description: global artifacts rollout channel
+  flat_name: Endpoint.policy.applied.artifacts.global.channel
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.artifacts.global.channel
+  normalize: []
+  short: global artifacts rollout channel
+  type: keyword
 Endpoint.policy.applied.artifacts.global.identifiers:
   dashed_name: Endpoint-policy-applied-artifacts-global-identifiers
   description: the identifiers of global artifacts applied.

--- a/schemas/v1/alerts/ransomware_event.yaml
+++ b/schemas/v1/alerts/ransomware_event.yaml
@@ -53,6 +53,16 @@ Endpoint.policy.applied.artifacts.global:
   normalize: []
   short: information about global protection artifacts applied.
   type: object
+Endpoint.policy.applied.artifacts.global.channel:
+  dashed_name: Endpoint-policy-applied-artifacts-global-channel
+  description: global artifacts rollout channel
+  flat_name: Endpoint.policy.applied.artifacts.global.channel
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.artifacts.global.channel
+  normalize: []
+  short: global artifacts rollout channel
+  type: keyword
 Endpoint.policy.applied.artifacts.global.identifiers:
   dashed_name: Endpoint-policy-applied-artifacts-global-identifiers
   description: the identifiers of global artifacts applied.

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -115,6 +115,16 @@ Endpoint.policy.applied.artifacts.global:
   normalize: []
   short: information about global protection artifacts applied.
   type: object
+Endpoint.policy.applied.artifacts.global.channel:
+  dashed_name: Endpoint-policy-applied-artifacts-global-channel
+  description: global artifacts rollout channel
+  flat_name: Endpoint.policy.applied.artifacts.global.channel
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.artifacts.global.channel
+  normalize: []
+  short: global artifacts rollout channel
+  type: keyword
 Endpoint.policy.applied.artifacts.global.identifiers:
   dashed_name: Endpoint-policy-applied-artifacts-global-identifiers
   description: the identifiers of global artifacts applied.


### PR DESCRIPTION
## Change Summary

<!-- please describe your changes. For mapping changes, describe the usage of the changed fields -->
Global artifacts are going to be rolled out gradually, only a selected few endpoints will receive the fast update. This PR adds global artifacts channel field which will indicate which artifacts were currently used by the Endpoint.

### Sample values

Endpoint using standard stable artifacts:
`"Endpoint.policy.applied.artifacts.global.channel": "stable"`

Endpoint testing artifacts from rapid rollout channel:
`"Endpoint.policy.applied.artifacts.global.channel": "rapid"`

Sample document:

Endpoint altert and Endpoint policy response:

```json
{
    "Endpoint": {
        "policy": {
            "applied": {
                "artifacts": {
                    "global": {
                        "channel": "stable,
                    },
}

```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
