### PR TITLE
Split metadata_united transform into stateful and serverless variants

### DIFF
--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -3,6 +3,9 @@
     - description: TBD
       type: enhancement
       link: https://github.com/elastic/endpoint-package/pull/99999
+    - description: Split the metadata_united transform into stateful (cross-cluster) and serverless (local) variants gated by _meta.environments
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/750
 - version: "9.4.0"
   changes:
     - description: automatic troubleshooting endpoint context docs

--- a/package/endpoint/elasticsearch/transform/metadata_united/serverless.json
+++ b/package/endpoint/elasticsearch/transform/metadata_united/serverless.json
@@ -2,7 +2,6 @@
     "source": {
         "index": [
             "metrics-endpoint.metadata_current_default*",
-            "*:metrics-endpoint.metadata_current_default*",
             ".fleet-agents*"
         ]
     },
@@ -39,7 +38,7 @@
     "_meta": {
         "managed": true,
         "environments": [
-            "stateful"
+            "serverless"
         ]
     }
 }


### PR DESCRIPTION
## Summary

Splits the `metadata_united` transform into two deployment-specific variants, selected at install time via a new `_meta.environments` field that Fleet honors:

- **`default.json`** — *stateful*: keeps the cross-cluster (`*:`) source so the managing cluster can read endpoint metadata from a remote Elasticsearch output. `_meta.environments: ["stateful"]`
- **`serverless.json`** — *serverless*: local-only source (CCS is unsupported on serverless; ES rejects remote sources in a transform there). `_meta.environments: ["serverless"]`

Both write to the same destination index, so exactly one installs per environment.

## Background

The cross-cluster `*:` source (#747) broke the endpoint package install on serverless QA projects — `action_request_validation_exception: Cross-project calls are not supported, but remote indices were requested` — and was reverted in #749 (`9.5.0-prerelease.2`).

This re-lands the CCS source for **stateful** while keeping **serverless** on a local-only transform, with **no install-time mutation**: Fleet installs whichever variant matches the deployment and skips the other.

## Paired Kibana change

Requires the Fleet install gate that reads `_meta.environments` (links the two variants to the deployment flavor): **elastic/kibana#275669**.

## Testing

Validated locally on both stateful and serverless (cross-project enabled): the matching variant installs verbatim (HTTP 200), the other is skipped, and the transform starts healthy. A package without `_meta.environments` installs unchanged (back-compat).
