### PR TITLE
update version constraint to be upgradable to 9.0, bump pre

### DIFF
--- a/.buildkite/scripts/find_oldest_supported_version.py
+++ b/.buildkite/scripts/find_oldest_supported_version.py
@@ -87,7 +87,7 @@ def handle_or(kibana_version_condition: str):
     conditions = kibana_version_condition.split("||")
     result = ""
     for cond in conditions:
-        candidate = find_oldest_supported_version(cond)
+        candidate = find_oldest_supported_version(cond.strip())
         if result == "" or candidate < result:
             result = candidate
 

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.18.0-prerelease.1
+version: 8.18.0-prerelease.2
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 
@@ -15,7 +15,7 @@ policy_templates:
     multiple: false
 conditions:
   kibana:
-    version: "^8.18.0"
+    version: "^8.18.0 || ^9.0.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
 
   # >= <the version> && < 8.0.0


### PR DESCRIPTION
## Change Summary

Update Kibana version constraint to include `9.0`. This will allow this version of the package (8.18.0) to function in the 9.x stack, prior to upgrade.

The constraint `^9.0.0` applies to _every_ version under the major number `9`, so this package will work for jumping to `9.1`, `9.2`, ... etc. We will not need to bump the "9" portion of this constraint for `8.19` package.


## Release Target

8.18.0


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
