### PR TITLE
Add `process.Ext.trusted` to custom docs for already-running process events

### DIFF
--- a/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
@@ -65,6 +65,8 @@ This event is generated for a process that was already running before Endpoint's
 | process.Ext.token.elevation_level |
 | process.Ext.token.integrity_level_name |
 | process.Ext.token.security_attributes |
+| process.Ext.trusted |
+| process.Ext.trusted_descendant |
 | process.Ext.windows.zone_identifier |
 | process.args |
 | process.args_count |

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
@@ -71,6 +71,8 @@ fields:
   - process.Ext.token.elevation_level
   - process.Ext.token.integrity_level_name
   - process.Ext.token.security_attributes
+  - process.Ext.trusted
+  - process.Ext.trusted_descendant
   - process.Ext.windows.zone_identifier
   - process.args
   - process.args_count


### PR DESCRIPTION
## Change Summary

Add `process.Ext.trusted` to custom docs for already-running process events.