### PR TITLE
Actions log spaces

### DIFF
--- a/custom_schemas/custom_action_policy.yml
+++ b/custom_schemas/custom_action_policy.yml
@@ -1,0 +1,32 @@
+- name: agent
+  title: Agent
+  type: group
+  group: 2
+  level: custom
+  short: agent
+  description: >
+    The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host.
+
+    Examples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.
+  fields:
+    - name: policy.elasticAgentId
+      title: Elastic Agent ID
+      type: keyword
+      level: custom
+      short: elastic agent ID
+      description: >
+        The agent ID of elastic agent explicitly, even if agent.id refers to an external agent.
+    - name: policy.integrationPolicyId
+      title: Integration Policy ID
+      type: keyword
+      level: custom
+      short: integration policy
+      description: >
+        The agent's integration policy ID at the time the action was initiated.
+    - name: policy.agentPolicyId
+      title: Agent Policy ID
+      type: keyword
+      level: custom
+      short: agent policy
+      description: >
+        The agent's policy ID at the time the action was initiated.

--- a/custom_schemas/custom_action_space.yml
+++ b/custom_schemas/custom_action_space.yml
@@ -1,0 +1,17 @@
+- name: space
+  root: true
+  title: Space
+  group: 2
+  short: Space-related fields
+  description: >
+    Fields to enable space-tracking in action documents
+  type: group
+  fields:
+    - name: originSpaceId
+      title: Origin Space ID
+      type: keyword
+      level: custom
+      short: originating space ID
+      description: >
+        The space ID that the action was initiated from
+

--- a/custom_subsets/elastic_endpoint/actions/actions.yaml
+++ b/custom_subsets/elastic_endpoint/actions/actions.yaml
@@ -23,6 +23,9 @@ fields:
   agent:
     fields:
       id: {}
+  space:
+    fields:
+      originSpaceId: {}
   rule:
     fields:
       id: {}

--- a/custom_subsets/elastic_endpoint/actions/actions.yaml
+++ b/custom_subsets/elastic_endpoint/actions/actions.yaml
@@ -23,6 +23,11 @@ fields:
   agent:
     fields:
       id: {}
+      policy:
+        fields:
+          elasticAgentId: {}
+          integrationPolicyId: {}
+          agentPolicyId: {}
   space:
     fields:
       originSpaceId: {}

--- a/package/endpoint/data_stream/actions/fields/fields.yml
+++ b/package/endpoint/data_stream/actions/fields/fields.yml
@@ -127,6 +127,24 @@
 
         Example: For Beats this would be beat.id.'
       example: 8a4f500d
+    - name: policy.agentPolicyId
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The agent's policy ID at the time the action was initiated.
+      default_field: false
+    - name: policy.elasticAgentId
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The agent ID of elastic agent explicitly, even if agent.id refers to an external agent.
+      default_field: false
+    - name: policy.integrationPolicyId
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: The agent's integration policy ID at the time the action was initiated.
+      default_field: false
 - name: data_stream
   title: data_stream
   group: 2

--- a/package/endpoint/data_stream/actions/fields/fields.yml
+++ b/package/endpoint/data_stream/actions/fields/fields.yml
@@ -319,6 +319,11 @@
       description: The name of the rule or signature generating the event.
       example: BLOCK_DNS_over_TLS
       default_field: false
+- name: originSpaceId
+  level: custom
+  type: keyword
+  ignore_above: 1024
+  description: The space ID that the action was initiated from
 - name: user
   title: User
   group: 2

--- a/package/endpoint/data_stream/actions/sample_event.json
+++ b/package/endpoint/data_stream/actions/sample_event.json
@@ -12,8 +12,23 @@
     "agent": {
         "id": [
             "c8cad7f3-9e62-43d0-94ed-8c51670fae62"
+        ],
+        "policy": [
+          {
+            "agentId": "ff1a47b4-71ed-4cbf-ad7f-55203358850d",
+            "elasticAgentId": "1e2f91a1-1946-460d-b885-af983d964ea3",
+            "integrationPolicyId": "645fe9a9-2afd-4b4b-a2d7-38ee21e0f19d",
+            "agentPolicyId": "e9734d0c-1816-4d68-8d9a-84418a850927"
+          },
+          {
+            "agentId": "a756f3f4-c974-4d44-84f5-ba02a954cd55",
+            "elasticAgentId": "20ceb5f6-4e15-4db5-9494-f47f589de33f",
+            "integrationPolicyId": "1f297497-14d4-4bf5-9d26-7c5e629e1d62",
+            "agentPolicyId": "100a3ee3-5304-4fc9-b495-e0022178a2f3"
+          }
         ]
     },
