### PR TITLE
Add LDAP (Ldap-Client ETW Provider) API Event fields

### DIFF
--- a/custom_documentation/doc/endpoint/api/windows/windows_api_ldap_client.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_ldap_client.md
@@ -1,0 +1,71 @@
+# Windows API
+
+- OS: Windows
+- Data Stream: `logs-endpoint.events.api-*`
+- KQL: `event.dataset : "endpoint.events.api" and event.module : "endpoint" and event.provider : "Microsoft-Windows-LDAP-Client" and host.os.type : "windows"`
+
+This event is generated when LDAP-Client related APIs are called.
+
+| Field |
+|---|
+| @timestamp |
+| agent.id |
+| agent.type |
+| agent.version |
+| data_stream.dataset |
+| data_stream.namespace |
+| data_stream.type |
+| ecs.version |
+| elastic.agent.id |
+| event.category |
+| event.created |
+| event.dataset |
+| event.id |
+| event.kind |
+| event.module |
+| event.outcome |
+| event.provider |
+| event.sequence |
+| event.type |
+| host.architecture |
+| host.hostname |
+| host.id |
+| host.ip |
+| host.mac |
+| host.name |
+| host.os.Ext.variant |
+| host.os.family |
+| host.os.full |
+| host.os.kernel |
+| host.os.name |
+| host.os.platform |
+| host.os.type |
+| host.os.version |
+| message |
+| process.Ext.ancestry |
+| process.Ext.api.name |
+| process.Ext.api.parameters.attribute_list |
+| process.Ext.api.parameters.distinguished_name |
+| process.Ext.api.parameters.scope_of_search |
+| process.Ext.api.parameters.search_filter |
+| process.Ext.code_signature.exists |
+| process.Ext.code_signature.status |
+| process.Ext.code_signature.subject_name |
+| process.Ext.code_signature.trusted |
+| process.Ext.protection |
+| process.Ext.token.integrity_level_name |
+| process.code_signature.exists |
+| process.code_signature.status |
+| process.code_signature.subject_name |
+| process.code_signature.trusted |
+| process.command_line |
+| process.entity_id |
+| process.executable |
+| process.name |
+| process.parent.executable |
+| process.pid |
+| process.thread.id |
+| user.domain |
+| user.id |
+| user.name |
+

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_ldap_client.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_ldap_client.yaml
@@ -1,0 +1,74 @@
+overview:
+  name: Windows API
+  description: This event is generated when LDAP-Client related APIs are called.
+identification:
+  filter:
+    event.dataset: endpoint.events.api
+    event.module: endpoint
+    event.provider: Microsoft-Windows-LDAP-Client
+    host.os.type: windows
+  os:
+  - windows
+  data_stream: logs-endpoint.events.api-*
+fields:
+  endpoint:
+  - '@timestamp'
+  - agent.id
+  - agent.type
+  - agent.version
+  - data_stream.dataset
+  - data_stream.namespace
+  - data_stream.type
+  - ecs.version
+  - elastic.agent.id
+  - event.category
+  - event.created
+  - event.dataset
+  - event.id
+  - event.kind
+  - event.module
+  - event.outcome
+  - event.provider
+  - event.sequence
+  - event.type
+  - host.architecture
+  - host.hostname
+  - host.id
+  - host.ip
+  - host.mac
+  - host.name
+  - host.os.Ext.variant
+  - host.os.family
+  - host.os.full
+  - host.os.kernel
+  - host.os.name
+  - host.os.platform
+  - host.os.type
+  - host.os.version
+  - message
+  - process.Ext.ancestry 
+  - process.Ext.api.name
+  - process.Ext.api.parameters.attribute_list
+  - process.Ext.api.parameters.distinguished_name
+  - process.Ext.api.parameters.scope_of_search
+  - process.Ext.api.parameters.search_filter
+  - process.Ext.code_signature.exists
+  - process.Ext.code_signature.status
+  - process.Ext.code_signature.subject_name
+  - process.Ext.code_signature.trusted
+  - process.Ext.protection
+  - process.Ext.token.integrity_level_name
+  - process.code_signature.exists
+  - process.code_signature.status
+  - process.code_signature.subject_name
+  - process.code_signature.trusted
+  - process.command_line
+  - process.entity_id
+  - process.executable
+  - process.name
+  - process.parent.executable
+  - process.pid
+  - process.thread.id
+  - user.domain
+  - user.id
+  - user.name

