### PR TITLE
custom_documentation update, policy state orphaned

### DIFF
--- a/custom_documentation/doc/endpoint/metadata/metadata.md
+++ b/custom_documentation/doc/endpoint/metadata/metadata.md
@@ -18,6 +18,7 @@ This is a relatively small state management document that includes details about
 | Endpoint.policy.applied.status |
 | Endpoint.policy.applied.version |
 | Endpoint.state.isolation |
+| Endpoint.state.orphaned |
 | Endpoint.state.tamper_protection |
 | Endpoint.status |
 | agent.build.original |

--- a/custom_documentation/doc/endpoint/policy/policy_response.md
+++ b/custom_documentation/doc/endpoint/policy/policy_response.md
@@ -65,6 +65,7 @@ This is a state management document that is generated every time Endpoint refres
 | Endpoint.policy.applied.status |
 | Endpoint.policy.applied.version |
 | Endpoint.state.isolation |
+| Endpoint.state.orphaned |
 | Endpoint.state.tamper_protection |
 | agent.build.original |
 | agent.id |

--- a/custom_documentation/src/endpoint/data_stream/metadata/metadata.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metadata/metadata.yaml
@@ -25,6 +25,7 @@ fields:
   - Endpoint.policy.applied.status
   - Endpoint.policy.applied.version
   - Endpoint.state.isolation
+  - Endpoint.state.orphaned
   - Endpoint.state.tamper_protection
   - Endpoint.status
   - agent.build.original

--- a/custom_documentation/src/endpoint/data_stream/policy/policy_response.yaml
+++ b/custom_documentation/src/endpoint/data_stream/policy/policy_response.yaml
@@ -73,6 +73,7 @@ fields:
   - Endpoint.policy.applied.status
   - Endpoint.policy.applied.version
   - Endpoint.state.isolation
+  - Endpoint.state.orphaned
   - Endpoint.state.tamper_protection
   - agent.build.original
   - agent.id

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -1110,6 +1110,16 @@
       type: boolean
       description: Current network isolation state of the host
 
+    - name: state.orphaned
+      level: custom
+      type: boolean
+      description: Current orphaned state of Endpoint
+
+    - name: state.tamper_protection
+      level: custom
+      type: boolean
+      description: Current network tamper protection state of Endpoint
+
     - name: capabilities
       level: custom
       type: keyword

--- a/custom_subsets/elastic_endpoint/metadata/metadata.yaml
+++ b/custom_subsets/elastic_endpoint/metadata/metadata.yaml
@@ -42,6 +42,8 @@ fields:
       state:
         fields:
           isolation: {}
+          orphaned: {}
+          tamper_protection: {}
       capabilities: {}
   elastic:
     fields:

--- a/custom_subsets/elastic_endpoint/policy/policy.yaml
+++ b/custom_subsets/elastic_endpoint/policy/policy.yaml
@@ -30,6 +30,8 @@ fields:
       state:
         fields:
           isolation: {}
+          orphaned: {}
+          tamper_protection: {}
   event:
     fields:
       action: {}

--- a/package/endpoint/data_stream/metadata/fields/fields.yml
+++ b/package/endpoint/data_stream/metadata/fields/fields.yml
@@ -73,6 +73,16 @@
       type: boolean
       description: Current network isolation state of the host
       default_field: false
+    - name: state.orphaned
+      level: custom
+      type: boolean
+      description: Current orphaned state of Endpoint
+      default_field: false
+    - name: state.tamper_protection
+      level: custom
+      type: boolean
+      description: Current network tamper protection state of Endpoint
+      default_field: false
     - name: status
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/policy/fields/fields.yml
+++ b/package/endpoint/data_stream/policy/fields/fields.yml
@@ -471,6 +471,16 @@
       type: boolean
       description: Current network isolation state of the host
       default_field: false
