### PR TITLE
Add custom documentation fields for `pipe_events`

### DIFF
--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -130,6 +130,8 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.system_impact.network_events.week_ms |
 | Endpoint.metrics.system_impact.overall.week_idle_ms |
 | Endpoint.metrics.system_impact.overall.week_ms |
+| Endpoint.metrics.system_impact.pipe_events.week_idle_ms |
+| Endpoint.metrics.system_impact.pipe_events.week_ms |
 | Endpoint.metrics.system_impact.process.code_signature.exists |
 | Endpoint.metrics.system_impact.process.code_signature.signing_id |
 | Endpoint.metrics.system_impact.process.code_signature.status |

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -137,6 +137,8 @@ fields:
   - Endpoint.metrics.system_impact.network_events.week_ms
   - Endpoint.metrics.system_impact.overall.week_idle_ms
   - Endpoint.metrics.system_impact.overall.week_ms
+  - Endpoint.metrics.system_impact.pipe_events.week_idle_ms
+  - Endpoint.metrics.system_impact.pipe_events.week_ms
   - Endpoint.metrics.system_impact.process.code_signature.exists
   - Endpoint.metrics.system_impact.process.code_signature.signing_id
   - Endpoint.metrics.system_impact.process.code_signature.status


### PR DESCRIPTION
## Change Summary

This PR adds the documentation fields required for the `pipe_event` 

See:
 - [issue](https://github.com/elastic/endpoint-dev/issues/12776)
 - [PR](https://github.com/elastic/endpoint-dev/pull/16517)


### Sample values


Sample document:

```text
Endpoint.metrics.system_impact.pipe_events.week_idle_ms
Endpoint.metrics.system_impact.pipe_events.week_ms
```


## Release Target




## Q/A



### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
