### PR TITLE
Add process.command_line to some windows file events

### DIFF
--- a/custom_documentation/doc/endpoint/file/windows/windows_file_modification.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_modification.md
@@ -64,6 +64,7 @@ This event is generated when a file is modified.
 | process.code_signature.status |
 | process.code_signature.subject_name |
 | process.code_signature.trusted |
+| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_overwrite.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_overwrite.md
@@ -64,6 +64,7 @@ This event is generated when a file is overwritten
 | process.code_signature.status |
 | process.code_signature.subject_name |
 | process.code_signature.trusted |
+| process.command_line |
 | process.entity_id |
 | process.executable |
 | process.name |

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_modification.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_modification.yaml
@@ -69,6 +69,7 @@ fields:
   - process.code_signature.status
   - process.code_signature.subject_name
   - process.code_signature.trusted
+  - process.command_line
   - process.entity_id
   - process.executable
   - process.name

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_overwrite.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_overwrite.yaml
@@ -69,6 +69,7 @@ fields:
   - process.code_signature.status
   - process.code_signature.subject_name
   - process.code_signature.trusted
+  - process.command_line
   - process.entity_id
   - process.executable
   - process.name


### PR DESCRIPTION
## Change Summary

`process.command_line` was missing from custom docs for two types of file events.