### PR TITLE
Add firewall_anti_tamper fields to production configuration

### DIFF
--- a/custom_documentation/doc/endpoint/api/windows/windows_api_firewall_anti_tamper.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_firewall_anti_tamper.md
@@ -1,0 +1,68 @@
+# Windows API
+
+- OS: Windows
+- Data Stream: `logs-endpoint.events.api-*`
+- KQL: `event.dataset : "endpoint.events.api" and event.module : "endpoint" and event.provider : "Windows-Firewall" and host.os.type : "windows"`
+
+This event is generated when firewall tampering is detected.
+
+| Field |
+|---|
+| @timestamp |
+| agent.id |
+| agent.type |
+| agent.version |
+| data_stream.dataset |
+| data_stream.namespace |
+| data_stream.type |
+| ecs.version |
+| elastic.agent.id |
+| event.category |
+| event.created |
+| event.dataset |
+| event.id |
+| event.kind |
+| event.module |
+| event.outcome |
+| event.provider |
+| event.sequence |
+| event.type |
+| host.architecture |
+| host.hostname |
+| host.id |
+| host.ip |
+| host.mac |
+| host.name |
+| host.os.Ext.variant |
+| host.os.family |
+| host.os.full |
+| host.os.kernel |
+| host.os.name |
+| host.os.platform |
+| host.os.type |
+| host.os.version |
+| message |
+| process.Ext.ancestry |
+| process.Ext.api.name |
+| process.Ext.api.summary |
+| process.Ext.code_signature.exists |
+| process.Ext.code_signature.status |
+| process.Ext.code_signature.subject_name |
+| process.Ext.code_signature.trusted |
+| process.Ext.protection |
+| process.Ext.token.integrity_level_name |
+| process.code_signature.exists |
+| process.code_signature.status |
+| process.code_signature.subject_name |
+| process.code_signature.trusted |
+| process.command_line |
+| process.entity_id |
+| process.executable |
+| process.name |
+| process.parent.executable |
+| process.pid |
+| process.thread.id |
+| user.domain |
+| user.id |
+| user.name |
+

--- a/custom_documentation/doc/endpoint/policy/policy_response.md
+++ b/custom_documentation/doc/endpoint/policy/policy_response.md
@@ -38,6 +38,8 @@ This is a state management document that is generated every time Endpoint refres
 | Endpoint.policy.applied.response.configurations.device_control.status |
 | Endpoint.policy.applied.response.configurations.events.concerned_actions |
 | Endpoint.policy.applied.response.configurations.events.status |
+| Endpoint.policy.applied.response.configurations.firewall_anti_tamper.concerned_actions |
+| Endpoint.policy.applied.response.configurations.firewall_anti_tamper.status |
 | Endpoint.policy.applied.response.configurations.host_isolation.concerned_actions |
 | Endpoint.policy.applied.response.configurations.host_isolation.status |
 | Endpoint.policy.applied.response.configurations.logging.concerned_actions |

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_firewall_anti_tamper.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_firewall_anti_tamper.yaml
@@ -1,0 +1,71 @@
+overview:
+  name: Windows API
+  description: This event is generated when firewall tampering is detected.
+identification:
+  filter:
+    event.dataset: endpoint.events.api
+    event.module: endpoint
+    event.provider: Windows-Firewall
+    host.os.type: windows
+  os:
+  - windows
+  data_stream: logs-endpoint.events.api-*
+fields:
+  endpoint:
+  - '@timestamp'
+  - agent.id
+  - agent.type
+  - agent.version
+  - data_stream.dataset
+  - data_stream.namespace
+  - data_stream.type
+  - ecs.version
+  - elastic.agent.id
+  - event.category
+  - event.created
+  - event.dataset
+  - event.id
+  - event.kind
+  - event.module
+  - event.outcome
+  - event.provider
+  - event.sequence
+  - event.type
+  - host.architecture
+  - host.hostname
+  - host.id
+  - host.ip
+  - host.mac
+  - host.name
+  - host.os.Ext.variant
+  - host.os.family
+  - host.os.full
+  - host.os.kernel
+  - host.os.name
+  - host.os.platform
+  - host.os.type
+  - host.os.version
+  - message
+  - process.Ext.ancestry
+  - process.Ext.api.name
+  - process.Ext.api.summary
+  - process.Ext.code_signature.exists
+  - process.Ext.code_signature.status
+  - process.Ext.code_signature.subject_name
+  - process.Ext.code_signature.trusted
+  - process.Ext.protection
+  - process.Ext.token.integrity_level_name
+  - process.code_signature.exists
+  - process.code_signature.status
+  - process.code_signature.subject_name
+  - process.code_signature.trusted
+  - process.command_line
+  - process.entity_id
+  - process.executable
+  - process.name
+  - process.parent.executable
+  - process.pid
+  - process.thread.id
+  - user.domain
+  - user.id
+  - user.name

--- a/custom_documentation/src/endpoint/data_stream/policy/policy_response.yaml
+++ b/custom_documentation/src/endpoint/data_stream/policy/policy_response.yaml
@@ -46,6 +46,8 @@ fields:
   - Endpoint.policy.applied.response.configurations.device_control.status
   - Endpoint.policy.applied.response.configurations.events.concerned_actions
   - Endpoint.policy.applied.response.configurations.events.status
