### PR TITLE
dashboard notice should also be in the source template

### DIFF
--- a/doc_templates/endpoint/docs/README.md
+++ b/doc_templates/endpoint/docs/README.md
@@ -1,3 +1,8 @@
+> ## Elastic Defend Detection and Response Dashboard
+>
+> Instantly investigate, triage, and respond to threats on the new, centralized Detection and Response dashboard for Elastic Defend alerts.
+
+
 # Elastic Defend Integration
 
 Elastic Defend provides organizations with prevention, detection, and response capabilities with deep visibility for EPP, EDR, SIEM, and Security Analytics use cases across Windows, macOS, and Linux operating systems running on both traditional endpoints and public cloud environments. ​​Use Elastic Defend to:


### PR DESCRIPTION
## Change Summary

a followup to #688 : the readme is built from templates, so make sure the notice is in the source templates or it gets erased on remake
