### PR TITLE
Add `file.Ext.entropy` to docs

### DIFF
--- a/custom_documentation/doc/endpoint/file/macos/macos_file_modification.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_modification.md
@@ -32,6 +32,7 @@ This event is generated when a file is modified.
 | event.outcome |
 | event.sequence |
 | event.type |
+| file.Ext.entropy |
 | file.Ext.header_bytes |
 | file.extension |
 | file.hash.sha256 |

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_modification.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_modification.yaml
@@ -37,6 +37,7 @@ fields:
   - event.outcome
   - event.sequence
   - event.type
+  - file.Ext.entropy
   - file.Ext.header_bytes
   - file.extension
   - file.hash.sha256


### PR DESCRIPTION
## Change Summary

<!-- please describe your changes. For mapping changes, describe the usage of the changed fields -->

Add `file.Ext.entropy` to documentation for macOS. Field already present in the schema

### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json


```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
