### PR TITLE
Add process group to macos documentation

### DIFF
--- a/custom_documentation/doc/endpoint/process/macos/macos_process_fork_exec_exit.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_fork_exec_exit.md
@@ -89,6 +89,8 @@ This event is generated when a process calls `fork()`, `exec()`, or exits.
 | process.parent.name |
 | process.parent.pid |
 | process.pid |
+| process.group_leader.pid |
+| process.session_leader.pid |
 | user.Ext.real.id |
 | user.Ext.real.name |
 | user.id |

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork_exec_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork_exec_exit.yaml
@@ -98,6 +98,8 @@ fields:
   - process.parent.name
   - process.parent.pid
   - process.pid
+  - process.group_leader.pid
+  - process.session_leader.pid
   - user.Ext.real.id
   - user.Ext.real.name
   - user.id


### PR DESCRIPTION
## Change Summary

Adds `process.group_leader.pid` and `process.session_leader.pid` to custom documentation


### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json


```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
