### PR TITLE
[9.1] Add API fields for Windows named pipe and mailslot events

### DIFF
--- a/custom_documentation/doc/endpoint/api/windows/windows_api_pipe.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_pipe.md
@@ -1,0 +1,73 @@
+# Windows API
+
+- OS: Windows
+- Data Stream: `logs-endpoint.events.api-*`
+- KQL: `event.dataset : "endpoint.events.api" and event.module : "endpoint" and event.provider : "MinifilterCallback" and host.os.type : "windows"`
+
+This event is generated when a Named Pipe or Mailslot event is generated.
+
+| Field |
+|---|
+| @timestamp |
+| Target.process.Ext.protection |
+| Target.process.name |
+| Target.process.pid |
+| agent.id |
+| agent.type |
+| agent.version |
+| data_stream.dataset |
+| data_stream.namespace |
+| data_stream.type |
+| ecs.version |
+| elastic.agent.id |
+| event.category |
+| event.created |
+| event.dataset |
+| event.id |
+| event.kind |
+| event.module |
+| event.outcome |
+| event.provider |
+| event.sequence |
+| event.type |
+| host.architecture |
+| host.hostname |
+| host.id |
+| host.ip |
+| host.mac |
+| host.name |
+| host.os.Ext.variant |
+| host.os.family |
+| host.os.full |
+| host.os.kernel |
+| host.os.name |
+| host.os.platform |
+| host.os.type |
+| host.os.version |
+| message |
+| process.Ext.ancestry |
+| process.Ext.api.name |
+| process.Ext.api.parameters.is_remote |
+| process.Ext.api.parameters.open_mode |
+| process.Ext.api.parameters.operation |
+| process.Ext.api.parameters.pipe_path |
+| process.Ext.api.parameters.pipe_type |
+| process.Ext.api.parameters.read_mode |
+| process.Ext.api.summary |
+| process.Ext.code_signature.exists |
+| process.Ext.code_signature.status |
+| process.Ext.code_signature.subject_name |
+| process.Ext.code_signature.trusted |
+| process.code_signature.exists |
+| process.code_signature.status |
+| process.code_signature.subject_name |
+| process.code_signature.trusted |
+| process.entity_id |
+| process.executable |
+| process.name |
+| process.pid |
+| process.thread.id |
+| user.domain |
+| user.id |
+| user.name |
+

--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -130,6 +130,8 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.system_impact.network_events.week_ms |
 | Endpoint.metrics.system_impact.overall.week_idle_ms |
 | Endpoint.metrics.system_impact.overall.week_ms |
+| Endpoint.metrics.system_impact.pipe_events.week_idle_ms |
+| Endpoint.metrics.system_impact.pipe_events.week_ms |
 | Endpoint.metrics.system_impact.process.code_signature.exists |
 | Endpoint.metrics.system_impact.process.code_signature.signing_id |
 | Endpoint.metrics.system_impact.process.code_signature.status |

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_pipe.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_pipe.yaml
@@ -1,0 +1,76 @@
+overview:
+  name: Windows API
+  description: This event is generated when a Named Pipe or Mailslot event is generated.
+identification:
+  filter:
+    event.dataset: endpoint.events.api
+    event.module: endpoint
+    event.provider: MinifilterCallback
+    host.os.type: windows
+  os:
+  - windows
+  data_stream: logs-endpoint.events.api-*
+fields:
+  endpoint:
+  - '@timestamp'
+  - Target.process.Ext.protection
+  - Target.process.name
+  - Target.process.pid
+  - agent.id
+  - agent.type
+  - agent.version
+  - data_stream.dataset
+  - data_stream.namespace
+  - data_stream.type
+  - ecs.version
+  - elastic.agent.id
+  - event.category
+  - event.created
+  - event.dataset
+  - event.id
+  - event.kind
+  - event.module
+  - event.outcome
+  - event.provider
+  - event.sequence
+  - event.type
+  - host.architecture
+  - host.hostname
+  - host.id
+  - host.ip
+  - host.mac
+  - host.name
+  - host.os.Ext.variant
+  - host.os.family
+  - host.os.full
+  - host.os.kernel
+  - host.os.name
+  - host.os.platform
+  - host.os.type
+  - host.os.version
+  - message
+  - process.Ext.ancestry
+  - process.Ext.api.name
+  - process.Ext.api.parameters.is_remote
+  - process.Ext.api.parameters.open_mode
+  - process.Ext.api.parameters.operation
+  - process.Ext.api.parameters.pipe_path
+  - process.Ext.api.parameters.pipe_type
+  - process.Ext.api.parameters.read_mode
+  - process.Ext.api.summary
+  - process.Ext.code_signature.exists
+  - process.Ext.code_signature.status
+  - process.Ext.code_signature.subject_name
+  - process.Ext.code_signature.trusted
+  - process.code_signature.exists
+  - process.code_signature.status
+  - process.code_signature.subject_name
+  - process.code_signature.trusted
+  - process.entity_id
+  - process.executable
+  - process.name
+  - process.pid
+  - process.thread.id
+  - user.domain
+  - user.id
+  - user.name

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -137,6 +137,8 @@ fields:
   - Endpoint.metrics.system_impact.network_events.week_ms
   - Endpoint.metrics.system_impact.overall.week_idle_ms
   - Endpoint.metrics.system_impact.overall.week_ms
