### PR TITLE
Fix EAF failures from missing ransomware docs

### DIFF
--- a/custom_documentation/doc/endpoint/alerts/windows/windows_ransomware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_ransomware_alert.md
@@ -42,6 +42,8 @@ This alert is generated when a Ransomware alert occurs.
 | Ransomware.files.operation |
 | Ransomware.files.path |
 | Ransomware.files.score |
+| Ransomware.files.original.extension |
+| Ransomware.files.original.path |
 | Ransomware.score |
 | Ransomware.version |
 | Responses.@timestamp |

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_ransomware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_ransomware_alert.yaml
@@ -47,6 +47,8 @@ fields:
   - Ransomware.files.operation
   - Ransomware.files.path
   - Ransomware.files.score
+  - Ransomware.files.original.extension
+  - Ransomware.files.original.path
   - Ransomware.score
   - Ransomware.version
   - Responses.@timestamp


### PR DESCRIPTION
## Change Summary

Fixes https://github.com/elastic/endpoint-dev/issues/19936 , change introduced in https://github.com/elastic/ransom-protect/pull/248

This adds support for `Ransomware.files.original.*` in the alerts, which is currently breaking windows EAF tests.


### Sample values

```json
[
  {
    "data": "504B5468697320697320612063616E61",
    "entropy": 4.113635791473841,
    "extension": "lock",
    "metrics": [
      "SUBEXTENSION_KNOWN"
    ],
    "operation": "rename",
    "original": {
      "extension": "docm",
      "path": "c:\\aaantiransomelastic-do-not-touch-def6d40c-a6a1-442c-adc4-9d57a47e58d7\\antiransomelastic-do-not-touch-def8452b-fc17-414d-afb6-ddeceb5ec54c.docm"
    },
    "path": "c:\\aaantiransomelastic-do-not-touch-def6d40c-a6a1-442c-adc4-9d57a47e58d7\\antiransomelastic-do-not-touch-def8452b-fc17-414d-afb6-ddeceb5ec54c.docm.lock",
    "score": 0.003
  },
  {
    "data": "504B5468697320697320612063616E61",
    "entropy": 4.113635791473841,
    "extension": "lock",
    "metrics": [
      "CANARY_ACTIVITY"
    ],
    "operation": "rename",
    "original": {
      "extension": "docm",
      "path": "c:\\aaantiransomelastic-do-not-touch-dab6d40c-a6a1-442c-adc4-9d57a47e58d7\\antiransomelastic-do-not-touch-4568452b-fc17-414d-afb6-ddeceb5ec54c.docm"
    },
    "path": "c:\\aaantiransomelastic-do-not-touch-dab6d40c-a6a1-442c-adc4-9d57a47e58d7\\antiransomelastic-do-not-touch-4568452b-fc17-414d-afb6-ddeceb5ec54c.docm.lock",
    "score": 0.0
  }
]

```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
