### PR TITLE
Add process.ai_agent.* custom documentation for Linux process events

### DIFF
--- a/custom_documentation/doc/endpoint/process/linux/linux_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_already_running.md
@@ -68,6 +68,8 @@ This event is generated for a process that was already running before Endpoint's
 | process.Ext.command_line_truncated |
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
+| process.ai_agent.is_descendant |
+| process.ai_agent.name |
 | process.args |
 | process.args_count |
 | process.command_line |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_fork_exec_exit.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_fork_exec_exit.md
@@ -68,6 +68,8 @@ This event is generated when a process calls `fork()`, `exec()`, exits, or an ag
 | process.Ext.command_line_truncated |
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
+| process.ai_agent.is_descendant |
+| process.ai_agent.name |
 | process.args |
 | process.args_count |
 | process.command_line |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_gid_change.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_gid_change.md
@@ -67,6 +67,8 @@ This event is generated when the group id changes for a process.
 | process.Ext.ancestry |
 | process.Ext.command_line_truncated |
 | process.Ext.trusted_descendant |
+| process.ai_agent.is_descendant |
+| process.ai_agent.name |
 | process.args |
 | process.args_count |
 | process.command_line |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_memfd_create.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_memfd_create.md
@@ -74,6 +74,8 @@ This event is generated when when a memfd anonymous file is created.
 | process.Ext.memfd.name |
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
+| process.ai_agent.is_descendant |
+| process.ai_agent.name |
 | process.args |
 | process.args_count |
 | process.command_line |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_ptrace.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_ptrace.md
@@ -71,6 +71,8 @@ This event is generated when when a process calls ptrace_attach on another proce
 | process.Ext.ptrace.request |
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
+| process.ai_agent.is_descendant |
+| process.ai_agent.name |
 | process.args |
 | process.args_count |
 | process.command_line |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_shmget.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_shmget.md
@@ -69,6 +69,8 @@ This event is generated when when a process calls shmget().
 | process.Ext.shmget.size |
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
+| process.ai_agent.is_descendant |
+| process.ai_agent.name |
 | process.args |
 | process.args_count |
 | process.command_line |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_uid_change.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_uid_change.md
@@ -67,6 +67,8 @@ This event is generated when the user id changes for a process.
 | process.Ext.command_line_truncated |
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
+| process.ai_agent.is_descendant |
+| process.ai_agent.name |
 | process.args |
 | process.args_count |
 | process.command_line |

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_already_running.yaml
@@ -74,6 +74,8 @@ fields:
   - process.Ext.command_line_truncated
   - process.Ext.trusted
   - process.Ext.trusted_descendant
+  - process.ai_agent.is_descendant
+  - process.ai_agent.name
   - process.args
   - process.args_count
   - process.command_line

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_fork_exec_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_fork_exec_exit.yaml
@@ -77,6 +77,8 @@ fields:
   - process.Ext.command_line_truncated
   - process.Ext.trusted
   - process.Ext.trusted_descendant
+  - process.ai_agent.is_descendant
+  - process.ai_agent.name
   - process.args
   - process.args_count
   - process.command_line

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_gid_change.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_gid_change.yaml
@@ -72,6 +72,8 @@ fields:
   - process.Ext.ancestry
   - process.Ext.command_line_truncated
   - process.Ext.trusted_descendant
+  - process.ai_agent.is_descendant
+  - process.ai_agent.name
   - process.args
   - process.args_count
   - process.command_line

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_memfd_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_memfd_create.yaml
@@ -78,6 +78,8 @@ fields:
   - process.Ext.memfd.name
   - process.Ext.trusted
   - process.Ext.trusted_descendant
+  - process.ai_agent.is_descendant
+  - process.ai_agent.name
   - process.args
   - process.args_count
   - process.command_line

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_ptrace.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_ptrace.yaml
@@ -76,6 +76,8 @@ fields:
   - process.Ext.ptrace.request
   - process.Ext.trusted
   - process.Ext.trusted_descendant
+  - process.ai_agent.is_descendant
+  - process.ai_agent.name
   - process.args
   - process.args_count
   - process.command_line

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_shmget.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_shmget.yaml
@@ -73,6 +73,8 @@ fields:
   - process.Ext.shmget.size
   - process.Ext.trusted
   - process.Ext.trusted_descendant
+  - process.ai_agent.is_descendant
+  - process.ai_agent.name
   - process.args
   - process.args_count
   - process.command_line

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_uid_change.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_uid_change.yaml
@@ -71,6 +71,8 @@ fields:
   - process.Ext.command_line_truncated
   - process.Ext.trusted
   - process.Ext.trusted_descendant
+  - process.ai_agent.is_descendant
+  - process.ai_agent.name
   - process.args
   - process.args_count
   - process.command_line


### PR DESCRIPTION
Register process.ai_agent.name and process.ai_agent.is_descendant in all Linux process event documentation templates that already carry the analogous process.Ext.trusted_descendant field (fork/exec/exit, already_running, gid_change, memfd_create, ptrace, shmget, uid_change).

## Change Summary

<!-- please describe your changes. For mapping changes, describe the usage of the changed fields -->


### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json


```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
