### PR TITLE
Add Ext.command_line_truncated

### DIFF
--- a/custom_documentation/doc/endpoint/process/linux/linux_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_already_running.md
@@ -69,6 +69,7 @@ This event is generated for a process that was already running before Endpoint's
 | process.args |
 | process.args_count |
 | process.command_line |
+| process.Ext.command_line_truncated |
 | process.entity_id |
 | process.entry_leader.args |
 | process.entry_leader.args_count |
@@ -130,6 +131,7 @@ This event is generated for a process that was already running before Endpoint's
 | process.parent.args |
 | process.parent.args_count |
 | process.parent.command_line |
+| process.parent.Ext.command_line_truncated |
 | process.parent.entity_id |
 | process.parent.executable |
 | process.parent.group.id |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_fork_exec_exit.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_fork_exec_exit.md
@@ -70,6 +70,7 @@ This event is generated when a process calls `fork()`, `exec()`, exits, or an ag
 | process.args |
 | process.args_count |
 | process.command_line |
+| process.Ext.command_line_truncated |
 | process.end |
 | process.entity_id |
 | process.entry_leader.args |
@@ -134,6 +135,7 @@ This event is generated when a process calls `fork()`, `exec()`, exits, or an ag
 | process.parent.args |
 | process.parent.args_count |
 | process.parent.command_line |
+| process.parent.Ext.command_line_truncated |
 | process.parent.entity_id |
 | process.parent.executable |
 | process.parent.group.id |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_gid_change.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_gid_change.md
@@ -69,6 +69,7 @@ This event is generated when the group id changes for a process.
 | process.args |
 | process.args_count |
 | process.command_line |
+| process.Ext.command_line_truncated |
 | process.end |
 | process.entity_id |
 | process.entry_leader.args |
@@ -132,6 +133,7 @@ This event is generated when the group id changes for a process.
 | process.parent.args |
 | process.parent.args_count |
 | process.parent.command_line |
+| process.parent.Ext.command_line_truncated |
 | process.parent.entity_id |
 | process.parent.executable |
 | process.parent.group.id |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_memfd_create.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_memfd_create.md
@@ -76,6 +76,7 @@ This event is generated when when a memfd anonymous file is created.
 | process.args |
 | process.args_count |
 | process.command_line |
+| process.Ext.command_line_truncated |
 | process.end |
 | process.entity_id |
 | process.entry_leader.args |
@@ -139,6 +140,7 @@ This event is generated when when a memfd anonymous file is created.
 | process.parent.args |
 | process.parent.args_count |
 | process.parent.command_line |
+| process.parent.Ext.command_line_truncated |
 | process.parent.entity_id |
 | process.parent.executable |
 | process.parent.group.id |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_ptrace.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_ptrace.md
@@ -71,6 +71,7 @@ This event is generated when when a process calls ptrace_attach on another proce
 | process.args |
 | process.args_count |
 | process.command_line |
+| process.Ext.command_line_truncated |
 | process.end |
 | process.entity_id |
 | process.entry_leader.args |
@@ -135,6 +136,7 @@ This event is generated when when a process calls ptrace_attach on another proce
 | process.parent.args |
 | process.parent.args_count |
 | process.parent.command_line |
+| process.parent.Ext.command_line_truncated |
 | process.parent.entity_id |
 | process.parent.executable |
 | process.parent.group.id |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_session_id_change.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_session_id_change.md
@@ -68,6 +68,7 @@ This event is generated when a process's session id changes.
 | process.args |
 | process.args_count |
 | process.command_line |
+| process.Ext.command_line_truncated |
 | process.entity_id |
 | process.entry_leader.args |
 | process.entry_leader.args_count |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_shmget.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_shmget.md
@@ -136,6 +136,7 @@ This event is generated when when a process calls shmget().
 | process.parent.args |
 | process.parent.args_count |
 | process.parent.command_line |
+| process.parent.Ext.command_line_truncated |
 | process.parent.entity_id |
 | process.parent.executable |
 | process.parent.group.id |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_text_output.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_text_output.md
@@ -67,6 +67,7 @@ This event is generated when a process generates text output.
 | process.args |
 | process.args_count |
 | process.command_line |
+| process.Ext.command_line_truncated |
 | process.entity_id |
 | process.entry_leader.args |
 | process.entry_leader.args_count |
@@ -132,6 +133,7 @@ This event is generated when a process generates text output.
 | process.parent.args |
 | process.parent.args_count |
 | process.parent.command_line |
+| process.parent.Ext.command_line_truncated |
 | process.parent.entity_id |
 | process.parent.executable |
 | process.parent.group.id |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_uid_change.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_uid_change.md
@@ -70,6 +70,7 @@ This event is generated when the user id changes for a process.
 | process.args |
 | process.args_count |
 | process.command_line |
+| process.Ext.command_line_truncated |
 | process.end |
 | process.entity_id |
 | process.entry_leader.args |
@@ -133,6 +134,7 @@ This event is generated when the user id changes for a process.
 | process.parent.args |
 | process.parent.args_count |
 | process.parent.command_line |
+| process.parent.Ext.command_line_truncated |
 | process.parent.entity_id |
 | process.parent.executable |
 | process.parent.group.id |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_already_running.md
@@ -58,6 +58,7 @@ This event is generated for a process that was already running before Endpoint's
 | process.code_signature.team_id |
 | process.code_signature.trusted |
 | process.command_line |
+| process.Ext.command_line_truncated |
 | process.entity_id |
 | process.env_vars |
 | process.executable |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_fork_exec_exit.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_fork_exec_exit.md
@@ -67,6 +67,7 @@ This event is generated when a process calls `fork()`, `exec()`, or exits.
 | process.code_signature.team_id |
 | process.code_signature.trusted |
 | process.command_line |
+| process.Ext.command_line_truncated |
 | process.entity_id |
 | process.env_vars |
 | process.executable |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_remote_thread.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_remote_thread.md
@@ -63,6 +63,7 @@ This event is generated when a remote thread is created.
 | process.code_signature.team_id |
 | process.code_signature.trusted |
 | process.command_line |
+| process.Ext.command_line_truncated |
 | process.entity_id |
 | process.env_vars |
 | process.executable |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
@@ -69,6 +69,7 @@ This event is generated for a process that was already running before Endpoint's
 | process.code_signature.subject_name |
 | process.code_signature.trusted |
 | process.command_line |
+| process.Ext.command_line_truncated |
 | process.entity_id |
 | process.executable |
 | process.hash.md5 |
@@ -86,6 +87,7 @@ This event is generated for a process that was already running before Endpoint's
 | process.parent.code_signature.subject_name |
 | process.parent.code_signature.trusted |
 | process.parent.command_line |
+| process.parent.Ext.command_line_truncated |
 | process.parent.entity_id |
 | process.parent.executable |
 | process.parent.name |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_create_and_exit.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_create_and_exit.md
@@ -85,6 +85,7 @@ This event is generated when a process is created or exits.
 | process.code_signature.subject_name |
 | process.code_signature.trusted |
 | process.command_line |
+| process.Ext.command_line_truncated |
 | process.entity_id |
 | process.executable |
 | process.exit_code |
@@ -105,6 +106,7 @@ This event is generated when a process is created or exits.
 | process.parent.code_signature.subject_name |
 | process.parent.code_signature.trusted |
 | process.parent.command_line |
+| process.parent.Ext.command_line_truncated |
 | process.parent.entity_id |
 | process.parent.executable |
 | process.parent.name |

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_already_running.yaml
@@ -75,6 +75,7 @@ fields:
   - process.args
   - process.args_count
   - process.command_line
+  - process.Ext.command_line_truncated
   - process.entity_id
   - process.entry_leader.args
   - process.entry_leader.args_count
@@ -136,6 +137,7 @@ fields:
   - process.parent.args
   - process.parent.args_count
   - process.parent.command_line
+  - process.parent.Ext.command_line_truncated
   - process.parent.entity_id
   - process.parent.executable
   - process.parent.group.id

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_fork_exec_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_fork_exec_exit.yaml
@@ -79,6 +79,7 @@ fields:
   - process.args
   - process.args_count
   - process.command_line
+  - process.Ext.command_line_truncated
   - process.end
   - process.entity_id
   - process.entry_leader.args
@@ -143,6 +144,7 @@ fields:
   - process.parent.args
   - process.parent.args_count
   - process.parent.command_line
+  - process.parent.Ext.command_line_truncated
   - process.parent.entity_id
   - process.parent.executable
   - process.parent.group.id

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_gid_change.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_gid_change.yaml
@@ -74,6 +74,7 @@ fields:
   - process.args
   - process.args_count
   - process.command_line
+  - process.Ext.command_line_truncated
   - process.end
   - process.entity_id
   - process.entry_leader.args
@@ -137,6 +138,7 @@ fields:
   - process.parent.args
   - process.parent.args_count
   - process.parent.command_line
+  - process.parent.Ext.command_line_truncated
   - process.parent.entity_id
   - process.parent.executable
   - process.parent.group.id

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_memfd_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_memfd_create.yaml
@@ -80,6 +80,7 @@ fields:
   - process.args
   - process.args_count
   - process.command_line
