### PR TITLE
[8.18/9.0]Change the size of region_start_bytes + add the field to the alert data stream

### DIFF
--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -150,8 +150,8 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.system_impact.wmi_events.week_ms |
 | Endpoint.metrics.threads.cpu.mean |
 | Endpoint.metrics.threads.name |
-| Endpoint.metrics.top_process_trees.values.last_seen |
 | Endpoint.metrics.top_process_trees.values.event_count |
+| Endpoint.metrics.top_process_trees.values.last_seen |
 | Endpoint.metrics.top_process_trees.values.sample.command_line |
 | Endpoint.metrics.top_process_trees.values.sample.entity_id |
 | Endpoint.metrics.top_process_trees.values.sample.executable |

--- a/custom_schemas/custom_memory_region.yml
+++ b/custom_schemas/custom_memory_region.yml
@@ -116,9 +116,9 @@
     - name: region_start_bytes
       level: custom
       type: keyword
-      example: "4d5a90000300000004000000ffff0000b8000000000000004000000000000000"
+      example: "4d5a90000300000004000000ffff0000b80000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000"
       description: >
-        First 32 bytes at the region base address.
+        First 64 bytes at the region base address.
         
     - name: region_state
       level: custom

--- a/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/memory_protection_event.yaml
@@ -717,6 +717,7 @@ fields:
               region_base: {}
               region_protection: {}
               region_size: {}
+              region_start_bytes: {}
               region_state: {}
               strings: {}
       parent:

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -1341,6 +1341,13 @@
       description: Size of the memory region.
       example: 4096
       default_field: false
+    - name: process.Ext.memory_region.region_start_bytes
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: First 64 bytes at the region base address.
+      example: 4d5a90000300000004000000ffff0000b80000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000
+      default_field: false
     - name: process.Ext.memory_region.region_state
       level: custom
       type: keyword
@@ -5099,6 +5106,13 @@
       type: unsigned_long
       description: Size of the memory region.
       example: 4096
+      default_field: false
+    - name: Ext.memory_region.region_start_bytes
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: First 64 bytes at the region base address.
+      example: 4d5a90000300000004000000ffff0000b80000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000
       default_field: false
     - name: Ext.memory_region.region_state
       level: custom

