### PR TITLE
Update branch target for major v9

### DIFF
--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,3 +1,8 @@
+- version: "9.0.0-next"
+  changes:
+    - description: TBD
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/999999
 - version: "8.18.0-next"
   changes:
     - description: TBD

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.18.0-prerelease.2
+version: 9.0.0-prerelease.0
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 
@@ -15,7 +15,7 @@ policy_templates:
     multiple: false
 conditions:
   kibana:
-    version: "^8.18.0 || ^9.0.0"
+    version: "^9.0.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
 
   # >= <the version> && < 8.0.0


### PR DESCRIPTION
## Change Summary

Updates `main` to now target stack 9

`8.x` has been branched, to handle `8.18` and `8.19` releases, backports will go to `8.x`.


## Release Target

9.0

