### PR TITLE
update main branch target for 9.1 stack cycle

### DIFF
--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,3 +1,8 @@
+- version: "9.1.0-next"
+  changes:
+    - description: TBD
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/99999
 - version: "9.0.0"
   changes:
     - description: '[macOS] Security events'

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 9.0.0
+version: 9.1.0-prerelease.0
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 
@@ -15,7 +15,7 @@ policy_templates:
     multiple: false
 conditions:
   kibana:
-    version: "^9.0.0"
+    version: "^9.1.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
   elastic:
     capabilities: ["security"]


### PR DESCRIPTION
Now that `v9.0.0` (package) has been released, the `9.0` _branch_ has been cut to issue any followup releases to the `9.0` stack. Main branch now targets the next stack release, `9.1`.