### PR TITLE
Fix Windows behavior alert custom doc

### DIFF
--- a/custom_documentation/doc/endpoint/alerts/windows/windows_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_malicious_behavior_alert.md
@@ -104,6 +104,7 @@ This alert occurs when a Malicious Behavior alert occurs.
 | threat.technique.id |
 | threat.technique.name |
 | threat.technique.reference |
+| threat.technique.subtechnique |
 | threat.technique.subtechnique.id |
 | threat.technique.subtechnique.name |
 | threat.technique.subtechnique.reference |

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malicious_behavior_alert.yaml
@@ -109,6 +109,7 @@ fields:
   - threat.technique.id
   - threat.technique.name
   - threat.technique.reference
+  - threat.technique.subtechnique
   - threat.technique.subtechnique.id
   - threat.technique.subtechnique.name
   - threat.technique.subtechnique.reference


### PR DESCRIPTION
## Change Summary

Some rules have `threat.technique.subtechnique: null`.  When Endpoint passes that through to Kibana, it results in a custom doc failure.

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes