### PR TITLE
add prebuilt rules bug banner

### DIFF
--- a/doc_templates/endpoint/docs/README.md
+++ b/doc_templates/endpoint/docs/README.md
@@ -1,3 +1,8 @@
+
+⚠️ **Critical issue notice:** Creation of a new Defend integration policy instance in versions v8.16.x, v8.17.x, v8.18.0, and v9.0.0 can result in the loss of exceptions and actions tied to prebuilt rules. [Please review the known issue and workarounds.](https://ela.st/releasenotes)
+
+---
+
 # Elastic Defend Integration
 
 Elastic Defend provides organizations with prevention, detection, and response capabilities with deep visibility for EPP, EDR, SIEM, and Security Analytics use cases across Windows, macOS, and Linux operating systems running on both traditional endpoints and public cloud environments. ​​Use Elastic Defend to:

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -1,3 +1,8 @@
+
+⚠️ **Critical issue notice:** Creation of a new Defend integration policy instance in versions v8.16.x, v8.17.x, v8.18.0, and v9.0.0 can result in the loss of exceptions and actions tied to prebuilt rules. [Please review the known issue and workarounds.](https://ela.st/releasenotes)
+
+---
+
 # Elastic Defend Integration
 
 Elastic Defend provides organizations with prevention, detection, and response capabilities with deep visibility for EPP, EDR, SIEM, and Security Analytics use cases across Windows, macOS, and Linux operating systems running on both traditional endpoints and public cloud environments. ​​Use Elastic Defend to:


### PR DESCRIPTION
## Change Summary

Adds a notice to the readme, about the bug effects from https://github.com/elastic/kibana/pull/217959



## Release Target

9.0, 8.18, 8.17, 8.16 (note: _not_ 9.1)

The merge target to start is therefore `9.0`, not `main`, and then we will cherry-pick backport to the previous release branches


