### PR TITLE
prepare 9.0 branch for patch release dev work cycle

### DIFF
--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,3 +1,8 @@
+- version: "9.0.1-next"
+  changes:
+    - description: TBD
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/999999
 - version: "9.0.0"
   changes:
     - description: '[macOS] Security events'

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 9.0.0
+version: 9.0.1-prerelease.0
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 


### PR DESCRIPTION
Package `v9.0.0` release is out. The `9.0` _branch_ is now used as the target for any additions or backports that need to go out to the `9.0`-series stack.

This change sets up the `9.0` branch to be in the dev/prep cycle to include any new changes as the next patch release (`9.0.1`)