### PR TITLE
add mapping for united.agent.namespaces

### DIFF
--- a/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
+++ b/package/endpoint/elasticsearch/index_template/metrics-metadata-united.json
@@ -479,6 +479,9 @@
                                         }
                                     }
                                 },
+                                "namespaces": {
+                                    "type": "keyword"
+                                },
                                 "packages": {
                                     "type": "keyword"
                                 },


### PR DESCRIPTION
## Change Summary

adds mapping for `united.agent.namespaces` in united metadata index template.


### Sample values

```json
{
	...,
	namespaces: ["default", "foo"]
	...,
}
```


## Release Target

`9.1`