### PR TITLE
Include policy name in alerts

### DIFF
--- a/custom_documentation/doc/endpoint/alerts/linux/linux_malware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/linux/linux_malware_alert.md
@@ -19,6 +19,8 @@ This alert is generated when a Malware alert occurs.
 | Endpoint.policy.applied.artifacts.user.identifiers.name |
 | Endpoint.policy.applied.artifacts.user.identifiers.sha256 |
 | Endpoint.policy.applied.artifacts.user.version |
+| Endpoint.policy.applied.id |
+| Endpoint.policy.applied.name |
 | agent.build.original |
 | agent.id |
 | agent.type |

--- a/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malware_alert.yaml
@@ -24,6 +24,8 @@ fields:
   - Endpoint.policy.applied.artifacts.user.identifiers.name
   - Endpoint.policy.applied.artifacts.user.identifiers.sha256
   - Endpoint.policy.applied.artifacts.user.version
+  - Endpoint.policy.applied.id
+  - Endpoint.policy.applied.name
   - agent.build.original
   - agent.id
   - agent.type


### PR DESCRIPTION
## Change Summary

Include policy `name` and policy `id` in alerts. 

Those fields are already mapped but were never sent, so we only need to update custom documentation now.

## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