+  - process.Ext.command_line_truncated
   - process.end
   - process.entity_id
   - process.entry_leader.args
@@ -143,6 +144,7 @@ fields:
   - process.parent.args
   - process.parent.args_count
   - process.parent.command_line
+  - process.parent.Ext.command_line_truncated
   - process.parent.entity_id
   - process.parent.executable
   - process.parent.group.id

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_ptrace.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_ptrace.yaml
@@ -75,6 +75,7 @@ fields:
   - process.args
   - process.args_count
   - process.command_line
+  - process.Ext.command_line_truncated
   - process.end
   - process.entity_id
   - process.entry_leader.args
@@ -139,6 +140,7 @@ fields:
   - process.parent.args
   - process.parent.args_count
   - process.parent.command_line
+  - process.parent.Ext.command_line_truncated
   - process.parent.entity_id
   - process.parent.executable
   - process.parent.group.id

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_session_id_change.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_session_id_change.yaml
@@ -73,6 +73,7 @@ fields:
   - process.args
   - process.args_count
   - process.command_line
+  - process.Ext.command_line_truncated
   - process.entity_id
   - process.entry_leader.args
   - process.entry_leader.args_count

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_shmget.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_shmget.yaml
@@ -140,6 +140,7 @@ fields:
   - process.parent.args
   - process.parent.args_count
   - process.parent.command_line
+  - process.parent.Ext.command_line_truncated
   - process.parent.entity_id
   - process.parent.executable
   - process.parent.group.id

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_text_output.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_text_output.yaml
@@ -72,6 +72,7 @@ fields:
   - process.args
   - process.args_count
   - process.command_line
+  - process.Ext.command_line_truncated
   - process.entity_id
   - process.entry_leader.args
   - process.entry_leader.args_count
@@ -137,6 +138,7 @@ fields:
   - process.parent.args
   - process.parent.args_count
   - process.parent.command_line
+  - process.parent.Ext.command_line_truncated
   - process.parent.entity_id
   - process.parent.executable
   - process.parent.group.id

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_uid_change.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_uid_change.yaml
@@ -75,6 +75,7 @@ fields:
   - process.args
   - process.args_count
   - process.command_line
+  - process.Ext.command_line_truncated
   - process.end
   - process.entity_id
   - process.entry_leader.args
@@ -138,6 +139,7 @@ fields:
   - process.parent.args
   - process.parent.args_count
   - process.parent.command_line
+  - process.parent.Ext.command_line_truncated
   - process.parent.entity_id
   - process.parent.executable
   - process.parent.group.id

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_already_running.yaml
@@ -64,6 +64,7 @@ fields:
   - process.code_signature.team_id
   - process.code_signature.trusted
   - process.command_line
+  - process.Ext.command_line_truncated
   - process.entity_id
   - process.env_vars
   - process.executable

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork_exec_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork_exec_exit.yaml
@@ -76,6 +76,7 @@ fields:
   - process.code_signature.team_id
   - process.code_signature.trusted
   - process.command_line
+  - process.Ext.command_line_truncated
   - process.entity_id
   - process.env_vars
   - process.executable

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_remote_thread.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_remote_thread.yaml
@@ -68,6 +68,7 @@ fields:
   - process.code_signature.team_id
   - process.code_signature.trusted
   - process.command_line
+  - process.Ext.command_line_truncated
   - process.entity_id
   - process.env_vars
   - process.executable

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
@@ -75,6 +75,7 @@ fields:
   - process.code_signature.subject_name
   - process.code_signature.trusted
   - process.command_line
+  - process.Ext.command_line_truncated
   - process.entity_id
   - process.executable
   - process.hash.md5
@@ -92,6 +93,7 @@ fields:
   - process.parent.code_signature.subject_name
   - process.parent.code_signature.trusted
   - process.parent.command_line
+  - process.parent.Ext.command_line_truncated
   - process.parent.entity_id
   - process.parent.executable
   - process.parent.name

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create_and_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create_and_exit.yaml
@@ -92,6 +92,7 @@ fields:
   - process.code_signature.subject_name
   - process.code_signature.trusted
   - process.command_line
+  - process.Ext.command_line_truncated
   - process.entity_id
   - process.executable
   - process.exit_code
@@ -112,6 +113,7 @@ fields:
   - process.parent.code_signature.subject_name
   - process.parent.code_signature.trusted
   - process.parent.command_line
+  - process.parent.Ext.command_line_truncated
   - process.parent.entity_id
   - process.parent.executable
   - process.parent.name


### PR DESCRIPTION
## Change Summary

Add `process.Ext.command_line_truncated` and `process.parent.Ext.command_line_truncated` to indicate the command line is truncated.

## Release Target

v8.18.0

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
