### PR TITLE
Update custom documentation for Windows ETW API events / Device unmount events

### DIFF
--- a/custom_documentation/doc/endpoint/api/windows/windows_api_kernel_audit.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_kernel_audit.md
@@ -9,6 +9,8 @@ This event is generated when ETW Microsoft-Windows-Kernel-Audit-API-Calls events
 | Field |
 |---|
 | @timestamp |
+| Target.process.Ext.created_suspended |
+| Target.process.Ext.protection |
 | Target.process.Ext.token.integrity_level_name |
 | Target.process.entity_id |
 | Target.process.executable |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_kernel_audit.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_kernel_audit.md
@@ -9,6 +9,11 @@ This event is generated when ETW Microsoft-Windows-Kernel-Audit-API-Calls events
 | Field |
 |---|
 | @timestamp |
+| Target.process.Ext.token.integrity_level_name |
+| Target.process.entity_id |
+| Target.process.executable |
+| Target.process.name |
+| Target.process.pid |
 | agent.id |
 | agent.type |
 | agent.version |
@@ -43,7 +48,10 @@ This event is generated when ETW Microsoft-Windows-Kernel-Audit-API-Calls events
 | host.os.version |
 | message |
 | process.Ext.api.behaviors |
+| process.Ext.api.metadata.return_value |
 | process.Ext.api.name |
+| process.Ext.api.parameters.desired_access |
+| process.Ext.api.parameters.desired_access_numeric |
 | process.Ext.api.summary |
 | process.Ext.code_signature.exists |
 | process.Ext.code_signature.status |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_threat_intelligence.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_threat_intelligence.md
@@ -12,7 +12,9 @@ This event is generated when ETW Threat-Intelligence events are generated.
 | Target.process.Ext.created_suspended |
 | Target.process.Ext.desktop_name |
 | Target.process.Ext.protection |
+| Target.process.Ext.token.impersonation_level |
 | Target.process.Ext.token.integrity_level_name |
+| Target.process.Ext.token.sid |
 | Target.process.entity_id |
 | Target.process.executable |
 | Target.process.name |

--- a/custom_documentation/doc/endpoint/device/windows/windows_volume_device_unmount.md
+++ b/custom_documentation/doc/endpoint/device/windows/windows_volume_device_unmount.md
@@ -10,6 +10,7 @@ This event is generated when a device is unmounted.
 |---|
 | volume.device_name |
 | volume.bus_type |
+| volume.size |
 | volume.removable |
 | volume.mount_name |
 | volume.file_system_type |

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_kernel_audit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_kernel_audit.yaml
@@ -14,6 +14,8 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Target.process.Ext.created_suspended
+  - Target.process.Ext.protection
   - Target.process.Ext.token.integrity_level_name
   - Target.process.entity_id
   - Target.process.executable

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_kernel_audit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_kernel_audit.yaml
@@ -14,6 +14,11 @@ identification:
 fields:
   endpoint:
   - '@timestamp'
+  - Target.process.Ext.token.integrity_level_name
+  - Target.process.entity_id
+  - Target.process.executable
+  - Target.process.name
+  - Target.process.pid
   - agent.id
   - agent.type
   - agent.version
@@ -48,7 +53,10 @@ fields:
   - host.os.version
   - message
   - process.Ext.api.behaviors
+  - process.Ext.api.metadata.return_value
   - process.Ext.api.name
+  - process.Ext.api.parameters.desired_access
+  - process.Ext.api.parameters.desired_access_numeric
   - process.Ext.api.summary
   - process.Ext.code_signature.exists
   - process.Ext.code_signature.status

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_threat_intelligence.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_threat_intelligence.yaml
@@ -16,7 +16,9 @@ fields:
   - Target.process.Ext.created_suspended
   - Target.process.Ext.desktop_name
   - Target.process.Ext.protection
+  - Target.process.Ext.token.impersonation_level
   - Target.process.Ext.token.integrity_level_name
+  - Target.process.Ext.token.sid
   - Target.process.entity_id
   - Target.process.executable
   - Target.process.name

--- a/custom_documentation/src/endpoint/data_stream/device/windows/windows_volume_device_unmount.yaml
+++ b/custom_documentation/src/endpoint/data_stream/device/windows/windows_volume_device_unmount.yaml
@@ -14,6 +14,7 @@ fields:
   endpoint:
   - volume.device_name
   - volume.bus_type
+  - volume.size
   - volume.removable
   - volume.mount_name
   - volume.file_system_type


### PR DESCRIPTION
## Change Summary
* https://github.com/elastic/endpoint-dev/pull/16419
* https://github.com/elastic/endpoint-dev/pull/16411
* https://github.com/elastic/endpoint-dev/issues/18277

Update custom documentation for the for the following events.
* ETW Microsoft-Windows-Kernel-Audit-API-Calls based API events.
  * `Target.process.Ext.created_suspended`
  * `Target.process.Ext.protection`
  * `Target.process.Ext.token.integrity_level_name`
  * `Target.process.entity_id`
  * `Target.process.executable`
  * `Target.process.name`
  * `Target.process.pid`
  * `process.Ext.api.metadata.return_value`
  * `process.Ext.api.parameters.desired_access`
  * `process.Ext.api.parameters.desired_access_numeric`
* ETW Microsoft-Threat-Intelligence based API events.
  * `Target.process.Ext.token.impersonation_level`
  * `Target.process.Ext.token.sid`
* Windows volume device unmount events.
  * `volume.size` 

## Release Target
9.4
<!-- What is intended Kibana release this is expected to ship with -->

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes