### PR TITLE
Add entropy and header_bytes on linux

### DIFF
--- a/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
@@ -28,6 +28,8 @@ This event is generated when a file is created.
 | event.outcome |
 | event.sequence |
 | event.type |
+| file.Ext.entropy |
+| file.Ext.header_bytes |
 | file.extension |
 | file.hash.sha256 |
 | file.name |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_delete.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_delete.md
@@ -28,6 +28,7 @@ This event is generated when a file is deleted.
 | event.outcome |
 | event.sequence |
 | event.type |
+| file.Ext.entropy |
 | file.extension |
 | file.name |
 | file.path |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_rename.md
@@ -28,6 +28,8 @@ This event is generated when a file is renamed.
 | event.outcome |
 | event.sequence |
 | event.type |
+| file.Ext.entropy |
+| file.Ext.header_bytes |
 | file.Ext.original.extension |
 | file.Ext.original.name |
 | file.Ext.original.path |

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
@@ -33,6 +33,8 @@ fields:
   - event.outcome
   - event.sequence
   - event.type
+  - file.Ext.entropy
+  - file.Ext.header_bytes
   - file.extension
   - file.hash.sha256
   - file.name

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_delete.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_delete.yaml
@@ -33,6 +33,7 @@ fields:
   - event.outcome
   - event.sequence
   - event.type
+  - file.Ext.entropy
   - file.extension
   - file.name
   - file.path

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_rename.yaml
@@ -33,6 +33,8 @@ fields:
   - event.outcome
   - event.sequence
   - event.type
+  - file.Ext.entropy
+  - file.Ext.header_bytes
   - file.Ext.original.extension
   - file.Ext.original.name
   - file.Ext.original.path


### PR DESCRIPTION
## Change Summary

<!-- please describe your changes. For mapping changes, describe the usage of the changed fields -->


### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json
    "file": {
        "Ext": {
            "entropy": 5.28353871945538,
            "header_bytes": "7570646174655f74696d653a20323032",
        },
    },

```


## Release Target
9.3.0
<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
