### PR TITLE
Add process caps to other process events

### DIFF
--- a/custom_documentation/doc/endpoint/process/linux/linux_process_load_module.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_load_module.md
@@ -191,6 +191,8 @@ This event is generated when when a process loads a kernel module.
 | process.start |
 | process.supplemental_groups.id |
 | process.supplemental_groups.name |
+| process.thread.capabilities.effective |
+| process.thread.capabilities.permitted |
 | process.user.id |
 | process.user.name |
 | process.working_directory |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_memfd_create.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_memfd_create.md
@@ -193,6 +193,8 @@ This event is generated when when a memfd anonymous file is created.
 | process.start |
 | process.supplemental_groups.id |
 | process.supplemental_groups.name |
+| process.thread.capabilities.effective |
+| process.thread.capabilities.permitted |
 | process.user.id |
 | process.user.name |
 | process.working_directory |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_ptrace.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_ptrace.md
@@ -191,6 +191,8 @@ This event is generated when when a process calls ptrace_attach on another proce
 | process.start |
 | process.supplemental_groups.id |
 | process.supplemental_groups.name |
+| process.thread.capabilities.effective |
+| process.thread.capabilities.permitted |
 | process.user.id |
 | process.user.name |
 | process.working_directory |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_shmget.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_shmget.md
@@ -189,6 +189,8 @@ This event is generated when when a process calls shmget().
 | process.start |
 | process.supplemental_groups.id |
 | process.supplemental_groups.name |
+| process.thread.capabilities.effective |
+| process.thread.capabilities.permitted |
 | process.user.id |
 | process.user.name |
 | process.working_directory |

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_load_module.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_load_module.yaml
@@ -195,6 +195,8 @@ fields:
   - process.start
   - process.supplemental_groups.id
   - process.supplemental_groups.name
+  - process.thread.capabilities.effective
+  - process.thread.capabilities.permitted
   - process.user.id
   - process.user.name
   - process.working_directory

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_memfd_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_memfd_create.yaml
@@ -197,6 +197,8 @@ fields:
   - process.start
   - process.supplemental_groups.id
   - process.supplemental_groups.name
+  - process.thread.capabilities.effective
+  - process.thread.capabilities.permitted
   - process.user.id
   - process.user.name
   - process.working_directory

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_ptrace.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_ptrace.yaml
@@ -196,6 +196,8 @@ fields:
   - process.start
   - process.supplemental_groups.id
   - process.supplemental_groups.name
+  - process.thread.capabilities.effective
+  - process.thread.capabilities.permitted
   - process.user.id
   - process.user.name
   - process.working_directory

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_shmget.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_shmget.yaml
@@ -193,6 +193,8 @@ fields:
   - process.start
   - process.supplemental_groups.id
   - process.supplemental_groups.name
+  - process.thread.capabilities.effective
+  - process.thread.capabilities.permitted
   - process.user.id
   - process.user.name
   - process.working_directory


### PR DESCRIPTION
## Change Summary
Add `process.thread.capabilities.permitted` and `process.thread.capabilities.effective` to memfd, module load, ptrace, and shmget Linux process events.

## Release Target

9.4.0


## Q/A

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes