### PR TITLE
Fix macOS file access documentation

### DIFF
--- a/custom_documentation/doc/endpoint/file/macos/macos_file_access.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_access.md
@@ -38,7 +38,9 @@ This event is generated when a file is accessed.
 | file.path |
 | file.size |
 | group.Ext.real.id |
+| group.Ext.real.name |
 | group.id |
+| group.name |
 | host.architecture |
 | host.hostname |
 | host.id |
@@ -54,8 +56,18 @@ This event is generated when a file is accessed.
 | host.os.type |
 | host.os.version |
 | message |
+| process.code_signature.exists |
+| process.code_signature.signing_id |
+| process.code_signature.status |
+| process.code_signature.team_id |
+| process.code_signature.trusted |
+| process.entity_id |
+| process.executable |
 | process.name |
+| process.parent.pid |
 | process.pid |
 | user.Ext.real.id |
+| user.Ext.real.name |
 | user.id |
+| user.name |
 

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_access.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_access.yaml
@@ -43,7 +43,9 @@ fields:
   - file.path
   - file.size
   - group.Ext.real.id
+  - group.Ext.real.name
   - group.id
+  - group.name
   - host.architecture
   - host.hostname
   - host.id
@@ -59,7 +61,17 @@ fields:
   - host.os.type
   - host.os.version
   - message
+  - process.code_signature.exists
+  - process.code_signature.signing_id
+  - process.code_signature.status
+  - process.code_signature.team_id
+  - process.code_signature.trusted
+  - process.entity_id
+  - process.executable
   - process.name
+  - process.parent.pid
   - process.pid
   - user.Ext.real.id
+  - user.Ext.real.name
   - user.id
+  - user.name


### PR DESCRIPTION
## Change Summary

Add missing fields to macos file access documentation

### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json


```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
