### PR TITLE
Add metric custom documentation for event tracing events 

### DIFF
--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -124,6 +124,8 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.system_impact.diagnostic_behavior_protection.week_ms |
 | Endpoint.metrics.system_impact.dns_events.week_idle_ms |
 | Endpoint.metrics.system_impact.dns_events.week_ms |
+| Endpoint.metrics.system_impact.event_tracing_events.week_idle_ms |
+| Endpoint.metrics.system_impact.event_tracing_events.week_ms |
 | Endpoint.metrics.system_impact.file_events.week_idle_ms |
 | Endpoint.metrics.system_impact.file_events.week_ms |
 | Endpoint.metrics.system_impact.kernel_api_events.week_idle_ms |

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -132,7 +132,7 @@ fields:
   - Endpoint.metrics.system_impact.dns_events.week_idle_ms
   - Endpoint.metrics.system_impact.dns_events.week_ms
   - Endpoint.metrics.system_impact.event_tracing_events.week_idle_ms
-  - Endpoint.metrics.system_impact.event_tracing_events.week_ms 
+  - Endpoint.metrics.system_impact.event_tracing_events.week_ms
   - Endpoint.metrics.system_impact.file_events.week_idle_ms
   - Endpoint.metrics.system_impact.file_events.week_ms
   - Endpoint.metrics.system_impact.kernel_api_events.week_idle_ms

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -131,6 +131,8 @@ fields:
   - Endpoint.metrics.system_impact.diagnostic_behavior_protection.week_ms
   - Endpoint.metrics.system_impact.dns_events.week_idle_ms
   - Endpoint.metrics.system_impact.dns_events.week_ms
+  - Endpoint.metrics.system_impact.event_tracing_events.week_idle_ms
+  - Endpoint.metrics.system_impact.event_tracing_events.week_ms 
   - Endpoint.metrics.system_impact.file_events.week_idle_ms
   - Endpoint.metrics.system_impact.file_events.week_ms
   - Endpoint.metrics.system_impact.kernel_api_events.week_idle_ms


### PR DESCRIPTION
## Change Summary

* https://github.com/elastic/endpoint-dev/pull/17068

This adds the followings to the metric custom documentation.
* `Endpoint.metrics.system_impact.event_tracing_events.week_idle_ms`
* `Endpoint.metrics.system_impact.event_tracing_events.week_ms`

This is a metric for ETW Microsoft-Windows-Kernel-EventTracing based events.

## Release Target
9.2
