### PR TITLE
Change trusted_ancestor types from double to unsigned_long

### DIFF
--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -857,12 +857,12 @@
 
     - name: metrics.events_cache.trusted_ancestors.hits
       level: custom
-      type: double
+      type: unsigned_long
       description: Number of successful trusted ancestor lookups
 
     - name: metrics.events_cache.trusted_ancestors.misses
       level: custom
-      type: double
+      type: unsigned_long
       description: Number of failed trusted ancestor lookups
 
     - name: metrics.malicious_behavior_rules.endpoint_uptime_percent

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -381,12 +381,12 @@
       default_field: false
     - name: metrics.events_cache.trusted_ancestors.hits
       level: custom
-      type: double
+      type: unsigned_long
       description: Number of successful trusted ancestor lookups
       default_field: false
     - name: metrics.events_cache.trusted_ancestors.misses
       level: custom
-      type: double
+      type: unsigned_long
       description: Number of failed trusted ancestor lookups
       default_field: false
     - name: metrics.malicious_behavior_rules

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -653,7 +653,7 @@ Endpoint.metrics.events_cache.trusted_ancestors.hits:
   name: metrics.events_cache.trusted_ancestors.hits
   normalize: []
   short: Number of successful trusted ancestor lookups
-  type: double
+  type: unsigned_long
 Endpoint.metrics.events_cache.trusted_ancestors.misses:
   dashed_name: Endpoint-metrics-events-cache-trusted-ancestors-misses
   description: Number of failed trusted ancestor lookups
@@ -662,7 +662,7 @@ Endpoint.metrics.events_cache.trusted_ancestors.misses:
   name: metrics.events_cache.trusted_ancestors.misses
   normalize: []
   short: Number of failed trusted ancestor lookups
-  type: double
+  type: unsigned_long
 Endpoint.metrics.malicious_behavior_rules:
   dashed_name: Endpoint-metrics-malicious-behavior-rules
   description: An array of performance information about each malicious behavior rule


### PR DESCRIPTION
## Change Summary

CC @pzl 

This is a minor update to  https://github.com/elastic/endpoint-package/pull/720 that changes the metrics types from double to unsigned_long, which is more appropriate. 

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match
