### PR TITLE
Add metrics queues custom docs

### DIFF
--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -95,6 +95,11 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.malicious_behavior_rules.id |
 | Endpoint.metrics.memory.endpoint.private.latest |
 | Endpoint.metrics.memory.endpoint.private.mean |
+| Endpoint.metrics.queue_metrics.kernel.send_to_user_queue.drops |
+| Endpoint.metrics.queue_metrics.kernel.send_to_user_queue.size |
+| Endpoint.metrics.queue_metrics.kernel.send_to_user_queue.last_drop_time_utc |
+| Endpoint.metrics.queue_metrics.user.async_kernel_event_queue.drops |
+| Endpoint.metrics.queue_metrics.user.async_kernel_event_queue.size |
 | Endpoint.metrics.system_impact.amsi_events.week_idle_ms |
 | Endpoint.metrics.system_impact.amsi_events.week_ms |
 | Endpoint.metrics.system_impact.attack_surface_events.week_idle_ms |

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -102,6 +102,11 @@ fields:
   - Endpoint.metrics.malicious_behavior_rules.id
   - Endpoint.metrics.memory.endpoint.private.latest
   - Endpoint.metrics.memory.endpoint.private.mean
+  - Endpoint.metrics.queue_metrics.kernel.send_to_user_queue.drops
+  - Endpoint.metrics.queue_metrics.kernel.send_to_user_queue.size
+  - Endpoint.metrics.queue_metrics.kernel.send_to_user_queue.last_drop_time_utc
+  - Endpoint.metrics.queue_metrics.user.async_kernel_event_queue.drops
+  - Endpoint.metrics.queue_metrics.user.async_kernel_event_queue.size
   - Endpoint.metrics.system_impact.amsi_events.week_idle_ms
   - Endpoint.metrics.system_impact.amsi_events.week_ms
   - Endpoint.metrics.system_impact.attack_surface_events.week_idle_ms


### PR DESCRIPTION
## Change Summary

Add Endpoint.metrics.queue_metric.* to custom docs to fix EAF failures:


```
AssertionError: Found documents with fields missing custom documentation, count: 2, undocumented keys: {'Endpoint.metrics.queue_metrics.user.async_kernel_event_queue.drops', 'Endpoint.metrics.queue_metrics.user.async_kernel_event_queue.size', 'Endpoint.metrics.queue_metrics.kernel.send_to_user_queue.drops', 'Endpoint.metrics.queue_metrics.kernel.send_to_user_queue.size'}. Documents written to custom_documentation_violations.ndjson
```

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes

## Release Target

8.17.6.