### PR TITLE
[9.0] Cleanup format

### DIFF
--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -150,8 +150,8 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.system_impact.wmi_events.week_ms |
 | Endpoint.metrics.threads.cpu.mean |
 | Endpoint.metrics.threads.name |
-| Endpoint.metrics.top_process_trees.values.last_seen |
 | Endpoint.metrics.top_process_trees.values.event_count |
+| Endpoint.metrics.top_process_trees.values.last_seen |
 | Endpoint.metrics.top_process_trees.values.sample.command_line |
 | Endpoint.metrics.top_process_trees.values.sample.entity_id |
 | Endpoint.metrics.top_process_trees.values.sample.executable |


### PR DESCRIPTION
For whatever reason, `make` is generating this field ordering change. This PR is just committing `make` on the `9.0` branch to clear up CI