### PR TITLE
Add missing field in the ASM API events custom documentation

### DIFF
--- a/custom_documentation/doc/endpoint/api/windows/windows_api_asm.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_asm.md
@@ -50,6 +50,7 @@ This event is generated when ETW AttackSurfaceMonitor events are generated.
 | host.os.version |
 | message |
 | process.Ext.api.behaviors |
+| process.Ext.api.metadata.security_descriptor |
 | process.Ext.api.name |
 | process.Ext.api.parameters.device |
 | process.Ext.api.parameters.io_control_code |

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_asm.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_asm.yaml
@@ -54,6 +54,7 @@ fields:
   - host.os.version
   - message
   - process.Ext.api.behaviors
+  - process.Ext.api.metadata.security_descriptor
   - process.Ext.api.name
   - process.Ext.api.parameters.device
   - process.Ext.api.parameters.io_control_code


### PR DESCRIPTION
## Change Summary

Added `process.Ext.api.metadata.security_descriptor` field to the ASM API events custom documentation ([windows_api_asm.yaml](https://github.com/elastic/endpoint-package/compare/add_custom_documentation_for_api_events?expand=1#diff-386ac889ceffe596fa92ab7800fc53a458b24f7c1ae81bfa10df0de2e937effe))

(It looks like I forgot to add this field when I created this custom documentation... 😓 )

## Release Target

9.4

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
