### PR TITLE
Add custom documentation entries for LDAP/HTTP ETW telemetry

### DIFF
--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -118,6 +118,8 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.system_impact.file_events.week_ms |
 | Endpoint.metrics.system_impact.kernel_api_events.week_idle_ms |
 | Endpoint.metrics.system_impact.kernel_api_events.week_ms |
+| Endpoint.metrics.system_impact.ldap_client_events.week_idle_ms |
+| Endpoint.metrics.system_impact.ldap_client_events.week_ms |
 | Endpoint.metrics.system_impact.library_load_events.week_idle_ms |
 | Endpoint.metrics.system_impact.library_load_events.week_ms |
 | Endpoint.metrics.system_impact.malware.week_idle_ms |
@@ -151,6 +153,10 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.system_impact.volume_device_events.week_ms |
 | Endpoint.metrics.system_impact.win32k_events.week_idle_ms |
 | Endpoint.metrics.system_impact.win32k_events.week_ms |
+| Endpoint.metrics.system_impact.winhttp_events.week_idle_ms |
+| Endpoint.metrics.system_impact.winhttp_events.week_ms |
+| Endpoint.metrics.system_impact.wininet_events.week_idle_ms |
+| Endpoint.metrics.system_impact.wininet_events.week_ms |
 | Endpoint.metrics.system_impact.wmi_events.week_idle_ms |
 | Endpoint.metrics.system_impact.wmi_events.week_ms |
 | Endpoint.metrics.threads.cpu.mean |

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -125,6 +125,8 @@ fields:
   - Endpoint.metrics.system_impact.file_events.week_ms
   - Endpoint.metrics.system_impact.kernel_api_events.week_idle_ms
   - Endpoint.metrics.system_impact.kernel_api_events.week_ms
+  - Endpoint.metrics.system_impact.ldap_client_events.week_idle_ms
+  - Endpoint.metrics.system_impact.ldap_client_events.week_ms
   - Endpoint.metrics.system_impact.library_load_events.week_idle_ms
   - Endpoint.metrics.system_impact.library_load_events.week_ms
   - Endpoint.metrics.system_impact.malware.week_idle_ms
@@ -158,6 +160,10 @@ fields:
   - Endpoint.metrics.system_impact.volume_device_events.week_ms
   - Endpoint.metrics.system_impact.win32k_events.week_idle_ms
   - Endpoint.metrics.system_impact.win32k_events.week_ms
+  - Endpoint.metrics.system_impact.winhttp_events.week_idle_ms
+  - Endpoint.metrics.system_impact.winhttp_events.week_ms
+  - Endpoint.metrics.system_impact.wininet_events.week_idle_ms
+  - Endpoint.metrics.system_impact.wininet_events.week_ms
   - Endpoint.metrics.system_impact.wmi_events.week_idle_ms
   - Endpoint.metrics.system_impact.wmi_events.week_ms
   - Endpoint.metrics.threads.cpu.mean

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -17,6 +17,7 @@ conditions:
   kibana:
     version: "^9.1.0"
   # See https://github.com/Masterminds/semver#caret-range-comparisons-major for more details on `^` and supported versioning
+
   elastic:
     capabilities: ["security"]
     subscription: basic


### PR DESCRIPTION
## Change Summary

Add the following fields for LDAP/WinHTTP/WinINet ETW telemetry:
```
Endpoint.metrics.system_impact.ldap_client_events.week_idle_ms
Endpoint.metrics.system_impact.ldap_client_events.week_ms
Endpoint.metrics.system_impact.winhttp_events.week_idle_ms
Endpoint.metrics.system_impact.winhttp_events.week_ms
Endpoint.metrics.system_impact.wininet_events.week_idle_ms
Endpoint.metrics.system_impact.wininet_events.week_ms
```

## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