+  - Endpoint.metrics.system_impact.pipe_events.week_idle_ms
+  - Endpoint.metrics.system_impact.pipe_events.week_ms
   - Endpoint.metrics.system_impact.process.code_signature.exists
   - Endpoint.metrics.system_impact.process.code_signature.signing_id
   - Endpoint.metrics.system_impact.process.code_signature.status

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -1642,6 +1642,12 @@
       description: Type of hook procedure to be installed.
       example: WH_KEYBOARD_LL
       default_field: false
+    - name: Ext.api.parameters.is_remote
+      level: custom
+      type: boolean
+      description: This parameter indicates whether a pipe is open for remote or local access
+      example: 'true'
+      default_field: false
     - name: Ext.api.parameters.io_control_code
       level: custom
       type: unsigned_long
@@ -1655,12 +1661,33 @@
       description: WMI namespace to which the connection is made.
       example: root\Microsoft\Windows\DeviceGuard
       default_field: false
+    - name: Ext.api.parameters.open_mode
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: This field indicates how the streaming mode (byte/message) of the pipe
+      example: message
+      default_field: false
     - name: Ext.api.parameters.operation
       level: custom
       type: keyword
       ignore_above: 1024
       description: Specifies the connection or request to WMI
       example: Win32_Process::Create
+      default_field: false
+    - name: Ext.api.parameters.pipe_path
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: This path of the pipe
+      example: \Device\NamedPipe\MyTestNamedPipe
+      default_field: false
+    - name: Ext.api.parameters.pipe_type
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: This type of the pipe (named pipe/mailslot)
+      example: mailslot
       default_field: false
     - name: Ext.api.parameters.procedure
       level: custom
@@ -1749,6 +1776,13 @@
       type: unsigned_long
       description: The x64 RSP stack pointer register.
       example: 2431737462784
+      default_field: false
+    - name: Ext.api.parameters.read_mode
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: This field indicates how the read mode (byte/message) of the pipe
+      example: message
       default_field: false
     - name: Ext.api.parameters.size
       level: custom

--- a/package/endpoint/data_stream/api/sample_event.json
+++ b/package/endpoint/data_stream/api/sample_event.json
@@ -209,7 +209,12 @@
                     "operation": "Win32_Process::Create",
                     "app_name": "PowerShell",
                     "content_name": "C:\\script.ps1",
-                    "buffer": "[Ref].Assembly.GetType('System.Management.Automation.AmsiUtils').GetField('amsiInitFailed', 'NonPublic,Static').SetValue($null, $true);"
+                    "buffer": "[Ref].Assembly.GetType('System.Management.Automation.AmsiUtils').GetField('amsiInitFailed', 'NonPublic,Static').SetValue($null, $true);",
+                    "is_remote": "false",
+                    "open_mode": "message",
+                    "read_mode": "byte",
+                    "pipe_path": "\\Device\\NamedPipe\\MyNamedPipe",
+                    "pipe_type": "named_pipe"
                 },
                 "summary": "VirtualAllocEx( charmap.exe, NULL, 0x10, COMMIT|RESERVE, R-X )"
             },


### PR DESCRIPTION
## Change Summary

This PR adds the `api.parameters` and `metrics` fields for populated for Windows named pipe and mailslot events.

Related issue:
 - https://github.com/elastic/endpoint-dev/issues/12776

Related PR(s):
 - https://github.com/elastic/endpoint-dev/pull/16517

### Sample values

Sample document:

```json
{
  "event": {
    "provider": "MinifilterCallback",
    "category": [
      "api"
    ]
  },
  "message": "Endpoint API event - CreateNamedPipe",
  "process": {
    "Ext": {
      "api": {
        "summary": "CreateNamedPipe( \\Device\\NamedPipe\\TestNamedPipe, local )",
        "name": "CreateNamedPipe",
        "parameters": {
          "is_remote": "false",
          "open_mode": "message",
          "operation": "create",
          "pipe_path": "\\Device\\NamedPipe\\TestNamedPipe",
          "pipe_type": "named_pipe",
          "read_mode": "message"
        }
      }
    }
  }
}
```


## Release Target

9.1


## Q/A


### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
