### PR TITLE
Enhance process event metrics

### DIFF
--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -75,6 +75,11 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.documents_volume.overall.suppressed_count |
 | Endpoint.metrics.documents_volume.process_events.sent_bytes |
 | Endpoint.metrics.documents_volume.process_events.sent_count |
+| Endpoint.metrics.documents_volume.process_events.sources.sent_bytes |
+| Endpoint.metrics.documents_volume.process_events.sources.sent_count |
+| Endpoint.metrics.documents_volume.process_events.sources.source |
+| Endpoint.metrics.documents_volume.process_events.sources.suppressed_bytes |
+| Endpoint.metrics.documents_volume.process_events.sources.suppressed_count |
 | Endpoint.metrics.documents_volume.process_events.suppressed_bytes |
 | Endpoint.metrics.documents_volume.process_events.suppressed_count |
 | Endpoint.metrics.documents_volume.registry_events.sent_bytes |

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -82,6 +82,11 @@ fields:
   - Endpoint.metrics.documents_volume.overall.suppressed_count
   - Endpoint.metrics.documents_volume.process_events.sent_bytes
   - Endpoint.metrics.documents_volume.process_events.sent_count
+  - Endpoint.metrics.documents_volume.process_events.sources.sent_bytes
+  - Endpoint.metrics.documents_volume.process_events.sources.sent_count
+  - Endpoint.metrics.documents_volume.process_events.sources.source
+  - Endpoint.metrics.documents_volume.process_events.sources.suppressed_bytes
+  - Endpoint.metrics.documents_volume.process_events.sources.suppressed_count
   - Endpoint.metrics.documents_volume.process_events.suppressed_bytes
   - Endpoint.metrics.documents_volume.process_events.suppressed_count
   - Endpoint.metrics.documents_volume.registry_events.sent_bytes


### PR DESCRIPTION
This adds `sources` info to process events in the metrics document.
```json
        "process_events": {
          "sent_bytes": 1478944,
          "sent_count": 732,
          "sources": [  <--- new for process events
            {
              "sent_bytes": 0,
              "sent_count": 0,
              "source": "shmget",
              "suppressed_bytes": 0,
              "suppressed_count": 1
            }
          ],
          "suppressed_bytes": 0,
          "suppressed_count": 7
        }
```
This change allows for data based diag->prod decisions for new Linux process events: load_module, ptrace, and shmget



## Release Target
8.19.1, 9.1.1, 9.2.0

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes

