### PR TITLE
Add process.Ext.ptrace.addr and .data

### DIFF
--- a/custom_documentation/doc/endpoint/process/linux/linux_process_ptrace.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_ptrace.md
@@ -67,6 +67,8 @@ This event is generated when when a process calls ptrace_attach on another proce
 | process.Ext.command_line_truncated |
 | process.Ext.ptrace.child_pid |
 | process.Ext.ptrace.request |
+| process.Ext.ptrace.addr |
+| process.Ext.ptrace.data |
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
 | process.args |

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_ptrace.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_ptrace.yaml
@@ -72,6 +72,8 @@ fields:
   - process.Ext.command_line_truncated
   - process.Ext.ptrace.child_pid
   - process.Ext.ptrace.request
+  - process.Ext.ptrace.addr
+  - process.Ext.ptrace.data
   - process.Ext.trusted
   - process.Ext.trusted_descendant
   - process.args

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -152,6 +152,16 @@
       type: long
       description: ptrace request.
 
+    - name: Ext.ptrace.addr
+      level: custom
+      type: long
+      description: ptrace address.
+
+    - name: Ext.ptrace.data
+      level: custom
+      type: long
+      description: ptrace data.
+
     - name: Ext.memfd
       level: custom
       type: object

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -164,6 +164,8 @@ fields:
             fields:
               child_pid: {}
               request: {}
+              addr: {}
+              data: {}
           shmget:
             fields:
               key: {}

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -959,10 +959,20 @@
       type: object
       description: Object for ptrace events.
       default_field: false
+    - name: Ext.ptrace.addr
+      level: custom
+      type: long
+      description: ptrace address.
+      default_field: false
     - name: Ext.ptrace.child_pid
       level: custom
       type: long
       description: PID of the ptrace target.
+      default_field: false
+    - name: Ext.ptrace.data
+      level: custom
+      type: long
+      description: ptrace data.
       default_field: false
     - name: Ext.ptrace.request
       level: custom

--- a/package/endpoint/data_stream/process/sample_event.json
+++ b/package/endpoint/data_stream/process/sample_event.json
@@ -73,6 +73,12 @@
                 "flag_cloexec": false,
                 "flag_noexec_seal": false
             },
+            "ptrace": {
+                "addr": 94501295312904,
+                "child_pid": 240116,
+                "data": 6042695217945480400,
+                "request": 5
+            },
             "code_signature": [
                 {
                     "trusted": true,

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2233,7 +2233,9 @@ sent by the endpoint.
 | process.Ext.mitigation_policies | Process mitigation policies include SignaturePolicy, DynamicCodePolicy, UserShadowStackPolicy, ControlFlowGuardPolicy, etc. Examples include Microsoft only, CF Guard, User Shadow Stack enabled | keyword |
 | process.Ext.protection | Indicates the protection level of this process.  Uses the same syntax as Process Explorer. Examples include PsProtectedSignerWinTcb, PsProtectedSignerWinTcb-Light, and PsProtectedSignerWindows-Light. | keyword |
 | process.Ext.ptrace | Object for ptrace events. | object |
+| process.Ext.ptrace.addr | ptrace address. | long |
 | process.Ext.ptrace.child_pid | PID of the ptrace target. | long |
+| process.Ext.ptrace.data | ptrace data. | long |
 | process.Ext.ptrace.request | ptrace request. | long |
 | process.Ext.relative_file_creation_time | Number of seconds since the process's file was created. This number may be negative if the file's timestamp is in the future. | double |
 | process.Ext.relative_file_name_modify_time | Number of seconds since the process's name was modified. This information can come from the NTFS MFT. This number may be negative if the file's timestamp is in the future. | double |

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1733,6 +1733,15 @@ process.Ext.ptrace:
   normalize: []
   short: Object for ptrace events.
   type: object
+process.Ext.ptrace.addr:
+  dashed_name: process-Ext-ptrace-addr
+  description: ptrace address.
+  flat_name: process.Ext.ptrace.addr
+  level: custom
+  name: Ext.ptrace.addr
+  normalize: []
+  short: ptrace address.
+  type: long
 process.Ext.ptrace.child_pid:
   dashed_name: process-Ext-ptrace-child-pid
   description: PID of the ptrace target.
@@ -1741,6 +1750,15 @@ process.Ext.ptrace.child_pid:
   name: Ext.ptrace.child_pid
   normalize: []
   short: PID of the ptrace target.
+  type: long
+process.Ext.ptrace.data:
+  dashed_name: process-Ext-ptrace-data
+  description: ptrace data.
+  flat_name: process.Ext.ptrace.data
+  level: custom
+  name: Ext.ptrace.data
+  normalize: []
+  short: ptrace data.
   type: long
 process.Ext.ptrace.request:
   dashed_name: process-Ext-ptrace-request


### PR DESCRIPTION
## Change Summary

Add more fields for [ptrace](https://man7.org/linux/man-pages/man2/ptrace.2.html) events. For example, when the request is `PTRACE_POKETEXT`, we can know the address and the value being changed in the traced process.

### Sample values

Sample document:

```json
{
  "@timestamp":"2025-09-03T18:13:08.8118015Z",
  "agent":{
    "id":"",
    "type":"endpoint",
    "version":"9.2.0-SNAPSHOT"
  },
  "data_stream":{
    "dataset":"",
    "namespace":"",
    "type":""
  },
  "ecs":{
    "version":"8.10.0"
  },
  "elastic":{
    "agent":{
      "id":""
    }
  },
  "event":{
    "action":["ptrace"],
    "category":["process"],
    "dataset":"",
    "id":"O9W37uzNQh7M/SpY+++++++8",
    "kind":"event",
    "module":"endpoint",
    "outcome":"unknown",
    "sequence":388,
    "type":["start"]
  },
  "host":{
    "id":"",
    "name":"",
    "os":{
      "type":"linux"
    }
  },
  "message":"Endpoint process event",
  "process":{
    "Ext":{
      "ptrace":{
        "addr":94501295312904,
        "child_pid":240116,
        "data":6042695217945480400,
        "request":5
      }
    },
    "args":[],
    "args_count":0,
    "parent":{
      "args":[],
      "args_count":0
    },
    "pid":240121
  }
}
```


## Release Target

9.2.0, 8.19.4, and 9.1.4


### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match


