### PR TITLE
Add fields for additional desktop_name process event field

### DIFF
--- a/custom_documentation/doc/endpoint/api/windows/windows_api_threat_intelligence.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_threat_intelligence.md
@@ -10,6 +10,7 @@ This event is generated when ETW Threat-Intelligence events are generated.
 |---|
 | @timestamp |
 | Target.process.Ext.created_suspended |
+| Target.process.Ext.desktop_name |
 | Target.process.Ext.protection |
 | Target.process.Ext.token.integrity_level_name |
 | Target.process.entity_id |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_win32k.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_win32k.md
@@ -9,6 +9,7 @@ This event is generated when keylogging-related Win32k APIs are called.
 | Field |
 |---|
 | @timestamp |
+| Target.process.Ext.desktop_name |
 | Target.process.Ext.protection |
 | Target.process.name |
 | Target.process.pid |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
@@ -50,6 +50,7 @@ This event is generated for a process that was already running before Endpoint's
 | process.Ext.code_signature.subject_name |
 | process.Ext.code_signature.trusted |
 | process.Ext.command_line_truncated |
+| process.Ext.desktop_name |
 | process.Ext.mitigation_policies |
 | process.Ext.protection |
 | process.Ext.relative_file_creation_time |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_create_and_exit.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_create_and_exit.md
@@ -63,6 +63,7 @@ This event is generated when a process is created or exits.
 | process.Ext.effective_parent.executable |
 | process.Ext.effective_parent.name |
 | process.Ext.effective_parent.pid |
+| process.Ext.desktop_name |
 | process.Ext.mitigation_policies |
 | process.Ext.protection |
 | process.Ext.relative_file_creation_time |

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_threat_intelligence.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_threat_intelligence.yaml
@@ -14,6 +14,7 @@ fields:
   endpoint:
   - '@timestamp'
   - Target.process.Ext.created_suspended
+  - Target.process.Ext.desktop_name
   - Target.process.Ext.protection
   - Target.process.Ext.token.integrity_level_name
   - Target.process.entity_id

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_win32k.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_win32k.yaml
@@ -13,6 +13,7 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Target.process.Ext.desktop_name
   - Target.process.Ext.protection
   - Target.process.name
   - Target.process.pid

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
@@ -56,6 +56,7 @@ fields:
   - process.Ext.code_signature.subject_name
   - process.Ext.code_signature.trusted
   - process.Ext.command_line_truncated
+  - process.Ext.desktop_name
   - process.Ext.mitigation_policies
   - process.Ext.protection
   - process.Ext.relative_file_creation_time

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create_and_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create_and_exit.yaml
@@ -70,6 +70,7 @@ fields:
   - process.Ext.effective_parent.executable
   - process.Ext.effective_parent.name
   - process.Ext.effective_parent.pid
+  - process.Ext.desktop_name
   - process.Ext.mitigation_policies
   - process.Ext.protection
   - process.Ext.relative_file_creation_time

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -624,7 +624,7 @@
       level: custom
       type: keyword
       short: Initial desktop name for the process.
-      description: Initial desktop name supplied to CreateProcess for the process.
+      description: Initial desktop name supplied to CreateProcess system API call to create the process.
       example: WinSta0\CustomDesktop
 
     - name: Ext.mitigation_policies

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -620,6 +620,13 @@
       description: A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32 CreateProcess API. Not valid for direct syscalls.
       example: "true"
 
+    - name: Ext.desktop_name
+      level: custom
+      type: keyword
+      short: Initial desktop name for the process.
+      description: Initial desktop name supplied to CreateProcess for the process.
+      example: WinSta0\Default
+
     - name: Ext.mitigation_policies
       level: custom
       type: keyword

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -625,7 +625,7 @@
       type: keyword
       short: Initial desktop name for the process.
       description: Initial desktop name supplied to CreateProcess for the process.
-      example: WinSta0\Default
+      example: WinSta0\CustomDesktop
 
     - name: Ext.mitigation_policies
       level: custom

--- a/custom_subsets/elastic_endpoint/alerts/rule_detection_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/rule_detection_event.yaml
@@ -35,6 +35,7 @@ fields:
                   app_name: {}
                   content_name: {}
           created_suspended: {}
+          desktop_name: {}
           token:
             fields:
               integrity_level_name: {}

--- a/custom_subsets/elastic_endpoint/api/api.yaml
+++ b/custom_subsets/elastic_endpoint/api/api.yaml
@@ -86,6 +86,7 @@ fields:
           Ext:
             fields:
               created_suspended: {}
+              desktop_name: {}
               memory_region:
                 fields: "*"
               protection: {}
@@ -112,6 +113,7 @@ fields:
               parameters:
                 fields: "*"
           created_suspended: {}
+          desktop_name: {}
           memory_region:
             fields: "*"
           token:

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -187,6 +187,7 @@ fields:
               valid: {}
           created_suspended: {}
           defense_evasions: {}
+          desktop_name: {}
           mitigation_policies: {}
           dll:
             fields:

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -4651,7 +4651,7 @@
       level: custom
       type: keyword
       ignore_above: 1024
-      description: Initial desktop name supplied to CreateProcess for the process.
+      description: Initial desktop name supplied to CreateProcess system API call to create the process.
       example: WinSta0\CustomDesktop
       default_field: false
     - name: Ext.dll.Ext

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -4647,6 +4647,13 @@
       description: A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32 CreateProcess API. Not valid for direct syscalls.
       example: 'true'
       default_field: false
+    - name: Ext.desktop_name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Initial desktop name supplied to CreateProcess for the process.
+      example: WinSta0\Default
+      default_field: false
     - name: Ext.dll.Ext
       level: custom
       type: object

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -4652,7 +4652,7 @@
       type: keyword
       ignore_above: 1024
       description: Initial desktop name supplied to CreateProcess for the process.
-      example: WinSta0\Default
+      example: WinSta0\CustomDesktop
       default_field: false
     - name: Ext.dll.Ext
       level: custom

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -46,7 +46,7 @@
       type: keyword
       ignore_above: 1024
       description: Initial desktop name supplied to CreateProcess for the process.
-      example: WinSta0\Default
+      example: WinSta0\CustomDesktop
       default_field: false
     - name: process.Ext.memory_region.allocation_base
       level: custom
@@ -1823,7 +1823,7 @@
       type: keyword
       ignore_above: 1024
       description: Initial desktop name supplied to CreateProcess for the process.
-      example: WinSta0\Default
+      example: WinSta0\CustomDesktop
       default_field: false
     - name: Ext.memory_region.allocation_base
       level: custom

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -45,7 +45,7 @@
       level: custom
       type: keyword
       ignore_above: 1024
-      description: Initial desktop name supplied to CreateProcess for the process.
+      description: Initial desktop name supplied to CreateProcess system API call to create the process.
       example: WinSta0\CustomDesktop
       default_field: false
     - name: process.Ext.memory_region.allocation_base
@@ -1822,7 +1822,7 @@
       level: custom
       type: keyword
       ignore_above: 1024
-      description: Initial desktop name supplied to CreateProcess for the process.
+      description: Initial desktop name supplied to CreateProcess system API call to create the process.
       example: WinSta0\CustomDesktop
       default_field: false
     - name: Ext.memory_region.allocation_base

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -41,6 +41,13 @@
       description: A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32 CreateProcess API. Not valid for direct syscalls.
       example: 'true'
       default_field: false
+    - name: process.Ext.desktop_name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Initial desktop name supplied to CreateProcess for the process.
+      example: WinSta0\Default
+      default_field: false
     - name: process.Ext.memory_region.allocation_base
       level: custom
       type: unsigned_long
@@ -1810,6 +1817,13 @@
       type: boolean
       description: A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32 CreateProcess API. Not valid for direct syscalls.
       example: 'true'
+      default_field: false
+    - name: Ext.desktop_name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Initial desktop name supplied to CreateProcess for the process.
+      example: WinSta0\Default
       default_field: false
     - name: Ext.memory_region.allocation_base
       level: custom

