### PR TITLE
Add security event metrics to custom documentation

### DIFF
--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -83,6 +83,11 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.documents_volume.registry_events.suppressed_count |
 | Endpoint.metrics.documents_volume.security_events.sent_bytes |
 | Endpoint.metrics.documents_volume.security_events.sent_count |
+| Endpoint.metrics.documents_volume.security_events.sources.sent_bytes |
+| Endpoint.metrics.documents_volume.security_events.sources.sent_count |
+| Endpoint.metrics.documents_volume.security_events.sources.source |
+| Endpoint.metrics.documents_volume.security_events.sources.suppressed_bytes |
+| Endpoint.metrics.documents_volume.security_events.sources.suppressed_count |
 | Endpoint.metrics.documents_volume.security_events.suppressed_bytes |
 | Endpoint.metrics.documents_volume.security_events.suppressed_count |
 | Endpoint.metrics.documents_volume.volume_device_events.sent_bytes |

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -90,6 +90,11 @@ fields:
   - Endpoint.metrics.documents_volume.registry_events.suppressed_count
   - Endpoint.metrics.documents_volume.security_events.sent_bytes
   - Endpoint.metrics.documents_volume.security_events.sent_count
+  - Endpoint.metrics.documents_volume.security_events.sources.sent_bytes
+  - Endpoint.metrics.documents_volume.security_events.sources.sent_count
+  - Endpoint.metrics.documents_volume.security_events.sources.source
+  - Endpoint.metrics.documents_volume.security_events.sources.suppressed_bytes
+  - Endpoint.metrics.documents_volume.security_events.sources.suppressed_count
   - Endpoint.metrics.documents_volume.security_events.suppressed_bytes
   - Endpoint.metrics.documents_volume.security_events.suppressed_count
   - Endpoint.metrics.documents_volume.volume_device_events.sent_bytes


### PR DESCRIPTION
## Change Summary
* https://github.com/elastic/endpoint-dev/pull/16755

This PR adds new metrics fields for the security events. 
```
Endpoint.metrics.documents_volume.security_events.sources.sent_bytes
Endpoint.metrics.documents_volume.security_events.sources.sent_count
Endpoint.metrics.documents_volume.security_events.sources.source
Endpoint.metrics.documents_volume.security_events.sources.suppressed_bytes
Endpoint.metrics.documents_volume.security_events.sources.suppressed_count
```

## Release Target
9.2


### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
