### PR TITLE
Add hit/miss metrics fields for trusted ancestors reporting

### DIFF
--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -101,6 +101,8 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.documents_volume.volume_device_events.suppressed_count |
 | Endpoint.metrics.event_filter.active_global_count |
 | Endpoint.metrics.event_filter.active_user_count |
+| Endpoint.metrics.events_cache.trusted_ancestors.hits |
+| Endpoint.metrics.events_cache.trusted_ancestors.misses |
 | Endpoint.metrics.malicious_behavior_rules.endpoint_uptime_percent |
 | Endpoint.metrics.malicious_behavior_rules.id |
 | Endpoint.metrics.memory.endpoint.private.latest |

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -108,6 +108,8 @@ fields:
   - Endpoint.metrics.documents_volume.volume_device_events.suppressed_count
   - Endpoint.metrics.event_filter.active_global_count
   - Endpoint.metrics.event_filter.active_user_count
+  - Endpoint.metrics.events_cache.trusted_ancestors.hits
+  - Endpoint.metrics.events_cache.trusted_ancestors.misses
   - Endpoint.metrics.malicious_behavior_rules.endpoint_uptime_percent
   - Endpoint.metrics.malicious_behavior_rules.id
   - Endpoint.metrics.memory.endpoint.private.latest

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -863,7 +863,7 @@
     - name: metrics.events_cache.trusted_ancestors.misses
       level: custom
       type: double
-      description: Number of successful trusted ancestor lookups
+      description: Number of failed trusted ancestor lookups
 
     - name: metrics.malicious_behavior_rules.endpoint_uptime_percent
       level: custom

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -843,6 +843,28 @@
       enabled: false
       description: An array of performance information about each malicious behavior rule
 
+    - name: metrics.events_cache
+      level: custom
+      type: object
+      enabled: false
+      description: An object of metrics information related to the event cache
+
+    - name: metrics.events_cache.trusted_ancestors
+      level: custom
+      type: object
+      enabled: false
+      description: An object for metrics information related to the trusted ancestor feature
+
+    - name: metrics.events_cache.trusted_ancestors.hits
+      level: custom
+      type: double
+      description: Number of successful trusted ancestor lookups
+
+    - name: metrics.events_cache.trusted_ancestors.misses
+      level: custom
+      type: double
+      description: Number of successful trusted ancestor lookups
+
     - name: metrics.malicious_behavior_rules.endpoint_uptime_percent
       level: custom
       type: double

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -367,6 +367,28 @@
       index: false
       doc_values: false
       default_field: false
+    - name: metrics.events_cache
+      level: custom
+      type: object
+      description: An object of metrics information related to the event cache
+      enabled: false
+      default_field: false
+    - name: metrics.events_cache.trusted_ancestors
+      level: custom
+      type: object
+      description: An object for metrics information related to the trusted ancestor feature
+      enabled: false
+      default_field: false
+    - name: metrics.events_cache.trusted_ancestors.hits
+      level: custom
+      type: double
+      description: Number of successful trusted ancestor lookups
+      default_field: false
+    - name: metrics.events_cache.trusted_ancestors.misses
+      level: custom
+      type: double
+      description: Number of successful trusted ancestor lookups
+      default_field: false
     - name: metrics.malicious_behavior_rules
       level: custom
       type: object

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -387,7 +387,7 @@
     - name: metrics.events_cache.trusted_ancestors.misses
       level: custom
       type: double
-      description: Number of successful trusted ancestor lookups
+      description: Number of failed trusted ancestor lookups
       default_field: false
     - name: metrics.malicious_behavior_rules
       level: custom

--- a/package/endpoint/data_stream/metrics/sample_event.json
+++ b/package/endpoint/data_stream/metrics/sample_event.json
@@ -12,7 +12,7 @@
     "Endpoint": {
         "metrics": {
             "events_cache": {
-                "ancestors": {
+                "trusted_ancestors": {
                     "hits": 504,
                     "misses": 23578
                 }

--- a/package/endpoint/data_stream/metrics/sample_event.json
+++ b/package/endpoint/data_stream/metrics/sample_event.json
@@ -11,6 +11,12 @@
     "@timestamp": "2022-04-04T18:38:15.7178887Z",
     "Endpoint": {
         "metrics": {
+            "events_cache": {
+                "ancestors": {
+                    "hits": 504,
+                    "misses": 23578
+                }
+            },
             "system_impact": [
                 {
                     "file_events": {

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -656,12 +656,12 @@ Endpoint.metrics.events_cache.trusted_ancestors.hits:
   type: double
 Endpoint.metrics.events_cache.trusted_ancestors.misses:
   dashed_name: Endpoint-metrics-events-cache-trusted-ancestors-misses
-  description: Number of successful trusted ancestor lookups
+  description: Number of failed trusted ancestor lookups
   flat_name: Endpoint.metrics.events_cache.trusted_ancestors.misses
   level: custom
   name: metrics.events_cache.trusted_ancestors.misses
   normalize: []
-  short: Number of successful trusted ancestor lookups
+  short: Number of failed trusted ancestor lookups
   type: double
 Endpoint.metrics.malicious_behavior_rules:
   dashed_name: Endpoint-metrics-malicious-behavior-rules

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -625,6 +625,44 @@ Endpoint.metrics.event_filter.active_user_count:
   normalize: []
   short: The number of active user event filters
   type: long
+Endpoint.metrics.events_cache:
+  dashed_name: Endpoint-metrics-events-cache
+  description: An object of metrics information related to the event cache
+  enabled: false
+  flat_name: Endpoint.metrics.events_cache
+  level: custom
+  name: metrics.events_cache
+  normalize: []
+  short: An object of metrics information related to the event cache
+  type: object
+Endpoint.metrics.events_cache.trusted_ancestors:
+  dashed_name: Endpoint-metrics-events-cache-trusted-ancestors
+  description: An object for metrics information related to the trusted ancestor feature
+  enabled: false
+  flat_name: Endpoint.metrics.events_cache.trusted_ancestors
+  level: custom
+  name: metrics.events_cache.trusted_ancestors
+  normalize: []
+  short: An object for metrics information related to the trusted ancestor feature
+  type: object
+Endpoint.metrics.events_cache.trusted_ancestors.hits:
+  dashed_name: Endpoint-metrics-events-cache-trusted-ancestors-hits
+  description: Number of successful trusted ancestor lookups
+  flat_name: Endpoint.metrics.events_cache.trusted_ancestors.hits
+  level: custom
+  name: metrics.events_cache.trusted_ancestors.hits
+  normalize: []
+  short: Number of successful trusted ancestor lookups
+  type: double
+Endpoint.metrics.events_cache.trusted_ancestors.misses:
+  dashed_name: Endpoint-metrics-events-cache-trusted-ancestors-misses
+  description: Number of successful trusted ancestor lookups
+  flat_name: Endpoint.metrics.events_cache.trusted_ancestors.misses
+  level: custom
+  name: metrics.events_cache.trusted_ancestors.misses
+  normalize: []
+  short: Number of successful trusted ancestor lookups
+  type: double
 Endpoint.metrics.malicious_behavior_rules:
   dashed_name: Endpoint-metrics-malicious-behavior-rules
   description: An array of performance information about each malicious behavior rule

--- a/schemas/v1/security/security.yaml
+++ b/schemas/v1/security/security.yaml
@@ -2641,7 +2641,6 @@ winlog.event_data.CountOfCredentialsReturned:
   description: Credential returned count.
   example: '0'
   flat_name: winlog.event_data.CountOfCredentialsReturned
-  ignore_above: 1024
   level: custom
   name: event_data.CountOfCredentialsReturned
   normalize: []

--- a/schemas/v1/security/security.yaml
+++ b/schemas/v1/security/security.yaml
@@ -2641,6 +2641,7 @@ winlog.event_data.CountOfCredentialsReturned:
   description: Credential returned count.
   example: '0'
   flat_name: winlog.event_data.CountOfCredentialsReturned
+  ignore_above: 1024
   level: custom
   name: event_data.CountOfCredentialsReturned
   normalize: []


### PR DESCRIPTION
## Change Summary

This adds two custom fields for reporting trusted ancestor lookup hits/misses:

```
  - Endpoint.metrics.events_cache.trusted_ancestors.hits
  - Endpoint.metrics.events_cache.trusted_ancestors.misses
```

I've never had to add anything to endpoint-package, so I'm not 100% sure I have everything completed here, even though I've run `make clean all`.

If you have alternate opinions about how these fields should be named, please tell me, I just came up with these in about 4 seconds.


### Sample values

```
    "events_cache": {
        "trusted_ancestors": {
            "hits": 504,
            "misses": 23578
        }
    },
```


## Release Target

9.x



### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