--- a/package/endpoint/data_stream/api/sample_event.json
+++ b/package/endpoint/data_stream/api/sample_event.json
@@ -4,6 +4,7 @@
         "process": {
             "Ext": {
                 "created_suspended": true,
+                "desktop_name": "WinSta0\\CustomDesktop",
                 "protection": "PsProtectedSignerWinTcb",
                 "memory_region": {
                     "allocation_base": 1649160290304,

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -782,7 +782,7 @@
       type: keyword
       ignore_above: 1024
       description: Initial desktop name supplied to CreateProcess for the process.
-      example: WinSta0\Default
+      example: WinSta0\CustomDesktop
       default_field: false
     - name: Ext.device.bus_type
       level: custom

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -777,6 +777,13 @@
       ignore_above: 1024
       description: List of defense evasions found in this process. These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior. Examples tools that can cause defense evasions include Process Doppelganging and Process Herpaderping.
       default_field: false
+    - name: Ext.desktop_name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Initial desktop name supplied to CreateProcess for the process.
+      example: WinSta0\Default
+      default_field: false
     - name: Ext.device.bus_type
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -781,7 +781,7 @@
       level: custom
       type: keyword
       ignore_above: 1024
-      description: Initial desktop name supplied to CreateProcess for the process.
+      description: Initial desktop name supplied to CreateProcess system API call to create the process.
       example: WinSta0\CustomDesktop
       default_field: false
     - name: Ext.device.bus_type

--- a/package/endpoint/data_stream/process/sample_event.json
+++ b/package/endpoint/data_stream/process/sample_event.json
@@ -82,6 +82,7 @@
                 }
             ],
             "created_suspended": true,
+            "desktop_name": "WinSta0\\CustomDesktop",
             "mitigation_policies": [
                 "Microsoft only, Opt-in to restrict to Microsoft, Windows Store and WHQL",
                 "CET dynamic APIs can only be called out of proc",

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -662,7 +662,7 @@ sent by the endpoint.
 | process.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | process.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.Ext.created_suspended | A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32 CreateProcess API. Not valid for direct syscalls. | boolean |
-| process.Ext.desktop_name | Initial desktop name supplied to CreateProcess for the process. | keyword |
+| process.Ext.desktop_name | Initial desktop name supplied to CreateProcess system API call to create the process. | keyword |
 | process.Ext.dll.Ext | Object for all custom defined fields to live in. | object |
 | process.Ext.dll.Ext.code_signature | Nested version of ECS code_signature fieldset. | nested |
 | process.Ext.dll.Ext.code_signature.exists | Boolean to capture if a signature is present. | boolean |
@@ -2203,7 +2203,7 @@ sent by the endpoint.
 | process.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.Ext.created_suspended | A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32 CreateProcess API. Not valid for direct syscalls. | boolean |
 | process.Ext.defense_evasions | List of defense evasions found in this process. These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior. Examples tools that can cause defense evasions include Process Doppelganging and Process Herpaderping. | keyword |
-| process.Ext.desktop_name | Initial desktop name supplied to CreateProcess for the process. | keyword |
+| process.Ext.desktop_name | Initial desktop name supplied to CreateProcess system API call to create the process. | keyword |
 | process.Ext.device.bus_type | Bus type of the device, such as Nvme, Usb, FileBackedVirtual,... etc. | keyword |
 | process.Ext.device.dos_name | DOS name of the device. DOS device name is in the format of driver letters such as C:, D:,... | keyword |
 | process.Ext.device.file_system_type | Volume device file system type. Following are examples of the most frequently seen volume device file system types: NTFS UDF | keyword |

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -662,6 +662,7 @@ sent by the endpoint.
 | process.Ext.code_signature.trusted | Stores the trust status of the certificate chain. Validating the trust of the certificate chain may be complicated, and this field should only be populated by tools that actively check the status. | boolean |
 | process.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.Ext.created_suspended | A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32 CreateProcess API. Not valid for direct syscalls. | boolean |
+| process.Ext.desktop_name | Initial desktop name supplied to CreateProcess for the process. | keyword |
 | process.Ext.dll.Ext | Object for all custom defined fields to live in. | object |
 | process.Ext.dll.Ext.code_signature | Nested version of ECS code_signature fieldset. | nested |
 | process.Ext.dll.Ext.code_signature.exists | Boolean to capture if a signature is present. | boolean |
@@ -2202,6 +2203,7 @@ sent by the endpoint.
 | process.Ext.code_signature.valid | Boolean to capture if the digital signature is verified against the binary content. Leave unpopulated if a certificate was unchecked. | boolean |
 | process.Ext.created_suspended | A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32 CreateProcess API. Not valid for direct syscalls. | boolean |
 | process.Ext.defense_evasions | List of defense evasions found in this process. These defense evasions can make it harder to inspect a process and/or cause abnormal OS behavior. Examples tools that can cause defense evasions include Process Doppelganging and Process Herpaderping. | keyword |
+| process.Ext.desktop_name | Initial desktop name supplied to CreateProcess for the process. | keyword |
 | process.Ext.device.bus_type | Bus type of the device, such as Nvme, Usb, FileBackedVirtual,... etc. | keyword |
 | process.Ext.device.dos_name | DOS name of the device. DOS device name is in the format of driver letters such as C:, D:,... | keyword |
 | process.Ext.device.file_system_type | Volume device file system type. Following are examples of the most frequently seen volume device file system types: NTFS UDF | keyword |

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -17,6 +17,7 @@ conditions:
   kibana:
     version: "^9.1.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
+
   elastic:
     capabilities: ["security"]
     subscription: basic

--- a/schemas/v1/alerts/rule_detection_event.yaml
+++ b/schemas/v1/alerts/rule_detection_event.yaml
@@ -616,6 +616,17 @@ process.Ext.created_suspended:
   short: A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32
     CreateProcess API.
   type: boolean
+process.Ext.desktop_name:
+  dashed_name: process-Ext-desktop-name
+  description: Initial desktop name supplied to CreateProcess for the process.
+  example: WinSta0\Default
+  flat_name: process.Ext.desktop_name
+  ignore_above: 1024
+  level: custom
+  name: Ext.desktop_name
+  normalize: []
+  short: Initial desktop name for the process.
+  type: keyword
 process.Ext.protection:
   dashed_name: process-Ext-protection
   description: Indicates the protection level of this process.  Uses the same syntax

--- a/schemas/v1/alerts/rule_detection_event.yaml
+++ b/schemas/v1/alerts/rule_detection_event.yaml
@@ -618,7 +618,8 @@ process.Ext.created_suspended:
   type: boolean
 process.Ext.desktop_name:
   dashed_name: process-Ext-desktop-name
-  description: Initial desktop name supplied to CreateProcess for the process.
+  description: Initial desktop name supplied to CreateProcess system API call to create
+    the process.
   example: WinSta0\CustomDesktop
   flat_name: process.Ext.desktop_name
   ignore_above: 1024

--- a/schemas/v1/alerts/rule_detection_event.yaml
+++ b/schemas/v1/alerts/rule_detection_event.yaml
@@ -619,7 +619,7 @@ process.Ext.created_suspended:
 process.Ext.desktop_name:
   dashed_name: process-Ext-desktop-name
   description: Initial desktop name supplied to CreateProcess for the process.
-  example: WinSta0\Default
+  example: WinSta0\CustomDesktop
   flat_name: process.Ext.desktop_name
   ignore_above: 1024
   level: custom

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -42,7 +42,8 @@ Target.process.Ext.created_suspended:
   type: boolean
 Target.process.Ext.desktop_name:
   dashed_name: Target-process-Ext-desktop-name
-  description: Initial desktop name supplied to CreateProcess for the process.
+  description: Initial desktop name supplied to CreateProcess system API call to create
+    the process.
   example: WinSta0\CustomDesktop
   flat_name: Target.process.Ext.desktop_name
   ignore_above: 1024
@@ -3573,7 +3574,8 @@ process.Ext.created_suspended:
   type: boolean
 process.Ext.desktop_name:
   dashed_name: process-Ext-desktop-name
-  description: Initial desktop name supplied to CreateProcess for the process.
+  description: Initial desktop name supplied to CreateProcess system API call to create
+    the process.
   example: WinSta0\CustomDesktop
   flat_name: process.Ext.desktop_name
   ignore_above: 1024

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -40,6 +40,18 @@ Target.process.Ext.created_suspended:
   short: A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32
     CreateProcess API.
   type: boolean
+Target.process.Ext.desktop_name:
+  dashed_name: Target-process-Ext-desktop-name
+  description: Initial desktop name supplied to CreateProcess for the process.
+  example: WinSta0\Default
+  flat_name: Target.process.Ext.desktop_name
+  ignore_above: 1024
+  level: custom
+  name: Ext.desktop_name
+  normalize: []
+  original_fieldset: process
+  short: Initial desktop name for the process.
+  type: keyword
 Target.process.Ext.memory_region.allocation_base:
   dashed_name: Target-process-Ext-memory-region-allocation-base
   description: Base address of the memory allocation containing the memory region.
@@ -3559,6 +3571,17 @@ process.Ext.created_suspended:
   short: A heuristic indicating if the CREATE_SUSPENDED flag was passed to the Win32
     CreateProcess API.
   type: boolean
+process.Ext.desktop_name:
+  dashed_name: process-Ext-desktop-name
+  description: Initial desktop name supplied to CreateProcess for the process.
+  example: WinSta0\Default
+  flat_name: process.Ext.desktop_name
+  ignore_above: 1024
+  level: custom
+  name: Ext.desktop_name
+  normalize: []
+  short: Initial desktop name for the process.
+  type: keyword
 process.Ext.memory_region.allocation_base:
   dashed_name: process-Ext-memory-region-allocation-base
   description: Base address of the memory allocation containing the memory region.

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -43,7 +43,7 @@ Target.process.Ext.created_suspended:
 Target.process.Ext.desktop_name:
   dashed_name: Target-process-Ext-desktop-name
   description: Initial desktop name supplied to CreateProcess for the process.
-  example: WinSta0\Default
+  example: WinSta0\CustomDesktop
   flat_name: Target.process.Ext.desktop_name
   ignore_above: 1024
   level: custom
@@ -3574,7 +3574,7 @@ process.Ext.created_suspended:
 process.Ext.desktop_name:
   dashed_name: process-Ext-desktop-name
   description: Initial desktop name supplied to CreateProcess for the process.
-  example: WinSta0\Default
+  example: WinSta0\CustomDesktop
   flat_name: process.Ext.desktop_name
   ignore_above: 1024
   level: custom

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1414,6 +1414,17 @@ process.Ext.defense_evasions:
   normalize: []
   short: List of defense evasions found in this process.
   type: keyword
+process.Ext.desktop_name:
+  dashed_name: process-Ext-desktop-name
+  description: Initial desktop name supplied to CreateProcess for the process.
+  example: WinSta0\Default
+  flat_name: process.Ext.desktop_name
+  ignore_above: 1024
+  level: custom
+  name: Ext.desktop_name
+  normalize: []
+  short: Initial desktop name for the process.
+  type: keyword
 process.Ext.device.bus_type:
   dashed_name: process-Ext-device-bus-type
   description: Bus type of the device, such as Nvme, Usb, FileBackedVirtual,... etc.

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1416,7 +1416,8 @@ process.Ext.defense_evasions:
   type: keyword
 process.Ext.desktop_name:
   dashed_name: process-Ext-desktop-name
-  description: Initial desktop name supplied to CreateProcess for the process.
+  description: Initial desktop name supplied to CreateProcess system API call to create
+    the process.
   example: WinSta0\CustomDesktop
   flat_name: process.Ext.desktop_name
   ignore_above: 1024

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1417,7 +1417,7 @@ process.Ext.defense_evasions:
 process.Ext.desktop_name:
   dashed_name: process-Ext-desktop-name
   description: Initial desktop name supplied to CreateProcess for the process.
-  example: WinSta0\Default
+  example: WinSta0\CustomDesktop
   flat_name: process.Ext.desktop_name
   ignore_above: 1024
   level: custom


### PR DESCRIPTION
## Change Summary

Add additional `desktop_name` field for process creation event telemetry.

## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