--- a/custom_schemas/custom_api.yml
+++ b/custom_schemas/custom_api.yml
@@ -579,7 +579,7 @@
       ignore_above: 1024
       example: "[ \"[Ref].Assembly.GetType('System.Management.Automation.AmsiUtils').GetField('amsiInitFailed', 'NonPublic,Static').SetValue($null, $true);Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public class Kernel32 {   [DllImport(\"kernel32.dll\")]   public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);}\" ]"
 
-    - name: process.Ext.api.parameters.scope_of_search
+    - name: parameters.scope_of_search
       level: custom
       description: >
         Specifies the range of a search.

--- a/custom_schemas/custom_api.yml
+++ b/custom_schemas/custom_api.yml
@@ -578,3 +578,32 @@
       type: keyword
       ignore_above: 1024
       example: "[ \"[Ref].Assembly.GetType('System.Management.Automation.AmsiUtils').GetField('amsiInitFailed', 'NonPublic,Static').SetValue($null, $true);Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public class Kernel32 {   [DllImport(\"kernel32.dll\")]   public static extern IntPtr VirtualAlloc(IntPtr lpAddress, uint dwSize, uint flAllocationType, uint flProtect);}\" ]"
+
+    - name: process.Ext.api.parameters.scope_of_search
+      level: custom
+      description: >
+        Specifies the range of a search.
+      type: keyword
+      example: "SubTree"
+
+    - name: parameters.search_filter
+      level: custom
+      description: >
+        Search filters enable users (Ldap Client) to define search criteria.
+      type: keyword
+      example: "(&(objectClass=group))"
+
+    - name: parameters.distinguished_name
+      level: custom
+      description: >
+        A sequence of relative distinguished names (RDN) connected by commas. 
+        This string specifies the starting point for a search within the directory.
+      type: keyword
+      example: "dc=test,dc=local"
+
+    - name: parameters.attribute_list
+      level: custom
+      description: >
+        A String which indicate which attributes to return for each matching entry.
+      type: keyword
+      example: "[ \"samaccountname\", \"lastlogondate\" ]"

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -1482,6 +1482,13 @@
       description: The third argument to the procedure.
       example: 3
       default_field: false
+    - name: Ext.api.parameters.attribute_list
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: A String which indicate which attributes to return for each matching entry.
+      example: '[ "samaccountname", "lastlogondate" ]'
+      default_field: false
     - name: Ext.api.parameters.buffer
       level: custom
       type: keyword
@@ -1539,6 +1546,13 @@
       ignore_above: 1024
       description: The name of the device object.
       example: \Device\NPCAP
+      default_field: false
+    - name: Ext.api.parameters.distinguished_name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: A sequence of relative distinguished names (RDN) connected by commas.  This string specifies the starting point for a search within the directory.
+      example: dc=test,dc=local
       default_field: false
     - name: Ext.api.parameters.driver
       level: custom
@@ -1749,6 +1763,20 @@
       type: unsigned_long
       description: The x64 RSP stack pointer register.
       example: 2431737462784
+      default_field: false
+    - name: Ext.api.parameters.scope_of_search
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Specifies the range of a search.
+      example: SubTree
+      default_field: false
+    - name: Ext.api.parameters.search_filter
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Search filters enable users (Ldap Client) to define search criteria.
+      example: (&(objectClass=group))
       default_field: false
     - name: Ext.api.parameters.size
       level: custom

--- a/package/endpoint/data_stream/api/sample_event.json
+++ b/package/endpoint/data_stream/api/sample_event.json
@@ -209,7 +209,14 @@
                     "operation": "Win32_Process::Create",
                     "app_name": "PowerShell",
                     "content_name": "C:\\script.ps1",
-                    "buffer": "[Ref].Assembly.GetType('System.Management.Automation.AmsiUtils').GetField('amsiInitFailed', 'NonPublic,Static').SetValue($null, $true);"
+                    "buffer": "[Ref].Assembly.GetType('System.Management.Automation.AmsiUtils').GetField('amsiInitFailed', 'NonPublic,Static').SetValue($null, $true);",
+                    "scope_of_search": "SubTree",
+                    "search_filter": "(&(objectClass=group))",
+                    "distinguished_name": "dc=test,dc=local",
+                    "attribute_list": [
+                        "samaccountname",
+                        "lastlogondate"
+                    ]
                 },
                 "summary": "VirtualAllocEx( charmap.exe, NULL, 0x10, COMMIT|RESERVE, R-X )"
             },

--- a/package/endpoint/data_stream/api/sample_event.json
+++ b/package/endpoint/data_stream/api/sample_event.json
@@ -211,7 +211,7 @@
                     "content_name": "C:\\script.ps1",
                     "buffer": "[Ref].Assembly.GetType('System.Management.Automation.AmsiUtils').GetField('amsiInitFailed', 'NonPublic,Static').SetValue($null, $true);",
                     "scope_of_search": "SubTree",
