### PR TITLE
Add new policy fields for firewall_anti_tamper plugin

### DIFF
--- a/custom_documentation/doc/endpoint/policy/policy_response.md
+++ b/custom_documentation/doc/endpoint/policy/policy_response.md
@@ -36,8 +36,6 @@ This is a state management document that is generated every time Endpoint refres
 | Endpoint.policy.applied.response.configurations.behavior_protection.status |
 | Endpoint.policy.applied.response.configurations.events.concerned_actions |
 | Endpoint.policy.applied.response.configurations.events.status |
-| Endpoint.policy.applied.response.configurations.firewall_anti_tamper.concerned_actions |
-| Endpoint.policy.applied.response.configurations.firewall_anti_tamper.status |
 | Endpoint.policy.applied.response.configurations.host_isolation.concerned_actions |
 | Endpoint.policy.applied.response.configurations.host_isolation.status |
 | Endpoint.policy.applied.response.configurations.logging.concerned_actions |
@@ -54,6 +52,8 @@ This is a state management document that is generated every time Endpoint refres
 | Endpoint.policy.applied.response.configurations.streaming.status |
 | Endpoint.policy.applied.response.diagnostic.behavior_protection.concerned_actions |
 | Endpoint.policy.applied.response.diagnostic.behavior_protection.status |
+| Endpoint.policy.applied.response.diagnostic.firewall_anti_tamper.concerned_actions |
+| Endpoint.policy.applied.response.diagnostic.firewall_anti_tamper.status |
 | Endpoint.policy.applied.response.diagnostic.malware.concerned_actions |
 | Endpoint.policy.applied.response.diagnostic.malware.status |
 | Endpoint.policy.applied.response.diagnostic.memory_protection.concerned_actions |

--- a/custom_documentation/src/endpoint/data_stream/policy/policy_response.yaml
+++ b/custom_documentation/src/endpoint/data_stream/policy/policy_response.yaml
@@ -44,8 +44,6 @@ fields:
   - Endpoint.policy.applied.response.configurations.behavior_protection.status
   - Endpoint.policy.applied.response.configurations.events.concerned_actions
   - Endpoint.policy.applied.response.configurations.events.status
-  - Endpoint.policy.applied.response.configurations.firewall_anti_tamper.concerned_actions
-  - Endpoint.policy.applied.response.configurations.firewall_anti_tamper.status
   - Endpoint.policy.applied.response.configurations.host_isolation.concerned_actions
   - Endpoint.policy.applied.response.configurations.host_isolation.status
   - Endpoint.policy.applied.response.configurations.logging.concerned_actions
@@ -62,6 +60,8 @@ fields:
   - Endpoint.policy.applied.response.configurations.streaming.status
   - Endpoint.policy.applied.response.diagnostic.behavior_protection.concerned_actions
   - Endpoint.policy.applied.response.diagnostic.behavior_protection.status
+  - Endpoint.policy.applied.response.diagnostic.firewall_anti_tamper.concerned_actions
+  - Endpoint.policy.applied.response.diagnostic.firewall_anti_tamper.status
   - Endpoint.policy.applied.response.diagnostic.malware.concerned_actions
   - Endpoint.policy.applied.response.diagnostic.malware.status
   - Endpoint.policy.applied.response.diagnostic.memory_protection.concerned_actions

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -171,24 +171,6 @@
         but not a simple sum of the actions
       short: the overall status of memory_protection
 
-    - name: policy.applied.response.configurations.firewall_anti_tamper
-      level: custom
-      type: object
-      description: overall firewall anti-tamper configuration and status of the applied policy
-
-    - name: policy.applied.response.configurations.firewall_anti_tamper.concerned_actions
-      level: custom
-      type: keyword
-      description: all actions that were taken for firewall anti-tamper
-
-    - name: policy.applied.response.configurations.firewall_anti_tamper.status
-      level: custom
-      type: keyword
-      description: >
-        the overall status of firewall anti-tamper, this is correlated to the status of concerned actions
-        but not a simple sum of the actions
-      short: the overall status of firewall anti-tamper
-
     - name: policy.applied.response.configurations.streaming
       level: custom
       type: object
