### PR TITLE
[backport] 8.18 release

### DIFF
--- a/.buildkite/pipeline.yml.py
+++ b/.buildkite/pipeline.yml.py
@@ -57,7 +57,7 @@ def main():
         },
     ]
 
-    if current_branch == "main" or re.match(r"^[78]\.\d+$", current_branch):
+    if current_branch == "main" or current_branch == "8.x" or re.match(r"^[78]\.\d+$", current_branch):
         steps.append({
                 "label": "Check if published",
                 "command": ".buildkite/scripts/sign_and_publish.sh --check",

--- a/.buildkite/sign_and_publish.yml.py
+++ b/.buildkite/sign_and_publish.yml.py
@@ -6,6 +6,7 @@
 import argparse
 import json
 import os
+import re
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
@@ -19,7 +20,7 @@ def main():
     # This only gets triggered when the branch is either main or 7.\d or 8.\d
     # So, dry_run is true for non main branch
     branch = os.getenv("BUILDKITE_BRANCH")
-    dry_run = branch != "main"
+    dry_run = not (branch == "main" or branch == "8.x" or re.match(r"^[78]\.\d+$", branch))
     pipeline = {}
     steps = [
         {

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -23,13 +23,13 @@ spec:
       pipeline_file: ".buildkite/pipeline.yml.py"
       # branch_configuration must be a space separated list of branches
       # to build automatically.
-      branch_configuration: main 8.12 8.13 8.14 8.15 8.16 8.17
+      branch_configuration: main 8.12 8.13 8.14 8.15 8.16 8.17 8.18 8.x
       cancel_intermediate_builds: true
       # Do not accidently skip main or release branch that may be in the middle of releasing
-      cancel_intermediate_builds_branch_filter: '!main !8.12 !8.13 !8.14 !8.15 !8.16 !8.17'
+      cancel_intermediate_builds_branch_filter: '!main !8.12 !8.13 !8.14 !8.15 !8.16 !8.17 !8.18 !8.x'
       skip_intermediate_builds: true
       # Do not accidently skip main or release branch that may be in the middle of releasing
-      skip_intermediate_builds_branch_filter: '!main !8.12 !8.13 !8.14 !8.15 !8.16 !8.17'
+      skip_intermediate_builds_branch_filter: '!main !8.12 !8.13 !8.14 !8.15 !8.16 !8.17 !8.18 !8.x'
       provider_settings:
         build_pull_request_forks: false
         build_pull_request_labels_changed: false

--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,8 +1,50 @@
-- version: "8.18.0-next"
+- version: "8.18.0"
   changes:
-    - description: TBD
+    - description: update version constraint to be upgradable to 9.0, bump pre
       type: enhancement
-      link: https://github.com/elastic/endpoint-package/pull/999999
+      link: https://github.com/elastic/endpoint-package/pull/577
+    - description: Add Ext.command_line_truncated
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/576
+    - description: '[8.18] API - AmsiScanBuffer events and new final_hook_module  fields'
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/572
+    - description: documentation update, policy name in alert
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/571
+    - description: Add linux dns events
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/574
+    - description: Update schema and docs for `ptrace`, `shmget` events, fix docs for memfd events
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/565
+    - description: Add Target.process.Ext.protection to API event custom docs
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/573
+    - description: Update README.md
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/566
+    - description: Include policy name in alerts
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/570
+    - description: '[8.18] Add new memory region field (region_start_bytes)'
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/567
+    - description: global artifacts rollout channel
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/569
+    - description: Memfd field types fix
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/568
+    - description: Aggregate network events for macOS, Linux, and Windows
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/555
+    - description: Add `memfd_create` fields to process datastream
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/564
+    - description: prepare 8.18 dev cycle
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/563
 - version: "8.17.0"
   changes:
     - description: prep 8.17

--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,3 +1,9 @@
+- version: "8.19.0-next"
+  changes:
+    - description: TBD
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/99999
+    - description: Add Ext.command_line_truncated
 - version: "8.18.0"
   changes:
     - description: update version constraint to be upgradable to 9.0, bump pre

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.18.0-prerelease.2
+version: 8.18.0
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 8.18.0
+version: 8.19.0-prerelease.0
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 
@@ -15,7 +15,7 @@ policy_templates:
     multiple: false
 conditions:
   kibana:
-    version: "^8.18.0 || ^9.0.0"
+    version: "^8.19.0 || ^9.0.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
 
   # >= <the version> && < 8.0.0


### PR DESCRIPTION
Backports current state of `8.x`, which is release point for 8.18.0, to the branch `8.18`


CI release and publish step from this point in `8.x` ran, and should have published `8.18.0` package, but epr is not reflecting that. backporting may trigger another release