### PR TITLE
Add GenAI process fields from ECS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 # we are intentionally pinning the ECS version here, when ecs releases a new version
 # we'll discuss whether we need to release a new package and bump the version here
-# 43a1a61a4a4db88e2de60da9019733610717ff7e is v8.10.0
-ECS_GIT_REF ?= 43a1a61a4a4db88e2de60da9019733610717ff7e
+# f04bb41e4fcc35befcaa94a1d9575bc61944520c adds process.ai_agent.* alpha fields.
+ECS_GIT_REF ?= f04bb41e4fcc35befcaa94a1d9575bc61944520c
 
 
 # This variable specifies to location of the package-storage repo. It is used for automatically creating a PR

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 # we are intentionally pinning the ECS version here, when ecs releases a new version
 # we'll discuss whether we need to release a new package and bump the version here
-# f04bb41e4fcc35befcaa94a1d9575bc61944520c adds process.ai_agent.* alpha fields.
-ECS_GIT_REF ?= f04bb41e4fcc35befcaa94a1d9575bc61944520c
+# 43a1a61a4a4db88e2de60da9019733610717ff7e is v8.10.0
+ECS_GIT_REF ?= 43a1a61a4a4db88e2de60da9019733610717ff7e
 
 
 # This variable specifies to location of the package-storage repo. It is used for automatically creating a PR

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -71,6 +71,41 @@
         The URL where the process's executable file is hosted.
       example: http://example.com/files/example.exe
 
+    - name: ai_agent
+      level: extended
+      type: object
+      alpha: This field is alpha and subject to change.
+      short: AI-agent tool identification fields.
+      description: >
+        Fields describing an AI-agent tool associated with a process.
+
+        When a process is identified as a known AI-agent development tool, these fields
+        can be populated on the process event and propagated to descendant processes.
+        This enables analysts and detection rules to distinguish AI-agent-initiated
+        activity from human-initiated activity.
+
+    - name: ai_agent.is_descendant
+      level: extended
+      type: boolean
+      alpha: This field is alpha and subject to change.
+      short: Whether this process is a descendant of an AI-agent tool process.
+      description: >
+        True when this process was spawned, directly or transitively, by
+        a known AI-agent tool process.
+
+    - name: ai_agent.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      alpha: This field is alpha and subject to change.
+      short: Canonical name of the AI-agent tool.
+      description: >
+        Canonical name of the AI-agent tool associated with this process
+        or its ancestor.
+
+        Examples include `cursor`, `claude_code`, `codex`, `copilot`, `ollama`, and
+        `gemini_cli`.
+
     - name: parent.thread
       level: custom
       type: object

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -102,6 +102,10 @@ fields:
               name: {}
   process:
     fields:
+      ai_agent:
+        fields:
+          is_descendant: {}
+          name: {}
       args: {}
       args_count: {}
       code_signature:

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -1131,31 +1131,22 @@
     - name: ai_agent
       level: extended
       type: object
-      alpha: This field is alpha and subject to change.
       description: 'Fields describing an AI-agent tool associated with a process.
 
-        When a process is identified as a known AI-agent development tool, these fields
-        can be populated on the process event and propagated to descendant processes.
-        This enables analysts and detection rules to distinguish AI-agent-initiated
-        activity from human-initiated activity.'
+        When a process is identified as a known AI-agent development tool, these fields can be populated on the process event and propagated to descendant processes. This enables analysts and detection rules to distinguish AI-agent-initiated activity from human-initiated activity.'
       default_field: false
     - name: ai_agent.is_descendant
       level: extended
       type: boolean
-      alpha: This field is alpha and subject to change.
-      description: True when this process was spawned, directly or transitively, by
-        a known AI-agent tool process.
+      description: True when this process was spawned, directly or transitively, by a known AI-agent tool process.
       default_field: false
     - name: ai_agent.name
       level: extended
       type: keyword
       ignore_above: 1024
-      alpha: This field is alpha and subject to change.
-      description: 'Canonical name of the AI-agent tool associated with this process
-        or its ancestor.
+      description: 'Canonical name of the AI-agent tool associated with this process or its ancestor.
 
-        Examples include `cursor`, `claude_code`, `codex`, `copilot`, `ollama`, and
-        `gemini_cli`.'
+        Examples include `cursor`, `claude_code`, `codex`, `copilot`, `ollama`, and `gemini_cli`.'
       default_field: false
     - name: args
       level: extended

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -1128,6 +1128,35 @@
       description: Windows zone identifier for a process's executable file
       example: 3
       default_field: false
