### PR TITLE
[8.18] Add `Target.process.Ext.protection` to API event custom docs

### DIFF
--- a/custom_documentation/doc/endpoint/api/windows/windows_api_credential_access.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_credential_access.md
@@ -9,6 +9,7 @@ This event is generated when a process attempts to access priviledged credential
 | Field |
 |---|
 | @timestamp |
+| Target.process.Ext.protection |
 | Target.process.name |
 | Target.process.pid |
 | agent.id |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_threat_intelligence.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_threat_intelligence.md
@@ -10,6 +10,7 @@ This event is generated when ETW Threat-Intelligence events are generated.
 |---|
 | @timestamp |
 | Target.process.Ext.created_suspended |
+| Target.process.Ext.protection |
 | Target.process.Ext.token.integrity_level_name |
 | Target.process.entity_id |
 | Target.process.executable |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_win32k.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_win32k.md
@@ -9,6 +9,7 @@ This event is generated when keylogging-related Win32k APIs are called.
 | Field |
 |---|
 | @timestamp |
+| Target.process.Ext.protection |
 | Target.process.name |
 | Target.process.pid |
 | agent.id |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_wmi.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_wmi.md
@@ -9,6 +9,7 @@ This event is generated when WMI Activity-related APIs are called.
 | Field |
 |---|
 | @timestamp |
+| Target.process.Ext.protection |
 | Target.process.name |
 | Target.process.pid |
 | agent.id |

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_credential_access.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_credential_access.yaml
@@ -14,6 +14,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Target.process.Ext.protection
   - Target.process.name
   - Target.process.pid
   - agent.id

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_threat_intelligence.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_threat_intelligence.yaml
@@ -14,6 +14,7 @@ fields:
   endpoint:
   - '@timestamp'
   - Target.process.Ext.created_suspended
+  - Target.process.Ext.protection
   - Target.process.Ext.token.integrity_level_name
   - Target.process.entity_id
   - Target.process.executable

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_win32k.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_win32k.yaml
@@ -13,6 +13,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Target.process.Ext.protection
   - Target.process.name
   - Target.process.pid
   - agent.id

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_wmi.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_wmi.yaml
@@ -13,6 +13,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Target.process.Ext.protection
   - Target.process.name
   - Target.process.pid
   - agent.id


### PR DESCRIPTION
## Change Summary

Add `Target.process.Ext.protection` to custom docs to fix EAF failure:

```
AssertionError: Found documents with fields missing custom documentation, count: 1, undocumented keys: {'Target.process.Ext.protection'}. Documents written to custom_documentation_violations.ndjson
```

## Release Target

8.18.  This PR is a candidate for 7.17 backports.