### PR TITLE
add RemoteCredentialGuard to security event

### DIFF
--- a/custom_documentation/doc/endpoint/security/windows/windows_security_auditing_log_on.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_auditing_log_on.md
@@ -70,6 +70,7 @@ This event is generated when a user logs on to the computer.
 | winlog.event_data.LmPackageName |
 | winlog.event_data.LoginGuid |
 | winlog.event_data.PrivilegeList |
+| winlog.event_data.RemoteCredentialGuard |
 | winlog.event_data.RestrictedAdminMode |
 | winlog.event_data.Status |
 | winlog.event_data.SubStatus |

--- a/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
@@ -86,6 +86,7 @@ This event is generated when a user logs on to the computer.
 | winlog.event_data.LmPackageName |
 | winlog.event_data.LoginGuid |
 | winlog.event_data.PrivilegeList |
+| winlog.event_data.RemoteCredentialGuard |
 | winlog.event_data.RestrictedAdminMode |
 | winlog.event_data.Status |
 | winlog.event_data.SubStatus |

--- a/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
@@ -86,7 +86,6 @@ This event is generated when a user logs on to the computer.
 | winlog.event_data.LmPackageName |
 | winlog.event_data.LoginGuid |
 | winlog.event_data.PrivilegeList |
-| winlog.event_data.RemoteCredentialGuard |
 | winlog.event_data.RestrictedAdminMode |
 | winlog.event_data.Status |
 | winlog.event_data.SubStatus |

--- a/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
@@ -6,7 +6,6 @@ identification:
     event.action: log_on
     event.dataset: endpoint.events.security
     event.module: endpoint
-    event.provider : "Microsoft-Windows-Security-Auditing"
     host.os.type: windows
   os:
   - windows

--- a/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
@@ -6,6 +6,7 @@ identification:
     event.action: log_on
     event.dataset: endpoint.events.security
     event.module: endpoint
+    event.provider : "Microsoft-Windows-Security-Auditing"
     host.os.type: windows
   os:
   - windows

--- a/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
@@ -90,6 +90,7 @@ fields:
   - winlog.event_data.LmPackageName
   - winlog.event_data.LoginGuid
   - winlog.event_data.PrivilegeList
+  - winlog.event_data.RemoteCredentialGuard
   - winlog.event_data.RestrictedAdminMode
   - winlog.event_data.Status
   - winlog.event_data.SubStatus

--- a/custom_schemas/custom_winlog.yml
+++ b/custom_schemas/custom_winlog.yml
@@ -96,6 +96,12 @@
         This value is a Yes/No flag indicating if the credentials provided
         were passed using Restricted Admin mode.
 
+    - name: event_data.RemoteCredentialGuard
+      level: custom
+      type : keyword
+      description: >
+          
+
     - name: event_data.VirtualAccount
       level: custom
       type : keyword

--- a/custom_schemas/custom_winlog.yml
+++ b/custom_schemas/custom_winlog.yml
@@ -100,7 +100,7 @@
       level: custom
       type : keyword
       description: >
-          
+        Only populated for RemoteInteractive logon type sessions.
 
     - name: event_data.VirtualAccount
       level: custom

--- a/custom_subsets/elastic_endpoint/security/security.yaml
+++ b/custom_subsets/elastic_endpoint/security/security.yaml
@@ -205,6 +205,7 @@ fields:
           LogonGuid: {}
           TargetLogonGuid: {}
           LmPackageName: {}
+	  RemoteCredentialGuard: {}
           TargetLinkedLogonId: {}
           ServiceName: {}
           ServiceFileName: {}

--- a/custom_subsets/elastic_endpoint/security/security.yaml
+++ b/custom_subsets/elastic_endpoint/security/security.yaml
@@ -205,7 +205,7 @@ fields:
           LogonGuid: {}
           TargetLogonGuid: {}
           LmPackageName: {}
-	  RemoteCredentialGuard: {}
+          RemoteCredentialGuard: {}
           TargetLinkedLogonId: {}
           ServiceName: {}
           ServiceFileName: {}

--- a/package/endpoint/data_stream/security/fields/fields.yml
+++ b/package/endpoint/data_stream/security/fields/fields.yml
@@ -1411,6 +1411,12 @@
       ignore_above: 1024
       description: Relative name of the accessed target file or folder.
       default_field: false
+    - name: event_data.RemoteCredentialGuard
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Only populated for RemoteInteractive logon type sessions.
+      default_field: false
     - name: event_data.Resource
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/security/sample_event.json
+++ b/package/endpoint/data_stream/security/sample_event.json
@@ -203,6 +203,7 @@
             "LogonGuid": "test_data",
             "TargetLogonGuid": "test_data",
             "LmPackageName": "test_data",
+            "RemoteCredentialGuard": "test_data",
             "TargetLinkedLogonId": "test_data",
             "ServiceName": "TestServiceName",
             "ServiceFileName": "C:\\TestService.exe",

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2852,6 +2852,7 @@ sent by the endpoint.
 | winlog.event_data.PrimaryGroupId | Relative Identifier (RID) of the user's object primary group. | keyword |
 | winlog.event_data.PrivilegeList | An array of sensitive privileges, assigned to the new logon. | keyword |
 | winlog.event_data.RelativeTargetName | Relative name of the accessed target file or folder. | keyword |
+| winlog.event_data.RemoteCredentialGuard | Only populated for RemoteInteractive logon type sessions. | keyword |
 | winlog.event_data.Resource | Resource Information. | keyword |
 | winlog.event_data.SamAccountName | Logon name for account used to support clients and servers from  previous versions of Windows (pre-Windows 2000 logon name). | keyword |
 | winlog.event_data.SchemaFriendlyName | A human-readable name associated with the schema GUID. | keyword |

--- a/schemas/v1/security/security.yaml
+++ b/schemas/v1/security/security.yaml
@@ -2705,6 +2705,16 @@ winlog.event_data.RelativeTargetName:
   normalize: []
   short: Relative name of the accessed target file or folder.
   type: keyword
+winlog.event_data.RemoteCredentialGuard:
+  dashed_name: winlog-event-data-RemoteCredentialGuard
+  description: Only populated for RemoteInteractive logon type sessions.
+  flat_name: winlog.event_data.RemoteCredentialGuard
+  ignore_above: 1024
+  level: custom
+  name: event_data.RemoteCredentialGuard
+  normalize: []
+  short: Only populated for RemoteInteractive logon type sessions.
+  type: keyword
 winlog.event_data.Resource:
   dashed_name: winlog-event-data-Resource
   description: Resource Information.


### PR DESCRIPTION
## Change Summary
* https://github.com/elastic/endpoint-dev/pull/17047

<!-- please describe your changes. For mapping changes, describe the usage of the changed fields -->


### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json

      "event_data": {
        "VirtualAccount": "No",
        "RestrictedAdminMode": "No",
        "ElevatedToken": "No",
        "SubjectDomainName": "WORKGROUP",
        "LogonProcessName": "User32 ",
        "TargetDomainName": "AzureAD",
        "LogonType": "10",
        "SubjectLogonId": "0x3e7",
        "KeyLength": "0",
        "RemoteCredentialGuard": "No",
```


## Release Target
9.2


### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