+    - name: state.orphaned
+      level: custom
+      type: boolean
+      description: Current orphaned state of Endpoint
+      default_field: false
+    - name: state.tamper_protection
+      level: custom
+      type: boolean
+      description: Current network tamper protection state of Endpoint
+      default_field: false
 - name: agent
   title: Agent
   group: 2

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2896,6 +2896,8 @@ sent by the endpoint.
 | Endpoint.policy.applied.status | the status of the applied policy | keyword |
 | Endpoint.state | Represents the current state of a non-policy setting These fields reflect the current status of a field, which may differ from what it is configured to be (see Endpoint.configuration) | object |
 | Endpoint.state.isolation | Current network isolation state of the host | boolean |
+| Endpoint.state.orphaned | Current orphaned state of Endpoint | boolean |
+| Endpoint.state.tamper_protection | Current network tamper protection state of Endpoint | boolean |
 | Endpoint.status | The current status of the endpoint e.g. enrolled, unenrolled. | keyword |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
 | agent.name | Custom name of the agent. This is a name that can be given to an agent. This can be helpful if for example two Filebeat instances are running on the same host but a human readable separation is needed on which Filebeat instance data is coming from. | keyword |
@@ -3096,6 +3098,8 @@ Metrics documents contain performance information about the endpoint executable 
 | Endpoint.policy.applied.version | the version of this applied policy | keyword |
 | Endpoint.state | Represents the current state of a non-policy setting These fields reflect the current status of a field, which may differ from what it is configured to be (see Endpoint.configuration) | object |
 | Endpoint.state.isolation | Current network isolation state of the host | boolean |
+| Endpoint.state.orphaned | Current orphaned state of Endpoint | boolean |
+| Endpoint.state.tamper_protection | Current network tamper protection state of Endpoint | boolean |
 | agent.build.original | Extended build information for the agent. This field is intended to contain any build information that a data source may provide, no specific formatting is required. | keyword |
 | agent.id | Unique identifier of this agent (if one exists). Example: For Beats this would be beat.id. | keyword |
 | agent.type | Type of the agent. The agent type always stays the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine. | keyword |

--- a/schemas/v1/metadata/metadata.yaml
+++ b/schemas/v1/metadata/metadata.yaml
@@ -116,6 +116,24 @@ Endpoint.state.isolation:
   normalize: []
   short: Current network isolation state of the host
   type: boolean
+Endpoint.state.orphaned:
+  dashed_name: Endpoint-state-orphaned
+  description: Current orphaned state of Endpoint
+  flat_name: Endpoint.state.orphaned
+  level: custom
+  name: state.orphaned
+  normalize: []
+  short: Current orphaned state of Endpoint
+  type: boolean
+Endpoint.state.tamper_protection:
+  dashed_name: Endpoint-state-tamper-protection
+  description: Current network tamper protection state of Endpoint
+  flat_name: Endpoint.state.tamper_protection
+  level: custom
+  name: state.tamper_protection
+  normalize: []
+  short: Current network tamper protection state of Endpoint
+  type: boolean
 Endpoint.status:
   dashed_name: Endpoint-status
   description: The current status of the endpoint e.g. enrolled, unenrolled.

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -809,6 +809,24 @@ Endpoint.state.isolation:
   normalize: []
   short: Current network isolation state of the host
   type: boolean
+Endpoint.state.orphaned:
+  dashed_name: Endpoint-state-orphaned
+  description: Current orphaned state of Endpoint
+  flat_name: Endpoint.state.orphaned
+  level: custom
+  name: state.orphaned
+  normalize: []
+  short: Current orphaned state of Endpoint
+  type: boolean
+Endpoint.state.tamper_protection:
+  dashed_name: Endpoint-state-tamper-protection
+  description: Current network tamper protection state of Endpoint
+  flat_name: Endpoint.state.tamper_protection
+  level: custom
+  name: state.tamper_protection
+  normalize: []
+  short: Current network tamper protection state of Endpoint
+  type: boolean
 agent.build.original:
   dashed_name: agent-build-original
   description: 'Extended build information for the agent.


### PR DESCRIPTION
## Change Summary

Add `Orphaned` status indicator to Endpoint policy response
Add tamper protection status indicator to Endpoint policy response
### Sample values

`Endpoint.state.orphaned: true`
`Endpoint.state.tamper_protection: true`

Sample document:

```json
        "state": {
            "isolation": false,
            "orphaned": true,
            "tamper_protection": false
        },
```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
