### PR TITLE
Add destination.domain field to alert mapping

### DIFF
--- a/custom_documentation/doc/endpoint/alerts/windows/windows_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_malicious_behavior_alert.md
@@ -54,6 +54,7 @@ This alert occurs when a Malicious Behavior alert occurs.
 | data_stream.dataset |
 | data_stream.namespace |
 | data_stream.type |
+| destination.domain |
 | destination.ip |
 | destination.port |
 | dll.*<br /><br />dll contains dll data from the primary event in Events. It can contain any fields that any other events includes within the dll fieldset. |

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malicious_behavior_alert.yaml
@@ -59,6 +59,7 @@ fields:
   - data_stream.dataset
   - data_stream.namespace
   - data_stream.type
+  - destination.domain
   - destination.ip
   - destination.port
   - dll.*

--- a/custom_subsets/elastic_endpoint/alerts/rule_detection_event.yaml
+++ b/custom_subsets/elastic_endpoint/alerts/rule_detection_event.yaml
@@ -8,6 +8,7 @@ fields:
         fields: "*"
   destination:
     fields:
+      domain: {}
       geo:
         fields: "*"
   base:

--- a/package/endpoint/data_stream/alerts/fields/fields.yml
+++ b/package/endpoint/data_stream/alerts/fields/fields.yml
@@ -2898,6 +2898,14 @@
   type: group
   default_field: true
   fields:
+    - name: domain
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'The domain name of the destination system.
+
+        This value may be a host name, a fully qualified domain name, or another host naming format. The value may derive from the original event or be added from enrichment.'
+      example: foo.example.com
     - name: geo.city_name
       level: core
       type: keyword

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -421,6 +421,7 @@ sent by the endpoint.
 | data_stream.dataset | Data stream dataset name. | constant_keyword |
 | data_stream.namespace | Data stream namespace. | constant_keyword |
 | data_stream.type | Data stream type. | constant_keyword |
+| destination.domain | The domain name of the destination system. This value may be a host name, a fully qualified domain name, or another host naming format. The value may derive from the original event or be added from enrichment. | keyword |
 | destination.geo.city_name | City name. | keyword |
 | destination.geo.continent_code | Two-letter code representing continent's name. | keyword |
 | destination.geo.continent_name | Name of the continent. | keyword |

--- a/schemas/v1/alerts/rule_detection_event.yaml
+++ b/schemas/v1/alerts/rule_detection_event.yaml
@@ -268,6 +268,20 @@ Responses.result:
   normalize: []
   short: Response action result code
   type: long
+destination.domain:
+  dashed_name: destination-domain
+  description: 'The domain name of the destination system.
+
+    This value may be a host name, a fully qualified domain name, or another host
+    naming format. The value may derive from the original event or be added from enrichment.'
+  example: foo.example.com
+  flat_name: destination.domain
+  ignore_above: 1024
+  level: core
+  name: domain
+  normalize: []
+  short: The domain name of the destination.
+  type: keyword
 destination.geo.city_name:
   dashed_name: destination-geo-city-name
   description: City name.


### PR DESCRIPTION
## Change Summary

Add `destination.domain` field part of alert mapping

### Sample values

Sample document:

```json


```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->

This should be merged in main and backported to 9.1 and 8.19 if possible
## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
