### PR TITLE
map event.module for logs-endpoint.events.api-*

### DIFF
--- a/custom_subsets/elastic_endpoint/api/api.yaml
+++ b/custom_subsets/elastic_endpoint/api/api.yaml
@@ -39,6 +39,7 @@ fields:
       hash: {}
       id: {}
       ingested: {}
+      module: {}
       provider: {}
       outcome: {}
       start: {}

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -1069,6 +1069,14 @@
         In normal conditions, assuming no tampering, the timestamps should chronologically look like this: `@timestamp` < `event.created` < `event.ingested`.'
       example: '2016-05-23T08:05:35.101Z'
       default_field: false
+    - name: module
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Name of the module this data is coming from.
+
+        If your monitoring agent supports the concept of modules or plugins to process events of a given source (e.g. Apache logs), `event.module` should contain the name of this module.'
+      example: apache
     - name: outcome
       level: core
       type: keyword

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -2039,6 +2039,21 @@ event.ingested:
   normalize: []
   short: Timestamp when an event arrived in the central data store.
   type: date
+event.module:
+  dashed_name: event-module
+  description: 'Name of the module this data is coming from.
+
+    If your monitoring agent supports the concept of modules or plugins to process
+    events of a given source (e.g. Apache logs), `event.module` should contain the
+    name of this module.'
+  example: apache
+  flat_name: event.module
+  ignore_above: 1024
+  level: core
+  name: module
+  normalize: []
+  short: Name of the module this data is coming from.
+  type: keyword
 event.outcome:
   allowed_values:
   - description: Indicates that this event describes a failed result. A common example


### PR DESCRIPTION
## Change Summary

`event.module` is not mapped for the `logs-endpoint.events.api-*` data stream. It's mapped for all the other `logs-*` and `metrics-*` data streams. This maps it for consistency and because `event.module : endpoint` is a good KQL filter to find just Endpoint data.

### Sample values
No new data

## Release Target
The next minor release is ok.

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