-                    "search_filter": "(&(objectClass=group))",
+                    "search_filter": "(\u0026(objectClass=group))",
                     "distinguished_name": "dc=test,dc=local",
                     "attribute_list": [
                         "samaccountname",

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -2941,6 +2941,19 @@ process.Ext.api.parameters.argument3:
   original_fieldset: api
   short: The third argument to the procedure.
   type: unsigned_long
+process.Ext.api.parameters.attribute_list:
+  dashed_name: process-Ext-api-parameters-attribute-list
+  description: A String which indicate which attributes to return for each matching
+    entry.
+  example: '[ "samaccountname", "lastlogondate" ]'
+  flat_name: process.Ext.api.parameters.attribute_list
+  ignore_above: 1024
+  level: custom
+  name: parameters.attribute_list
+  normalize: []
+  original_fieldset: api
+  short: A String which indicate which attributes to return for each matching entry.
+  type: keyword
 process.Ext.api.parameters.buffer:
   dashed_name: process-Ext-api-parameters-buffer
   description: The content associated with an AMSI scan.
@@ -3064,6 +3077,20 @@ process.Ext.api.parameters.device:
   normalize: []
   original_fieldset: api
   short: The name of the device object.
+  type: keyword
+process.Ext.api.parameters.distinguished_name:
+  dashed_name: process-Ext-api-parameters-distinguished-name
+  description: A sequence of relative distinguished names (RDN) connected by commas.  This
+    string specifies the starting point for a search within the directory.
+  example: dc=test,dc=local
+  flat_name: process.Ext.api.parameters.distinguished_name
+  ignore_above: 1024
+  level: custom
+  name: parameters.distinguished_name
+  normalize: []
+  original_fieldset: api
+  short: A sequence of relative distinguished names (RDN) connected by commas.  This
+    string specifies the starting point for a search within the directory.
   type: keyword
 process.Ext.api.parameters.driver:
   dashed_name: process-Ext-api-parameters-driver
@@ -3451,6 +3478,30 @@ process.Ext.api.parameters.rsp:
   original_fieldset: api
   short: The x64 RSP stack pointer register.
   type: unsigned_long
+process.Ext.api.parameters.scope_of_search:
+  dashed_name: process-Ext-api-parameters-scope-of-search
+  description: Specifies the range of a search.
+  example: SubTree
+  flat_name: process.Ext.api.parameters.scope_of_search
+  ignore_above: 1024
+  level: custom
+  name: parameters.scope_of_search
+  normalize: []
+  original_fieldset: api
+  short: Specifies the range of a search.
+  type: keyword
+process.Ext.api.parameters.search_filter:
+  dashed_name: process-Ext-api-parameters-search-filter
+  description: Search filters enable users (Ldap Client) to define search criteria.
+  example: (&(objectClass=group))
+  flat_name: process.Ext.api.parameters.search_filter
+  ignore_above: 1024
+  level: custom
+  name: parameters.search_filter
+  normalize: []
+  original_fieldset: api
+  short: Search filters enable users (Ldap Client) to define search criteria.
+  type: keyword
 process.Ext.api.parameters.size:
   dashed_name: process-Ext-api-parameters-size
   description: The size.


### PR DESCRIPTION
## Change Summary

* https://github.com/elastic/endpoint-dev/pull/17049

Adds new custom API fields and custom documentation for the LDAP events (Ldap-Client ETW Provider API events). 
More specifically, Event ID 30 fields.

* `process.Ext.api.parameters.scope_of_search`
* `process.Ext.api.parameters.search_filter`
* `process.Ext.api.parameters.distinguished_name`
* `process.Ext.api.parameters.attribute_list`

### Sample values

Below is the example of the custom API fields that will be added by this PR. The sample of the document is here. ([sample_event.json](https://github.com/elastic/endpoint-package/blob/401246123ac41e8d1e9108dbe6e15324573673ce/package/endpoint/data_stream/api/sample_event.json))

```
   "message":"Endpoint API event - ldap_search",
   "process":{
      "Ext":{
         "api":{
            "name":"ldap_search",
            "parameters":{
               "attribute_list":[
                  "samaccountname",
                  "lastlogondate"
               ],
               "distinguished_name":"dc=test,dc=local",
               "scope_of_search":"SubTree",
               "search_filter":"(&(samAccountType=805306368)(samAccountName=*))"
            }
         }
      },
```

## Release Target

9.2

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
