### PR TITLE
Fix Linux and macOS behavior alert custom doc for subtechnique fields

### DIFF
--- a/custom_documentation/doc/endpoint/alerts/linux/linux_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/linux/linux_malicious_behavior_alert.md
@@ -111,6 +111,9 @@ This alert is generated when a Malicious Behavior alert occurs.
 | threat.technique.name |
 | threat.technique.reference |
 | threat.technique.subtechnique |
+| threat.technique.subtechnique.id |
+| threat.technique.subtechnique.name |
+| threat.technique.subtechnique.reference |
 | user.Ext.real.id |
 | user.Ext.real.name |
 | user.id |

--- a/custom_documentation/doc/endpoint/alerts/macos/macos_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/macos/macos_malicious_behavior_alert.md
@@ -98,6 +98,9 @@ This alert is generated when a Malicious Behavior alert occurs.
 | threat.technique.name |
 | threat.technique.reference |
 | threat.technique.subtechnique |
+| threat.technique.subtechnique.id |
+| threat.technique.subtechnique.name |
+| threat.technique.subtechnique.reference |
 | user.Ext.real.id |
 | user.Ext.real.name |
 | user.id |

--- a/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malicious_behavior_alert.yaml
@@ -116,6 +116,9 @@ fields:
   - threat.technique.name
   - threat.technique.reference
   - threat.technique.subtechnique
+  - threat.technique.subtechnique.id
+  - threat.technique.subtechnique.name
+  - threat.technique.subtechnique.reference
   - user.Ext.real.id
   - user.Ext.real.name
   - user.id

--- a/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malicious_behavior_alert.yaml
@@ -103,6 +103,9 @@ fields:
   - threat.technique.name
   - threat.technique.reference
   - threat.technique.subtechnique
+  - threat.technique.subtechnique.id
+  - threat.technique.subtechnique.name
+  - threat.technique.subtechnique.reference
   - user.Ext.real.id
   - user.Ext.real.name
   - user.id


### PR DESCRIPTION
## Change Summary

Some rules emit populated `threat.technique.subtechnique.{id,name,reference}` fields. The Linux and macOS `malicious_behavior_alert` `custom_documentation` only listed the parent `threat.technique.subtechnique` path, so the EAF custom-documentation validator fails with:

```
AssertionError: Found documents with fields missing custom documentation, count: 1,
undocumented keys: {'threat.technique.subtechnique.id',
                    'threat.technique.subtechnique.reference',
                    'threat.technique.subtechnique.name'}.
```

This adds the three leaf entries to the Linux and macOS YAML and the rendered MD docs, mirroring the shape already present for Windows (added in #614). No schema/field changes — this only touches hand-maintained files under `custom_documentation/`.

EAF reference (build 603, Amazon Linux EAF, `ProductionRuleTestCase::test_production_rule`):
https://buildkite.com/elastic/endpoint-generate-new-eaf-test-durations/builds/603

## Release Target

9.5