### PR TITLE
Revert 747

### DIFF
--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,8 +1,8 @@
 - version: "9.5.0-next"
   changes:
-    - description: Add cross-cluster search source to the metadata_united transform for Elastic Defend remote Elasticsearch output support
+    - description: TBD
       type: enhancement
-      link: https://github.com/elastic/endpoint-package/pull/747
+      link: https://github.com/elastic/endpoint-package/pull/99999
 - version: "9.4.0"
   changes:
     - description: automatic troubleshooting endpoint context docs

--- a/package/endpoint/elasticsearch/transform/metadata_united/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_united/default.json
@@ -2,7 +2,6 @@
     "source": {
         "index": [
             "metrics-endpoint.metadata_current_default*",
-            "*:metrics-endpoint.metadata_current_default*",
             ".fleet-agents*"
         ]
     },

--- a/package/endpoint/manifest.yml
+++ b/package/endpoint/manifest.yml
@@ -2,7 +2,7 @@ format_version: 3.0.0
 name: endpoint
 title: Elastic Defend
 description: Protect your hosts and cloud workloads with threat prevention, detection, and deep security data visibility.
-version: 9.5.0-prerelease.1
+version: 9.5.0-prerelease.2
 categories: ["security", "edr_xdr"]
 # The package type. The options for now are [integration, input], more type might be added in the future.
 


### PR DESCRIPTION
## Change Summary

- Reverts #747 -- environments that do not support CCS error on install
- bump prerelease to 9.5.0-prerelease.2