+  - Endpoint.policy.applied.response.configurations.firewall_anti_tamper.concerned_actions
+  - Endpoint.policy.applied.response.configurations.firewall_anti_tamper.status
   - Endpoint.policy.applied.response.configurations.host_isolation.concerned_actions
   - Endpoint.policy.applied.response.configurations.host_isolation.status
   - Endpoint.policy.applied.response.configurations.logging.concerned_actions

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -98,6 +98,24 @@
         but not a simple sum of the actions
       short: the overall status of event collection
 
+    - name: policy.applied.response.configurations.firewall_anti_tamper
+      level: custom
+      type: object
+      description: overall firewall anti-tamper configuration and status of the applied policy
+
+    - name: policy.applied.response.configurations.firewall_anti_tamper.concerned_actions
+      level: custom
+      type: keyword
+      description: all actions that were taken for the configuration of firewall anti-tamper
+
+    - name: policy.applied.response.configurations.firewall_anti_tamper.status
+      level: custom
+      type: keyword
+      description: >
+        the overall status of the configuration of firewall anti-tamper, this is correlated to
+        the status of concerned actions but not a simple sum of the actions
+      short: the overall status of firewall anti-tamper
+
     - name: policy.applied.response.configurations.logging
       level: custom
       type: object

--- a/package/endpoint/data_stream/policy/fields/fields.yml
+++ b/package/endpoint/data_stream/policy/fields/fields.yml
@@ -262,6 +262,23 @@
       ignore_above: 1024
       description: the overall status of event collection, this is correlated to the status of concerned actions  but not a simple sum of the actions
       default_field: false
+    - name: policy.applied.response.configurations.firewall_anti_tamper
+      level: custom
+      type: object
+      description: overall firewall anti-tamper configuration and status of the applied policy
+      default_field: false
+    - name: policy.applied.response.configurations.firewall_anti_tamper.concerned_actions
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: all actions that were taken for the configuration of firewall anti-tamper
+      default_field: false
+    - name: policy.applied.response.configurations.firewall_anti_tamper.status
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: the overall status of the configuration of firewall anti-tamper, this is correlated to the status of concerned actions but not a simple sum of the actions
+      default_field: false
     - name: policy.applied.response.configurations.host_isolation.concerned_actions
       level: custom
       type: keyword

--- a/package/endpoint/data_stream/policy/sample_event.json
+++ b/package/endpoint/data_stream/policy/sample_event.json
@@ -134,6 +134,17 @@
                             ],
                             "status": "success"
                         },
+                        "firewall_anti_tamper": {
+                            "concerned_actions": [
+                                "agent_connectivity",
+                                "load_config",
+                                "workflow",
+                                "download_global_artifacts",
+                                "download_user_artifacts",
+                                "configure_firewall_anti_tamper"
+                            ],
+                            "status": "success"
+                        },
                         "ransomware": {
                             "concerned_actions": [
                                 "agent_connectivity",

--- a/schemas/v1/policy/policy.yaml
+++ b/schemas/v1/policy/policy.yaml
@@ -425,6 +425,37 @@ Endpoint.policy.applied.response.configurations.events.status:
   normalize: []
   short: the overall status of event collection
   type: keyword
+Endpoint.policy.applied.response.configurations.firewall_anti_tamper:
+  dashed_name: Endpoint-policy-applied-response-configurations-firewall-anti-tamper
+  description: overall firewall anti-tamper configuration and status of the applied
+    policy
+  flat_name: Endpoint.policy.applied.response.configurations.firewall_anti_tamper
+  level: custom
+  name: policy.applied.response.configurations.firewall_anti_tamper
+  normalize: []
+  short: overall firewall anti-tamper configuration and status of the applied policy
+  type: object
+Endpoint.policy.applied.response.configurations.firewall_anti_tamper.concerned_actions:
+  dashed_name: Endpoint-policy-applied-response-configurations-firewall-anti-tamper-concerned-actions
+  description: all actions that were taken for the configuration of firewall anti-tamper
+  flat_name: Endpoint.policy.applied.response.configurations.firewall_anti_tamper.concerned_actions
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.response.configurations.firewall_anti_tamper.concerned_actions
+  normalize: []
+  short: all actions that were taken for the configuration of firewall anti-tamper
+  type: keyword
+Endpoint.policy.applied.response.configurations.firewall_anti_tamper.status:
+  dashed_name: Endpoint-policy-applied-response-configurations-firewall-anti-tamper-status
+  description: the overall status of the configuration of firewall anti-tamper, this
+    is correlated to the status of concerned actions but not a simple sum of the actions
+  flat_name: Endpoint.policy.applied.response.configurations.firewall_anti_tamper.status
+  ignore_above: 1024
+  level: custom
+  name: policy.applied.response.configurations.firewall_anti_tamper.status
+  normalize: []
+  short: the overall status of firewall anti-tamper
+  type: keyword
 Endpoint.policy.applied.response.configurations.host_isolation.concerned_actions:
   dashed_name: Endpoint-policy-applied-response-configurations-host-isolation-concerned-actions
   description: all actions that were taken for host isolation


### PR DESCRIPTION
## Change Summary

Add `firewall_anti_tamper` fields to production configuration.


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