--- a/package/endpoint/data_stream/alerts/sample_event.json
+++ b/package/endpoint/data_stream/alerts/sample_event.json
@@ -39,47 +39,47 @@
         }
     },
     "process": {
-      "Ext": {
-        "ancestry": [
-          "MmIxZWI3ZjctYmQ2MS00MzZhLTk4YWYtYzJiMTgyMDQzNDc2LTAtMTMyOTM1NDczMTkuOTk5Mjc0NjAw"
-        ],
-        "protection": "PsProtectedSignerWinSystem",
-        "user": "SYSTEM",
-        "architecture": "x86_64",
-        "token": {
-          "elevation": true,
-          "integrity_level_name": "system",
-          "domain": "NT AUTHORITY",
+        "Ext": {
+          "ancestry": [
+            "MmIxZWI3ZjctYmQ2MS00MzZhLTk4YWYtYzJiMTgyMDQzNDc2LTAtMTMyOTM1NDczMTkuOTk5Mjc0NjAw"
+          ],
+          "protection": "PsProtectedSignerWinSystem",
           "user": "SYSTEM",
-          "elevation_type": "default",
-          "sid": "S-1-5-18"
-        },
-        "memory_region": {
-          "region_size": 4096,
-          "region_protection": "RWX",
-          "allocation_base": 2401471234048,
-          "allocation_type": "PRIVATE",
-          "bytes_allocation_offset": 0,
-          "region_state": "COMMIT",
-          "bytes_compressed_present": false,
-          "region_start_bytes": "58354f2150254041505b345c505a58353428505e2937434329377d2445494341522d5354414e444152442d414e544956495255532d544553542d46494c452124",
-          "malware_signature": {
-            "secondary": [],
-            "identifier": "production-malware-signature-v1-windows",
-            "all_names": "Multi.EICAR.Not-a-virus",
-            "version": "1.0.54",
-            "primary": {
-              "signature": {
-                "name": "Multi.EICAR.Not-a-virus",
-                "id": "ac8f42d6-52da-46ec-8db1-5a5f69222a38",
-                "hash": {
-                  "sha256": "bb0e0bdf70ec65d98f652e2428e3567013d5413f2725a2905b372fd18da8b9dd"
-                }
-              },
-              "matches": [
-                "WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5EQVJELUFOVElWSVJVUy1URVNULUZJTEUhJEgrSCo="
-              ]
-            }
+          "architecture": "x86_64",
+          "token": {
+            "elevation": true,
+            "integrity_level_name": "system",
+            "domain": "NT AUTHORITY",
+            "user": "SYSTEM",
+            "elevation_type": "default",
+            "sid": "S-1-5-18"
+          },
+          "memory_region": {
+            "region_size": 4096,
+            "region_protection": "RWX",
+            "allocation_base": 2401471234048,
+            "allocation_type": "PRIVATE",
+            "bytes_allocation_offset": 0,
+            "region_state": "COMMIT",
+            "bytes_compressed_present": false,
+            "region_start_bytes": "58354f2150254041505b345c505a58353428505e2937434329377d2445494341522d5354414e444152442d414e544956495255532d544553542d46494c452124",
+            "malware_signature": {
+              "secondary": [],
+              "identifier": "production-malware-signature-v1-windows",
+              "all_names": "Multi.EICAR.Not-a-virus",
+              "version": "1.0.54",
+              "primary": {
+                "signature": {
+                  "name": "Multi.EICAR.Not-a-virus",
+                  "id": "ac8f42d6-52da-46ec-8db1-5a5f69222a38",
+                  "hash": {
+                    "sha256": "bb0e0bdf70ec65d98f652e2428e3567013d5413f2725a2905b372fd18da8b9dd"
+                  }
+                },
+                "matches": [
+                  "WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5EQVJELUFOVElWSVJVUy1URVNULUZJTEUhJEgrSCo="
+                ]
+              }
           },
           "allocation_protection": "RW-",
           "region_base": 2401471238144,

--- a/package/endpoint/data_stream/alerts/sample_event.json
+++ b/package/endpoint/data_stream/alerts/sample_event.json
@@ -39,22 +39,54 @@
         }
     },
     "process": {
-        "Ext": {
-            "ancestry": [
-                "MmIxZWI3ZjctYmQ2MS00MzZhLTk4YWYtYzJiMTgyMDQzNDc2LTAtMTMyOTM1NDczMTkuOTk5Mjc0NjAw"
-            ],
-            "protection": "PsProtectedSignerWinSystem",
-            "user": "SYSTEM",
-            "architecture": "x86_64",
-            "token": {
-                "elevation": true,
-                "integrity_level_name": "system",
-                "domain": "NT AUTHORITY",
-                "user": "SYSTEM",
-                "elevation_type": "default",
-                "sid": "S-1-5-18"
-            }
+      "Ext": {
+        "ancestry": [
+          "MmIxZWI3ZjctYmQ2MS00MzZhLTk4YWYtYzJiMTgyMDQzNDc2LTAtMTMyOTM1NDczMTkuOTk5Mjc0NjAw"
+        ],
+        "protection": "PsProtectedSignerWinSystem",
+        "user": "SYSTEM",
+        "architecture": "x86_64",
+        "token": {
+          "elevation": true,
+          "integrity_level_name": "system",
+          "domain": "NT AUTHORITY",
+          "user": "SYSTEM",
+          "elevation_type": "default",
+          "sid": "S-1-5-18"
         },
+        "memory_region": {
+          "region_size": 4096,
+          "region_protection": "RWX",
+          "allocation_base": 2401471234048,
+          "allocation_type": "PRIVATE",
+          "bytes_allocation_offset": 0,
+          "region_state": "COMMIT",
+          "bytes_compressed_present": false,
+          "region_start_bytes": "58354f2150254041505b345c505a58353428505e2937434329377d2445494341522d5354414e444152442d414e544956495255532d544553542d46494c452124",
+          "malware_signature": {
+            "secondary": [],
+            "identifier": "production-malware-signature-v1-windows",
+            "all_names": "Multi.EICAR.Not-a-virus",
+            "version": "1.0.54",
+            "primary": {
+              "signature": {
+                "name": "Multi.EICAR.Not-a-virus",
+                "id": "ac8f42d6-52da-46ec-8db1-5a5f69222a38",
+                "hash": {
+                  "sha256": "bb0e0bdf70ec65d98f652e2428e3567013d5413f2725a2905b372fd18da8b9dd"
+                }
+              },
+              "matches": [
+                "WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5EQVJELUFOVElWSVJVUy1URVNULUZJTEUhJEgrSCo="
+              ]
+            }
+          },
+          "allocation_protection": "RW-",
+          "region_base": 2401471238144,
+          "allocation_size": 8192,
+          "bytes_address": 2401471234048
+        }
+      },
         "parent": {
             "Ext": {
                 "protection": "",

--- a/package/endpoint/data_stream/alerts/sample_event.json
+++ b/package/endpoint/data_stream/alerts/sample_event.json
@@ -40,53 +40,53 @@
     },
     "process": {
         "Ext": {
-          "ancestry": [
-            "MmIxZWI3ZjctYmQ2MS00MzZhLTk4YWYtYzJiMTgyMDQzNDc2LTAtMTMyOTM1NDczMTkuOTk5Mjc0NjAw"
-          ],
-          "protection": "PsProtectedSignerWinSystem",
-          "user": "SYSTEM",
-          "architecture": "x86_64",
-          "token": {
-            "elevation": true,
-            "integrity_level_name": "system",
-            "domain": "NT AUTHORITY",
+            "ancestry": [
+                "MmIxZWI3ZjctYmQ2MS00MzZhLTk4YWYtYzJiMTgyMDQzNDc2LTAtMTMyOTM1NDczMTkuOTk5Mjc0NjAw"
+            ],
+            "protection": "PsProtectedSignerWinSystem",
             "user": "SYSTEM",
-            "elevation_type": "default",
-            "sid": "S-1-5-18"
-          },
-          "memory_region": {
-            "region_size": 4096,
-            "region_protection": "RWX",
-            "allocation_base": 2401471234048,
-            "allocation_type": "PRIVATE",
-            "bytes_allocation_offset": 0,
-            "region_state": "COMMIT",
-            "bytes_compressed_present": false,
-            "region_start_bytes": "58354f2150254041505b345c505a58353428505e2937434329377d2445494341522d5354414e444152442d414e544956495255532d544553542d46494c452124",
-            "malware_signature": {
-              "secondary": [],
-              "identifier": "production-malware-signature-v1-windows",
-              "all_names": "Multi.EICAR.Not-a-virus",
-              "version": "1.0.54",
-              "primary": {
-                "signature": {
-                  "name": "Multi.EICAR.Not-a-virus",
-                  "id": "ac8f42d6-52da-46ec-8db1-5a5f69222a38",
-                  "hash": {
-                    "sha256": "bb0e0bdf70ec65d98f652e2428e3567013d5413f2725a2905b372fd18da8b9dd"
-                  }
+            "architecture": "x86_64",
+            "token": {
+                "elevation": true,
+                "integrity_level_name": "system",
+                "domain": "NT AUTHORITY",
+                "user": "SYSTEM",
+                "elevation_type": "default",
+                "sid": "S-1-5-18"
+            },
+            "memory_region": {
+                "region_size": 4096,
+                "region_protection": "RWX",
+                "allocation_base": 2401471234048,
+                "allocation_type": "PRIVATE",
+                "bytes_allocation_offset": 0,
+                "region_state": "COMMIT",
+                "bytes_compressed_present": false,
+                "region_start_bytes": "58354f2150254041505b345c505a58353428505e2937434329377d2445494341522d5354414e444152442d414e544956495255532d544553542d46494c452124",
+                "malware_signature": {
+                    "secondary": [],
+                    "identifier": "production-malware-signature-v1-windows",
+                    "all_names": "Multi.EICAR.Not-a-virus",
+                    "version": "1.0.54",
+                    "primary": {
+                        "signature": {
+                            "name": "Multi.EICAR.Not-a-virus",
+                            "id": "ac8f42d6-52da-46ec-8db1-5a5f69222a38",
+                            "hash": {
+                                "sha256": "bb0e0bdf70ec65d98f652e2428e3567013d5413f2725a2905b372fd18da8b9dd"
+                            }
+                        },
+                        "matches": [
+                            "WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5EQVJELUFOVElWSVJVUy1URVNULUZJTEUhJEgrSCo="
+                        ]
+                    }
                 },
-                "matches": [
-                  "WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5EQVJELUFOVElWSVJVUy1URVNULUZJTEUhJEgrSCo="
-                ]
-              }
-          },
-          "allocation_protection": "RW-",
-          "region_base": 2401471238144,
-          "allocation_size": 8192,
-          "bytes_address": 2401471234048
-        }
-      },
+                "allocation_protection": "RW-",
+                "region_base": 2401471238144,
+                "allocation_size": 8192,
+                "bytes_address": 2401471234048
+            }
+        },
         "parent": {
             "Ext": {
                 "protection": "",

--- a/package/endpoint/data_stream/alerts/sample_event.json
+++ b/package/endpoint/data_stream/alerts/sample_event.json
@@ -63,24 +63,6 @@
                 "region_state": "COMMIT",
                 "bytes_compressed_present": false,
                 "region_start_bytes": "58354f2150254041505b345c505a58353428505e2937434329377d2445494341522d5354414e444152442d414e544956495255532d544553542d46494c452124",
-                "malware_signature": {
-                    "secondary": [],
-                    "identifier": "production-malware-signature-v1-windows",
-                    "all_names": "Multi.EICAR.Not-a-virus",
-                    "version": "1.0.54",
-                    "primary": {
-                        "signature": {
-                            "name": "Multi.EICAR.Not-a-virus",
-                            "id": "ac8f42d6-52da-46ec-8db1-5a5f69222a38",
-                            "hash": {
-                                "sha256": "bb0e0bdf70ec65d98f652e2428e3567013d5413f2725a2905b372fd18da8b9dd"
-                            }
-                        },
-                        "matches": [
-                            "WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5EQVJELUFOVElWSVJVUy1URVNULUZJTEUhJEgrSCo="
-                        ]
-                    }
-                },
                 "allocation_protection": "RW-",
                 "region_base": 2401471238144,
                 "allocation_size": 8192,

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -772,8 +772,8 @@
       level: custom
       type: keyword
       ignore_above: 1024
-      description: First 32 bytes at the region base address.
-      example: 4d5a90000300000004000000ffff0000b8000000000000004000000000000000
+      description: First 64 bytes at the region base address.
+      example: 4d5a90000300000004000000ffff0000b80000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000
       default_field: false
     - name: process.Ext.memory_region.region_state
       level: custom
@@ -2534,8 +2534,8 @@
       level: custom
       type: keyword
       ignore_above: 1024
-      description: First 32 bytes at the region base address.
-      example: 4d5a90000300000004000000ffff0000b8000000000000004000000000000000
+      description: First 64 bytes at the region base address.
+      example: 4d5a90000300000004000000ffff0000b80000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000
       default_field: false
     - name: Ext.memory_region.region_state
       level: custom

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -227,6 +227,7 @@ sent by the endpoint.
 | Target.process.Ext.memory_region.region_base | Base address of the memory region. | unsigned_long |
 | Target.process.Ext.memory_region.region_protection | Memory protection of the memory region. Example values include "RWX" and "R-X". | keyword |
 | Target.process.Ext.memory_region.region_size | Size of the memory region. | unsigned_long |
+| Target.process.Ext.memory_region.region_start_bytes | First 64 bytes at the region base address. | keyword |
 | Target.process.Ext.memory_region.region_state | State of the memory region. Example values include "RESERVE", "COMMIT", and "FREE". | keyword |
 | Target.process.Ext.memory_region.strings | Array of strings found within the memory region. | keyword |
 | Target.process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
@@ -726,6 +727,7 @@ sent by the endpoint.
 | process.Ext.memory_region.region_base | Base address of the memory region. | unsigned_long |
 | process.Ext.memory_region.region_protection | Memory protection of the memory region. Example values include "RWX" and "R-X". | keyword |
 | process.Ext.memory_region.region_size | Size of the memory region. | unsigned_long |
+| process.Ext.memory_region.region_start_bytes | First 64 bytes at the region base address. | keyword |
 | process.Ext.memory_region.region_state | State of the memory region. Example values include "RESERVE", "COMMIT", and "FREE". | keyword |
 | process.Ext.memory_region.strings | Array of strings found within the memory region. | keyword |
 | process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |

--- a/schemas/v1/alerts/memory_protection_event.yaml
+++ b/schemas/v1/alerts/memory_protection_event.yaml
@@ -1183,6 +1183,18 @@ Target.process.Ext.memory_region.region_size:
   original_fieldset: memory_region
   short: Size of the memory region.
   type: unsigned_long
+Target.process.Ext.memory_region.region_start_bytes:
+  dashed_name: Target-process-Ext-memory-region-region-start-bytes
+  description: First 64 bytes at the region base address.
+  example: 4d5a90000300000004000000ffff0000b80000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000
+  flat_name: Target.process.Ext.memory_region.region_start_bytes
+  ignore_above: 1024
+  level: custom
+  name: region_start_bytes
+  normalize: []
+  original_fieldset: memory_region
+  short: First 64 bytes at the region base address.
+  type: keyword
 Target.process.Ext.memory_region.region_state:
   dashed_name: Target-process-Ext-memory-region-region-state
   description: State of the memory region. Example values include "RESERVE", "COMMIT",
@@ -6552,6 +6564,18 @@ process.Ext.memory_region.region_size:
   original_fieldset: memory_region
   short: Size of the memory region.
   type: unsigned_long
+process.Ext.memory_region.region_start_bytes:
+  dashed_name: process-Ext-memory-region-region-start-bytes
+  description: First 64 bytes at the region base address.
+  example: 4d5a90000300000004000000ffff0000b80000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000
+  flat_name: process.Ext.memory_region.region_start_bytes
+  ignore_above: 1024
+  level: custom
+  name: region_start_bytes
+  normalize: []
+  original_fieldset: memory_region
+  short: First 64 bytes at the region base address.
+  type: keyword
 process.Ext.memory_region.region_state:
   dashed_name: process-Ext-memory-region-region-state
   description: State of the memory region. Example values include "RESERVE", "COMMIT",

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -1382,15 +1382,15 @@ Target.process.Ext.memory_region.region_size:
   type: unsigned_long
 Target.process.Ext.memory_region.region_start_bytes:
   dashed_name: Target-process-Ext-memory-region-region-start-bytes
-  description: First 32 bytes at the region base address.
-  example: 4d5a90000300000004000000ffff0000b8000000000000004000000000000000
+  description: First 64 bytes at the region base address.
+  example: 4d5a90000300000004000000ffff0000b80000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000
   flat_name: Target.process.Ext.memory_region.region_start_bytes
   ignore_above: 1024
   level: custom
   name: region_start_bytes
   normalize: []
   original_fieldset: memory_region
-  short: First 32 bytes at the region base address.
+  short: First 64 bytes at the region base address.
   type: keyword
 Target.process.Ext.memory_region.region_state:
   dashed_name: Target-process-Ext-memory-region-region-state
@@ -4886,15 +4886,15 @@ process.Ext.memory_region.region_size:
   type: unsigned_long
 process.Ext.memory_region.region_start_bytes:
   dashed_name: process-Ext-memory-region-region-start-bytes
-  description: First 32 bytes at the region base address.
-  example: 4d5a90000300000004000000ffff0000b8000000000000004000000000000000
+  description: First 64 bytes at the region base address.
+  example: 4d5a90000300000004000000ffff0000b80000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000
   flat_name: process.Ext.memory_region.region_start_bytes
   ignore_above: 1024
   level: custom
   name: region_start_bytes
   normalize: []
   original_fieldset: memory_region
-  short: First 32 bytes at the region base address.
+  short: First 64 bytes at the region base address.
   type: keyword
 process.Ext.memory_region.region_state:
   dashed_name: process-Ext-memory-region-region-state


### PR DESCRIPTION
## Change Summary

<!-- please describe your changes. For mapping changes, describe the usage of the changed fields -->

We changed the size (string size) of the following fields from 32 bytes to 64 bytes. Thus, we would like to change the discription and example written in the endpoint-package as well. Moreover, this PR add the fields to the alert data stream.
The field itself was added at this [PR](https://github.com/elastic/endpoint-package/pull/567).

* process.Ext.memory_region.region_start_bytes

### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json
    "message": "Memory Threat Detection Alert: Multi.EICAR.Not-a-virus",
    "process": {
        "Ext": {
            "ancestry": [
                "pPVZfPJXb3LwUZ6tFZ8cNA",
                "zkRe4BMHSS5W62hRN/nEhw",
                "oMfl23/bSjrkV8n+vJdWKQ",
                "/kph1ryYQOxMtjxrL99sxQ",
                "tfZhGzm7UQh2y/dLc5PM5g"
            ],
            "architecture": "x86_64",
            "code_signature": [
                {
                    "exists": false
                }
            ],
            "memory_region": {
                "allocation_base": 6442450944,
                "allocation_protection": "RW-",
                "allocation_size": 110592,
                "allocation_type": "PRIVATE",
                "bytes_address": 6442450944,
                "bytes_allocation_offset": 0,
                "bytes_compressed_present": false,
                "malware_signature": {
                    "all_names": "Multi.EICAR.Not-a-virus",
                    "identifier": "diagnostic-malware-signature-v1-windows",
                    "primary": {
                        "matches": [
                            "WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5EQVJELUFOVElWSVJVUy1URVNULUZJTEUhJEgrSCo="
                        ],
                        "signature": {
                            "hash": {
                                "sha256": "bb0e0bdf70ec65d98f652e2428e3567013d5413f2725a2905b372fd18da8b9dd"
                            },
                            "id": "ac8f42d6-52da-46ec-8db1-5a5f69222a38",
                            "name": "Multi.EICAR.Not-a-virus"
                        }
                    },
                    "secondary": [],
                    "version": "1.0.70"
                },
                "region_base": 6442536960,
                "region_protection": "RW-",
                "region_size": 8192,
                "region_start_bytes": "58354f2150254041505b345c505a58353428505e2937434329377d2445494341522d5354414e444152442d414e544956495255532d544553542d46494c452124",
                "region_state": "COMMIT"
            },
```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->

8.18/9.0

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes