### PR TITLE
Update the copyright year to 2026

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Elastic Endpoint Package
-Copyright 2017-2025 Elasticsearch B.V.
+Copyright 2017-2026 Elasticsearch B.V.
 
 This product includes software developed at
 Elasticsearch, B.V. (https://www.elastic.co/).


### PR DESCRIPTION
## Change Summary

Update copyright year from 2025 to 2026. 

## Release Target
9.4