+    - name: ai_agent
+      level: extended
+      type: object
+      alpha: This field is alpha and subject to change.
+      description: 'Fields describing an AI-agent tool associated with a process.
+
+        When a process is identified as a known AI-agent development tool, these fields
+        can be populated on the process event and propagated to descendant processes.
+        This enables analysts and detection rules to distinguish AI-agent-initiated
+        activity from human-initiated activity.'
+      default_field: false
+    - name: ai_agent.is_descendant
+      level: extended
+      type: boolean
+      alpha: This field is alpha and subject to change.
+      description: True when this process was spawned, directly or transitively, by
+        a known AI-agent tool process.
+      default_field: false
+    - name: ai_agent.name
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      alpha: This field is alpha and subject to change.
+      description: 'Canonical name of the AI-agent tool associated with this process
+        or its ancestor.
+
+        Examples include `cursor`, `claude_code`, `codex`, `copilot`, `ollama`, and
+        `gemini_cli`.'
+      default_field: false
     - name: args
       level: extended
       type: keyword

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2445,6 +2445,9 @@ sent by the endpoint.
 | process.Ext.trusted_descendant | Whether or not the process is a descendent of a trusted application | boolean |
 | process.Ext.windows | Platform-specific Windows fields | object |
 | process.Ext.windows.zone_identifier | Windows zone identifier for a process's executable file | keyword |
+| process.ai_agent | Fields describing an AI-agent tool associated with a process. When a process is identified as a known AI-agent development tool, these fields can be populated on the process event and propagated to descendant processes. This enables analysts and detection rules to distinguish AI-agent-initiated activity from human-initiated activity. | object |
+| process.ai_agent.is_descendant | True when this process was spawned, directly or transitively, by a known AI-agent tool process. | boolean |
+| process.ai_agent.name | Canonical name of the AI-agent tool associated with this process or its ancestor. Examples include `cursor`, `claude_code`, `codex`, `copilot`, `ollama`, and `gemini_cli`. | keyword |
 | process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |
 | process.args_count | Length of the process.args array. This field can be useful for querying or performing bucket analysis on how many arguments were provided to start a process. More arguments may be an indication of suspicious activity. | long |
 | process.code_signature.exists | Boolean to capture if a signature is present. | boolean |

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -2039,6 +2039,46 @@ process.Ext.windows.zone_identifier:
   normalize: []
   short: Windows zone identifier for a process's executable file
   type: keyword
+process.ai_agent:
+  alpha: This field is alpha and subject to change.
+  dashed_name: process-ai-agent
+  description: 'Fields describing an AI-agent tool associated with a process.
+
+    When a process is identified as a known AI-agent development tool, these fields
+    can be populated on the process event and propagated to descendant processes.
+    This enables analysts and detection rules to distinguish AI-agent-initiated activity
+    from human-initiated activity.'
+  flat_name: process.ai_agent
+  level: extended
+  name: ai_agent
+  normalize: []
+  short: AI-agent tool identification fields.
+  type: object
+process.ai_agent.is_descendant:
+  alpha: This field is alpha and subject to change.
+  dashed_name: process-ai-agent-is-descendant
+  description: True when this process was spawned, directly or transitively, by a
+    known AI-agent tool process.
+  flat_name: process.ai_agent.is_descendant
+  level: extended
+  name: ai_agent.is_descendant
+  normalize: []
+  short: Whether this process is a descendant of an AI-agent tool process.
+  type: boolean
+process.ai_agent.name:
+  alpha: This field is alpha and subject to change.
+  dashed_name: process-ai-agent-name
+  description: 'Canonical name of the AI-agent tool associated with this process or
+    its ancestor.
+
+    Examples include `cursor`, `claude_code`, `codex`, `copilot`, `ollama`, and `gemini_cli`.'
+  flat_name: process.ai_agent.name
+  ignore_above: 1024
+  level: extended
+  name: ai_agent.name
+  normalize: []
+  short: Canonical name of the AI-agent tool.
+  type: keyword
 process.args:
   dashed_name: process-args
   description: 'Array of process arguments, starting with the absolute path to the


### PR DESCRIPTION
process.ai_agent.* was documented on Linux process events in #744, but the underlying field/schema definitions were never merged to main - here they are

(cherry picked from commit f645c16613a9bda71106f51443a1aab61defe002)

## Change Summary

<!-- please describe your changes. For mapping changes, describe the usage of the changed fields -->


### Sample values

<!--  For field/mapping changes, please provide sample values for this field, in JSON format.
    
    This ticket is a good reference: https://github.com/elastic/endpoint-dev/issues/9533

    Delete this section if this is not a mapping change
-->


Sample document:

```json


```


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [ ] I ran `make` after making the schema changes, and committed all changes
- [ ] If these field(s) are "exception"-able, I made a companion PR to Kibana adding it (see [Readme](https://github.com/elastic/endpoint-package#exceptionable))
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match

### For Transform changes:

- [ ] The new transform successfully starts in Kibana
- [ ] The corresponding transform destination schema was updated if necessary
