### PR TITLE
disable DRY_RUN on releasable branches

### DIFF
--- a/.buildkite/sign_and_publish.yml.py
+++ b/.buildkite/sign_and_publish.yml.py
@@ -6,6 +6,7 @@
 import argparse
 import json
 import os
+import re
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
@@ -19,7 +20,7 @@ def main():
     # This only gets triggered when the branch is either main or 7.\d or 8.\d
     # So, dry_run is true for non main branch
     branch = os.getenv("BUILDKITE_BRANCH")
-    dry_run = branch != "main"
+    dry_run = not (branch == "main" or branch == "8.x" or re.match(r"^[78]\.\d+$", branch))
     pipeline = {}
     steps = [
         {


### PR DESCRIPTION
on branches like `8.x`, package release would happen in a dry run mode

So the on-merge step on the `8.x` branch right now did not publish the `8.18.0` package, epr still reflects `8.17.0` as current.

Making sure these specific branches allow live deployments may fix. This change will be backported to `8.x` branch