### PR TITLE
Add lookup_requested to dns event.actions

### DIFF
--- a/custom_documentation/doc/endpoint/network/linux/linux_network_dns_lookup_result.md
+++ b/custom_documentation/doc/endpoint/network/linux/linux_network_dns_lookup_result.md
@@ -2,7 +2,7 @@
 
 - OS: Linux
 - Data Stream: `logs-endpoint.events.network-*`
-- KQL: `event.action : "lookup_result" and event.dataset : "endpoint.events.network" and event.module : "endpoint" and host.os.type : "linux"`
+- KQL: `event.action : ("lookup_result" or "lookup_requested") and event.dataset : "endpoint.events.network" and event.module : "endpoint" and host.os.type : "linux"`
 
 This event is generated when results are returned for a DNS lookup request.
 

--- a/custom_documentation/src/endpoint/data_stream/network/linux/linux_network_dns_lookup_result.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/linux/linux_network_dns_lookup_result.yaml
@@ -4,7 +4,9 @@ overview:
     request.
 identification:
   filter:
-    event.action: lookup_result
+    event.action:
+    - lookup_result
+    - lookup_requested
     event.dataset: endpoint.events.network
     event.module: endpoint
     host.os.type: linux


### PR DESCRIPTION
## Change Summary

Update the event.action field for Linux DNS events to include `lookup_requested`.


### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes