### PR TITLE
Add device dashboard

### DIFF
--- a/package/endpoint/kibana/dashboard/endpoint-43ff2ab2-cda0-4da5-b928-b412600c7a9c.json
+++ b/package/endpoint/kibana/dashboard/endpoint-43ff2ab2-cda0-4da5-b928-b412600c7a9c.json
@@ -4,7 +4,7 @@
             "chainingSystem": "HIERARCHICAL",
             "controlStyle": "oneLine",
             "ignoreParentSettingsJSON": "{\"ignoreFilters\": false,\"ignoreQuery\": false,\"ignoreTimerange\": false,\"ignoreValidations\": false}",
-            "panelsJSON": {},
+            "panelsJSON": "{}",
             "showApplySelections": false
         },
         "description": "",


### PR DESCRIPTION
## Change Summary

Adds device control dashboard


## Release Target

9.2


<img width="1627" height="832" alt="2025-09-30-101239_scrot" src="https://github.com/user-attachments/assets/824b22db-5155-41e4-b600-92c266f99b75" />

<img width="2243" height="1471" alt="2025-09-30-101305_scrot" src="https://github.com/user-attachments/assets/fa036b7c-fe14-4b1c-8941-0f181c58de62" />


the small error marker on the dashboard is about `device.vendor.name`, which could be a mapping bug, or might only show up before documents are written to the device index. Will address in a followup
