### PR TITLE
Add process fields to custom documentation for security events

### DIFF
--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -150,8 +150,8 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.system_impact.wmi_events.week_ms |
 | Endpoint.metrics.threads.cpu.mean |
 | Endpoint.metrics.threads.name |
-| Endpoint.metrics.top_process_trees.values.last_seen |
 | Endpoint.metrics.top_process_trees.values.event_count |
+| Endpoint.metrics.top_process_trees.values.last_seen |
 | Endpoint.metrics.top_process_trees.values.sample.command_line |
 | Endpoint.metrics.top_process_trees.values.sample.entity_id |
 | Endpoint.metrics.top_process_trees.values.sample.executable |

--- a/custom_documentation/doc/endpoint/security/macos/macos_security_gatekeeper_override.md
+++ b/custom_documentation/doc/endpoint/security/macos/macos_security_gatekeeper_override.md
@@ -56,12 +56,15 @@ This event is generated when a user grants a gatekeeper exception
 | process.Ext.code_signature.trusted |
 | process.Ext.session_info.logon_type |
 | process.code_signature.exists |
+| process.code_signature.signing_id |
 | process.code_signature.status |
 | process.code_signature.subject_name |
+| process.code_signature.team_id |
 | process.code_signature.trusted |
 | process.entity_id |
 | process.executable |
 | process.name |
+| process.pid |
 | user.domain |
 | user.effective.domain |
 | user.effective.email |

--- a/custom_documentation/doc/endpoint/security/macos/macos_security_log_on.md
+++ b/custom_documentation/doc/endpoint/security/macos/macos_security_log_on.md
@@ -53,12 +53,15 @@ This event is generated when a user logs on to the computer.
 | process.Ext.code_signature.trusted |
 | process.Ext.session_info.logon_type |
 | process.code_signature.exists |
+| process.code_signature.signing_id |
 | process.code_signature.status |
 | process.code_signature.subject_name |
+| process.code_signature.team_id |
 | process.code_signature.trusted |
 | process.entity_id |
 | process.executable |
 | process.name |
+| process.pid |
 | user.domain |
 | user.effective.domain |
 | user.effective.email |

--- a/custom_documentation/doc/endpoint/security/macos/macos_security_rdp_log_on.md
+++ b/custom_documentation/doc/endpoint/security/macos/macos_security_rdp_log_on.md
@@ -53,12 +53,15 @@ This event is generated when a user logs on to the computer with screensharing.
 | process.Ext.code_signature.trusted |
 | process.Ext.session_info.logon_type |
 | process.code_signature.exists |
+| process.code_signature.signing_id |
 | process.code_signature.status |
 | process.code_signature.subject_name |
+| process.code_signature.team_id |
 | process.code_signature.trusted |
 | process.entity_id |
 | process.executable |
 | process.name |
+| process.pid |
 | user.domain |
 | user.effective.domain |
 | user.effective.email |

--- a/custom_documentation/doc/endpoint/security/macos/macos_security_ssh_log_on.md
+++ b/custom_documentation/doc/endpoint/security/macos/macos_security_ssh_log_on.md
@@ -53,12 +53,15 @@ This event is generated when a user logs on to the computer with SSH.
 | process.Ext.code_signature.trusted |
 | process.Ext.session_info.logon_type |
 | process.code_signature.exists |
+| process.code_signature.signing_id |
 | process.code_signature.status |
 | process.code_signature.subject_name |
+| process.code_signature.team_id |
 | process.code_signature.trusted |
 | process.entity_id |
 | process.executable |
 | process.name |
+| process.pid |
 | user.domain |
 | user.effective.domain |
 | user.effective.email |

--- a/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_gatekeeper_override.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_gatekeeper_override.yaml
@@ -61,12 +61,15 @@ fields:
   - process.Ext.code_signature.trusted
   - process.Ext.session_info.logon_type
   - process.code_signature.exists
+  - process.code_signature.signing_id
   - process.code_signature.status
   - process.code_signature.subject_name
+  - process.code_signature.team_id
   - process.code_signature.trusted
   - process.entity_id
   - process.executable
   - process.name
+  - process.pid
   - user.domain
   - user.effective.domain
   - user.effective.email

--- a/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_log_on.yaml
@@ -58,12 +58,15 @@ fields:
   - process.Ext.code_signature.trusted
   - process.Ext.session_info.logon_type
   - process.code_signature.exists
+  - process.code_signature.signing_id
   - process.code_signature.status
   - process.code_signature.subject_name
+  - process.code_signature.team_id
   - process.code_signature.trusted
   - process.entity_id
   - process.executable
   - process.name
+  - process.pid
   - user.domain
   - user.effective.domain
   - user.effective.email

--- a/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_rdp_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_rdp_log_on.yaml
@@ -58,12 +58,15 @@ fields:
   - process.Ext.code_signature.trusted
   - process.Ext.session_info.logon_type
   - process.code_signature.exists
+  - process.code_signature.signing_id
   - process.code_signature.status
   - process.code_signature.subject_name
+  - process.code_signature.team_id
   - process.code_signature.trusted
   - process.entity_id
   - process.executable
   - process.name
+  - process.pid
   - user.domain
   - user.effective.domain
   - user.effective.email

--- a/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_ssh_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_ssh_log_on.yaml
@@ -58,12 +58,15 @@ fields:
   - process.Ext.code_signature.trusted
   - process.Ext.session_info.logon_type
   - process.code_signature.exists
+  - process.code_signature.signing_id
   - process.code_signature.status
   - process.code_signature.subject_name
+  - process.code_signature.team_id
   - process.code_signature.trusted
   - process.entity_id
   - process.executable
   - process.name
+  - process.pid
   - user.domain
   - user.effective.domain
   - user.effective.email


### PR DESCRIPTION
## Change Summary

Fixing custom documentation fields 

### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->

## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
