### PR TITLE
Add `event.provider` to API events

### DIFF
--- a/custom_subsets/elastic_endpoint/api/api.yaml
+++ b/custom_subsets/elastic_endpoint/api/api.yaml
@@ -38,6 +38,7 @@ fields:
       hash: {}
       id: {}
       ingested: {}
+      provider: {}
       outcome: {}
       start: {}
       type: {}

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -1068,6 +1068,14 @@
 
         Further note that not all events will have an associated outcome. For example, this field is generally not populated for metric events, events with `event.type:info`, or any events for which an outcome does not make logical sense.'
       example: success
+    - name: provider
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: 'Source of the event.
+
+        Event transports such as Syslog or the Windows Event Log typically mention the source of an event. It can be the name of the software that generated the event (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+      example: kernel
     - name: start
       level: extended
       type: date

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -2056,6 +2056,21 @@ event.outcome:
   normalize: []
   short: The outcome of the event. The lowest level categorization field in the hierarchy.
   type: keyword
+event.provider:
+  dashed_name: event-provider
+  description: 'Source of the event.
+
+    Event transports such as Syslog or the Windows Event Log typically mention the
+    source of an event. It can be the name of the software that generated the event
+    (e.g. Sysmon, httpd), or of a subsystem of the operating system (kernel, Microsoft-Windows-Security-Auditing).'
+  example: kernel
+  flat_name: event.provider
+  ignore_above: 1024
+  level: extended
+  name: provider
+  normalize: []
+  short: Source of the event.
+  type: keyword
 event.start:
   dashed_name: event-start
   description: '`event.start` contains the date when the event started or when the


### PR DESCRIPTION
## Change Summary

- https://github.com/elastic/endpoint-package/issues/630

Add `event.provider` to API events to fix the issue reported in https://github.com/elastic/endpoint-package/issues/630



### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))