+    "originSpaceId": "b88dae77-9037-459b-be31-efefa6788362",
     "@timestamp": "2022-04-04T20:44:07.805Z",
     "event": {
         "agent_id_status": "auth_metadata_missing",

--- a/package/endpoint/data_stream/actions/sample_event.json
+++ b/package/endpoint/data_stream/actions/sample_event.json
@@ -14,18 +14,18 @@
             "c8cad7f3-9e62-43d0-94ed-8c51670fae62"
         ],
         "policy": [
-          {
-            "agentId": "ff1a47b4-71ed-4cbf-ad7f-55203358850d",
-            "elasticAgentId": "1e2f91a1-1946-460d-b885-af983d964ea3",
-            "integrationPolicyId": "645fe9a9-2afd-4b4b-a2d7-38ee21e0f19d",
-            "agentPolicyId": "e9734d0c-1816-4d68-8d9a-84418a850927"
-          },
-          {
-            "agentId": "a756f3f4-c974-4d44-84f5-ba02a954cd55",
-            "elasticAgentId": "20ceb5f6-4e15-4db5-9494-f47f589de33f",
-            "integrationPolicyId": "1f297497-14d4-4bf5-9d26-7c5e629e1d62",
-            "agentPolicyId": "100a3ee3-5304-4fc9-b495-e0022178a2f3"
-          }
+            {
+                "agentId": "ff1a47b4-71ed-4cbf-ad7f-55203358850d",
+                "elasticAgentId": "1e2f91a1-1946-460d-b885-af983d964ea3",
+                "integrationPolicyId": "645fe9a9-2afd-4b4b-a2d7-38ee21e0f19d",
+                "agentPolicyId": "e9734d0c-1816-4d68-8d9a-84418a850927"
+            },
+            {
+                "agentId": "a756f3f4-c974-4d44-84f5-ba02a954cd55",
+                "elasticAgentId": "20ceb5f6-4e15-4db5-9494-f47f589de33f",
+                "integrationPolicyId": "1f297497-14d4-4bf5-9d26-7c5e629e1d62",
+                "agentPolicyId": "100a3ee3-5304-4fc9-b495-e0022178a2f3"
+            }
         ]
     },
     "originSpaceId": "b88dae77-9037-459b-be31-efefa6788362",

--- a/schemas/v1/actions/actions.yaml
+++ b/schemas/v1/actions/actions.yaml
@@ -119,6 +119,40 @@ agent.id:
   normalize: []
   short: Unique identifier of this agent.
   type: keyword
+agent.policy.agentPolicyId:
+  dashed_name: agent-policy-agentPolicyId
+  description: The agent's policy ID at the time the action was initiated.
+  flat_name: agent.policy.agentPolicyId
+  ignore_above: 1024
+  level: custom
+  name: policy.agentPolicyId
+  normalize: []
+  short: agent policy
+  title: Agent Policy ID
+  type: keyword
+agent.policy.elasticAgentId:
+  dashed_name: agent-policy-elasticAgentId
+  description: The agent ID of elastic agent explicitly, even if agent.id refers to
+    an external agent.
+  flat_name: agent.policy.elasticAgentId
+  ignore_above: 1024
+  level: custom
+  name: policy.elasticAgentId
+  normalize: []
+  short: elastic agent ID
+  title: Elastic Agent ID
+  type: keyword
+agent.policy.integrationPolicyId:
+  dashed_name: agent-policy-integrationPolicyId
+  description: The agent's integration policy ID at the time the action was initiated.
+  flat_name: agent.policy.integrationPolicyId
+  ignore_above: 1024
+  level: custom
+  name: policy.integrationPolicyId
+  normalize: []
+  short: integration policy
+  title: Integration Policy ID
+  type: keyword
 agents:
   dashed_name: agents
   description: 'Alias field that maps to {agent: {id}}'

--- a/schemas/v1/actions/actions.yaml
+++ b/schemas/v1/actions/actions.yaml
@@ -791,6 +791,17 @@ input_type:
   path: EndpointActions.input_type
   short: input_type
   type: alias
+originSpaceId:
+  dashed_name: originSpaceId
+  description: The space ID that the action was initiated from
+  flat_name: originSpaceId
+  ignore_above: 1024
+  level: custom
+  name: originSpaceId
+  normalize: []
+  short: originating space ID
+  title: Origin Space ID
+  type: keyword
 rule.id:
   dashed_name: rule-id
   description: A rule ID that is unique within the scope of an agent, observer, or


### PR DESCRIPTION
## Change Summary

Adds a space-awareness field (`originSpaceId`) as well as some policy-related IDs to action request documents


### Sample values

included in [`package/endpoint/data_stream/actions/sample_event.json`](https://github.com/elastic/endpoint-package/compare/actions-log-spaces?expand=1#diff-75c3868aefbfe12fdad1d549144e903bc85355948d8e5c8c30723e0eb029d179)

## Release Target

9.1


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes

