### PR TITLE
Catch up from 8.18

### DIFF
--- a/.buildkite/pipeline.yml.py
+++ b/.buildkite/pipeline.yml.py
@@ -57,7 +57,7 @@ def main():
         },
     ]
 
-    if current_branch == "main" or re.match(r"^[78]\.\d+$", current_branch):
+    if current_branch == "main" or current_branch == "8.x" or re.match(r"^[78]\.\d+$", current_branch):
         steps.append({
                 "label": "Check if published",
                 "command": ".buildkite/scripts/sign_and_publish.sh --check",

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -23,13 +23,13 @@ spec:
       pipeline_file: ".buildkite/pipeline.yml.py"
       # branch_configuration must be a space separated list of branches
       # to build automatically.
-      branch_configuration: main 8.12 8.13 8.14 8.15 8.16 8.17
+      branch_configuration: main 8.12 8.13 8.14 8.15 8.16 8.17 8.18 8.x
       cancel_intermediate_builds: true
       # Do not accidently skip main or release branch that may be in the middle of releasing
-      cancel_intermediate_builds_branch_filter: '!main !8.12 !8.13 !8.14 !8.15 !8.16 !8.17'
+      cancel_intermediate_builds_branch_filter: '!main !8.12 !8.13 !8.14 !8.15 !8.16 !8.17 !8.18 !8.x'
       skip_intermediate_builds: true
       # Do not accidently skip main or release branch that may be in the middle of releasing
-      skip_intermediate_builds_branch_filter: '!main !8.12 !8.13 !8.14 !8.15 !8.16 !8.17'
+      skip_intermediate_builds_branch_filter: '!main !8.12 !8.13 !8.14 !8.15 !8.16 !8.17 !8.18 !8.x'
       provider_settings:
         build_pull_request_forks: false
         build_pull_request_labels_changed: false

--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -2,12 +2,54 @@
   changes:
     - description: TBD
       type: enhancement
-      link: https://github.com/elastic/endpoint-package/pull/999999
-- version: "8.18.0-next"
+      link: https://github.com/elastic/endpoint-package/pull/9999
+- version: "8.18.0"
   changes:
-    - description: TBD
+    - description: update version constraint to be upgradable to 9.0, bump pre
       type: enhancement
-      link: https://github.com/elastic/endpoint-package/pull/999999
+      link: https://github.com/elastic/endpoint-package/pull/577
+    - description: Add Ext.command_line_truncated
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/576
+    - description: '[8.18] API - AmsiScanBuffer events and new final_hook_module  fields'
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/572
+    - description: documentation update, policy name in alert
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/571
+    - description: Add linux dns events
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/574
+    - description: Update schema and docs for `ptrace`, `shmget` events, fix docs for memfd events
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/565
+    - description: Add Target.process.Ext.protection to API event custom docs
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/573
+    - description: Update README.md
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/566
+    - description: Include policy name in alerts
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/570
+    - description: '[8.18] Add new memory region field (region_start_bytes)'
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/567
+    - description: global artifacts rollout channel
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/569
+    - description: Memfd field types fix
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/568
+    - description: Aggregate network events for macOS, Linux, and Windows
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/555
+    - description: Add `memfd_create` fields to process datastream
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/564
+    - description: prepare 8.18 dev cycle
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/563
 - version: "8.17.0"
   changes:
     - description: prep 8.17


### PR DESCRIPTION
This is a back- (forward?) port of changes from `8.x` and `8.18` release, into main

- Changelog release notes from 8.18.0 release
- #586 fix to release pipeline
- adding release branches to catalog-info