@@ -264,6 +246,24 @@
       type: object
       enabled: false
       description: the diagnostic configurations of the applied policy
+
+    - name: policy.applied.response.diagnostic.firewall_anti_tamper
+      level: custom
+      type: object
+      description: overall firewall anti-tamper configuration and status of the applied policy
+
+    - name: policy.applied.response.diagnostic.firewall_anti_tamper.concerned_actions
+      level: custom
+      type: keyword
+      description: all actions that were taken for the diagnostic configuration of firewall anti-tamper
+
+    - name: policy.applied.response.diagnostic.firewall_anti_tamper.status
+      level: custom
+      type: keyword
+      description: >
+        the overall status of the diagnostic configuration of firewall anti-tamper, this is correlated to
+        the status of concerned actions but not a simple sum of the actions
+      short: the overall status of diagnostic firewall anti-tamper
 
     - name: policy.applied.response.diagnostic.ransomware.concerned_actions
       level: custom

--- a/package/endpoint/data_stream/policy/fields/fields.yml
+++ b/package/endpoint/data_stream/policy/fields/fields.yml
@@ -245,23 +245,6 @@
       ignore_above: 1024
       description: the overall status of event collection, this is correlated to the status of concerned actions  but not a simple sum of the actions
       default_field: false
-    - name: policy.applied.response.configurations.firewall_anti_tamper
-      level: custom
-      type: object
-      description: overall firewall anti-tamper configuration and status of the applied policy
-      default_field: false
-    - name: policy.applied.response.configurations.firewall_anti_tamper.concerned_actions
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: all actions that were taken for firewall anti-tamper
-      default_field: false
-    - name: policy.applied.response.configurations.firewall_anti_tamper.status
-      level: custom
-      type: keyword
-      ignore_above: 1024
-      description: the overall status of firewall anti-tamper, this is correlated to the status of concerned actions but not a simple sum of the actions
-      default_field: false
     - name: policy.applied.response.configurations.host_isolation.concerned_actions
       level: custom
       type: keyword
@@ -383,6 +366,23 @@
       type: keyword
       ignore_above: 1024
       description: the overall status of the diagnostic configuration of credential protection, this is correlated to  the status of concerned actions but not a simple sum of the actions
+      default_field: false
+    - name: policy.applied.response.diagnostic.firewall_anti_tamper
+      level: custom
+      type: object
+      description: overall firewall anti-tamper configuration and status of the applied policy
+      default_field: false
+    - name: policy.applied.response.diagnostic.firewall_anti_tamper.concerned_actions
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: all actions that were taken for the diagnostic configuration of firewall anti-tamper
+      default_field: false
+    - name: policy.applied.response.diagnostic.firewall_anti_tamper.status
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: the overall status of the diagnostic configuration of firewall anti-tamper, this is correlated to the status of concerned actions but not a simple sum of the actions
       default_field: false
     - name: policy.applied.response.diagnostic.malware.concerned_actions
       level: custom

--- a/package/endpoint/data_stream/policy/sample_event.json
+++ b/package/endpoint/data_stream/policy/sample_event.json
@@ -243,6 +243,16 @@
                                 "configure_diagnostic_rollback"
                             ],
                             "status": "success"
+                        },
+                        "firewall_anti_tamper": {
+                            "concerned_actions": [
+                                "load_config",
+                                "workflow",
+                                "download_global_artifacts",
+                                "download_user_artifacts",
+                                "configure_diagnostic_firewall_anti_tamper"
+                            ],
+                            "status": "success"
                         }
                     }
                 },

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -395,37 +395,6 @@ Endpoint.policy.applied.response.configurations.events.status:
   normalize: []
   short: the overall status of event collection
   type: keyword
-Endpoint.policy.applied.response.configurations.firewall_anti_tamper:
-  dashed_name: Endpoint-policy-applied-response-configurations-firewall-anti-tamper
-  description: overall firewall anti-tamper configuration and status of the applied
-    policy
-  flat_name: Endpoint.policy.applied.response.configurations.firewall_anti_tamper
-  level: custom
-  name: policy.applied.response.configurations.firewall_anti_tamper
-  normalize: []
-  short: overall firewall anti-tamper configuration and status of the applied policy
-  type: object
-Endpoint.policy.applied.response.configurations.firewall_anti_tamper.concerned_actions:
-  dashed_name: Endpoint-policy-applied-response-configurations-firewall-anti-tamper-concerned-actions
-  description: all actions that were taken for firewall anti-tamper
-  flat_name: Endpoint.policy.applied.response.configurations.firewall_anti_tamper.concerned_actions
-  ignore_above: 1024
-  level: custom
-  name: policy.applied.response.configurations.firewall_anti_tamper.concerned_actions
-  normalize: []
-  short: all actions that were taken for firewall anti-tamper
-  type: keyword
-Endpoint.policy.applied.response.configurations.firewall_anti_tamper.status:
-  dashed_name: Endpoint-policy-applied-response-configurations-firewall-anti-tamper-status
-  description: the overall status of firewall anti-tamper, this is correlated to the
-    status of concerned actions but not a simple sum of the actions
-  flat_name: Endpoint.policy.applied.response.configurations.firewall_anti_tamper.status
-  ignore_above: 1024
-  level: custom
-  name: policy.applied.response.configurations.firewall_anti_tamper.status
-  normalize: []
-  short: the overall status of firewall anti-tamper
-  type: keyword
 Endpoint.policy.applied.response.configurations.host_isolation.concerned_actions:
   dashed_name: Endpoint-policy-applied-response-configurations-host-isolation-concerned-actions
   description: all actions that were taken for host isolation
@@ -645,6 +614,40 @@ Endpoint.policy.applied.response.diagnostic.credential_protection.status:
   name: policy.applied.response.diagnostic.credential_protection.status
   normalize: []
   short: overall status of diagnostic behavior protection
+  type: keyword
+Endpoint.policy.applied.response.diagnostic.firewall_anti_tamper:
+  dashed_name: Endpoint-policy-applied-response-diagnostic-firewall-anti-tamper
+  description: overall firewall anti-tamper configuration and status of the applied
+    policy
+  flat_name: Endpoint.policy.applied.response.diagnostic.firewall_anti_tamper
+  level: custom
+  name: policy.applied.response.diagnostic.firewall_anti_tamper
+  normalize: []
+  short: overall firewall anti-tamper configuration and status of the applied policy
+  type: object
+Endpoint.policy.applied.response.diagnostic.firewall_anti_tamper.concerned_actions:
+  dashed_name: Endpoint-policy-applied-response-diagnostic-firewall-anti-tamper-concerned-actions
+  description: all actions that were taken for the diagnostic configuration of firewall
+    anti-tamper
+  flat_name: Endpoint.policy.applied.response.diagnostic.firewall_anti_tamper.concerned_actions
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.response.diagnostic.firewall_anti_tamper.concerned_actions
+  normalize: []
+  short: all actions that were taken for the diagnostic configuration of firewall
+    anti-tamper
+  type: keyword
+Endpoint.policy.applied.response.diagnostic.firewall_anti_tamper.status:
+  dashed_name: Endpoint-policy-applied-response-diagnostic-firewall-anti-tamper-status
+  description: the overall status of the diagnostic configuration of firewall anti-tamper,
+    this is correlated to the status of concerned actions but not a simple sum of
+    the actions
+  flat_name: Endpoint.policy.applied.response.diagnostic.firewall_anti_tamper.status
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.response.diagnostic.firewall_anti_tamper.status
+  normalize: []
+  short: the overall status of diagnostic firewall anti-tamper
   type: keyword
 Endpoint.policy.applied.response.diagnostic.malware.concerned_actions:
   dashed_name: Endpoint-policy-applied-response-diagnostic-malware-concerned-actions


### PR DESCRIPTION
## Change Summary

Add additional Policy field entries for new `firewall_anti_tamper` plugin.


### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
