### PR TITLE
fix field def from #704

### DIFF
--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -832,7 +832,7 @@
 
     - name: Ext.script.content
       level: custom
-      type: keyword
+      type: match_only_text
       short: Content of the script being executed
       description: >
         Content of the script being executed


### PR DESCRIPTION
## Change Summary

PR #704 added some fields, and after review comments, `Ext.script.content` was edited to be `match_only_text`, but it was manually edited in the _output_ file, `package/endpoint/data_stream/process/fields/fields.yml` and not the input field _source_ field in `custom_schemas/custom_process.yml`.

So further runs of `make` would overwrite the field, going back to the source file which defined it as `keyword` still.


### Details


This wasn't caught in the PR itself because of how the `make` prereqs are defined. At the point that the _output_ file (`fields.yml`) was edited, wouldn't trigger make to run. It is not a **prereq** file for anything. Make would decide there is "nothing to do" since everything was up-to-date.  Editing output files would escape being overwritten _in that PR_.

Only when a subsequent change gets made to the related input file (`custom_process.yml`) would that `make` recipe run, and overwrite the field.

Luckily, another PR did make a related change, the file was overwritten, and CI _then_ caught the diff occurring.

Updates should be made in the future for `make` to run in more cases, e.g. if the output files were their own prereqs.
