### PR TITLE
Add fleet unenrolled audit fields

### DIFF
--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
@@ -509,6 +509,12 @@
                                 "unenrollment_started_at": {
                                     "type": "date"
                                 },
+                                "audit_unenrolled_time": {
+                                    "type": "date"
+                                },
+                                "audit_unenrolled_reason": {
+                                    "type": "keyword"
+                                },
                                 "updated_at": {
                                     "type": "date"
                                 },


### PR DESCRIPTION
## Change Summary

Adds fleet agent unenrolled reason fields to support the new agent statuses added here: https://github.com/elastic/kibana/pull/205815

## Release Target

9.0+


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [x] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [x] The new transform successfully starts in Kibana
- [x] The corresponding transform destination schema was updated if necessary
