### PR TITLE
Backport missing custom-documentation fields to 8.19

### DIFF
--- a/custom_documentation/doc/endpoint/alerts/linux/linux_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/linux/linux_malicious_behavior_alert.md
@@ -111,6 +111,9 @@ This alert is generated when a Malicious Behavior alert occurs.
 | threat.technique.name |
 | threat.technique.reference |
 | threat.technique.subtechnique |
+| threat.technique.subtechnique.id |
+| threat.technique.subtechnique.name |
+| threat.technique.subtechnique.reference |
 | user.Ext.real.id |
 | user.Ext.real.name |
 | user.id |

--- a/custom_documentation/doc/endpoint/alerts/macos/macos_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/macos/macos_malicious_behavior_alert.md
@@ -98,6 +98,9 @@ This alert is generated when a Malicious Behavior alert occurs.
 | threat.technique.name |
 | threat.technique.reference |
 | threat.technique.subtechnique |
+| threat.technique.subtechnique.id |
+| threat.technique.subtechnique.name |
+| threat.technique.subtechnique.reference |
 | user.Ext.real.id |
 | user.Ext.real.name |
 | user.id |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_asm.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_asm.md
@@ -49,6 +49,7 @@ This event is generated when ETW AttackSurfaceMonitor events are generated.
 | host.os.version |
 | message |
 | process.Ext.api.behaviors |
+| process.Ext.api.metadata.security_descriptor |
 | process.Ext.api.name |
 | process.Ext.api.parameters.device |
 | process.Ext.api.parameters.io_control_code |

--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -83,6 +83,11 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.documents_volume.registry_events.suppressed_count |
 | Endpoint.metrics.documents_volume.security_events.sent_bytes |
 | Endpoint.metrics.documents_volume.security_events.sent_count |
+| Endpoint.metrics.documents_volume.security_events.sources.sent_bytes |
+| Endpoint.metrics.documents_volume.security_events.sources.sent_count |
+| Endpoint.metrics.documents_volume.security_events.sources.source |
+| Endpoint.metrics.documents_volume.security_events.sources.suppressed_bytes |
+| Endpoint.metrics.documents_volume.security_events.sources.suppressed_count |
 | Endpoint.metrics.documents_volume.security_events.suppressed_bytes |
 | Endpoint.metrics.documents_volume.security_events.suppressed_count |
 | Endpoint.metrics.documents_volume.volume_device_events.sent_bytes |

--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -75,6 +75,11 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.documents_volume.overall.suppressed_count |
 | Endpoint.metrics.documents_volume.process_events.sent_bytes |
 | Endpoint.metrics.documents_volume.process_events.sent_count |
+| Endpoint.metrics.documents_volume.process_events.sources.sent_bytes |
+| Endpoint.metrics.documents_volume.process_events.sources.sent_count |
+| Endpoint.metrics.documents_volume.process_events.sources.source |
+| Endpoint.metrics.documents_volume.process_events.sources.suppressed_bytes |
+| Endpoint.metrics.documents_volume.process_events.sources.suppressed_count |
 | Endpoint.metrics.documents_volume.process_events.suppressed_bytes |
 | Endpoint.metrics.documents_volume.process_events.suppressed_count |
 | Endpoint.metrics.documents_volume.registry_events.sent_bytes |

--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -128,6 +128,8 @@ This is an internal state management document that includes metrics on Endpoint'
 | Endpoint.metrics.system_impact.file_events.week_ms |
 | Endpoint.metrics.system_impact.kernel_api_events.week_idle_ms |
 | Endpoint.metrics.system_impact.kernel_api_events.week_ms |
+| Endpoint.metrics.system_impact.kernel_process_events.week_idle_ms |
+| Endpoint.metrics.system_impact.kernel_process_events.week_ms |
 | Endpoint.metrics.system_impact.ldap_client_events.week_idle_ms |
 | Endpoint.metrics.system_impact.ldap_client_events.week_ms |
 | Endpoint.metrics.system_impact.library_load_events.week_idle_ms |

--- a/custom_documentation/doc/endpoint/network/macos/macos_network_connection_attempted_and_disconnect.md
+++ b/custom_documentation/doc/endpoint/network/macos/macos_network_connection_attempted_and_disconnect.md
@@ -52,6 +52,7 @@ This event is generated when a connection is attempted or a request to terminate
 | host.os.type |
 | host.os.version |
 | message |
+| network.direction |
 | network.transport |
 | network.type |
 | process.Ext.ancestry |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
@@ -64,6 +64,8 @@ This event is generated for a process that was already running before Endpoint's
 | process.Ext.token.elevation_level |
 | process.Ext.token.integrity_level_name |
 | process.Ext.token.security_attributes |
+| process.Ext.trusted |
+| process.Ext.trusted_descendant |
 | process.Ext.windows.zone_identifier |
 | process.args |
 | process.args_count |

--- a/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malicious_behavior_alert.yaml
@@ -116,6 +116,9 @@ fields:
   - threat.technique.name
   - threat.technique.reference
   - threat.technique.subtechnique
+  - threat.technique.subtechnique.id
+  - threat.technique.subtechnique.name
+  - threat.technique.subtechnique.reference
   - user.Ext.real.id
   - user.Ext.real.name
   - user.id

--- a/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malicious_behavior_alert.yaml
@@ -103,6 +103,9 @@ fields:
   - threat.technique.name
   - threat.technique.reference
   - threat.technique.subtechnique
+  - threat.technique.subtechnique.id
+  - threat.technique.subtechnique.name
+  - threat.technique.subtechnique.reference
   - user.Ext.real.id
   - user.Ext.real.name
   - user.id

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_asm.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_asm.yaml
@@ -53,6 +53,7 @@ fields:
   - host.os.version
   - message
   - process.Ext.api.behaviors
+  - process.Ext.api.metadata.security_descriptor
   - process.Ext.api.name
   - process.Ext.api.parameters.device
   - process.Ext.api.parameters.io_control_code

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -90,6 +90,11 @@ fields:
   - Endpoint.metrics.documents_volume.registry_events.suppressed_count
   - Endpoint.metrics.documents_volume.security_events.sent_bytes
   - Endpoint.metrics.documents_volume.security_events.sent_count
+  - Endpoint.metrics.documents_volume.security_events.sources.sent_bytes
+  - Endpoint.metrics.documents_volume.security_events.sources.sent_count
+  - Endpoint.metrics.documents_volume.security_events.sources.source
+  - Endpoint.metrics.documents_volume.security_events.sources.suppressed_bytes
+  - Endpoint.metrics.documents_volume.security_events.sources.suppressed_count
   - Endpoint.metrics.documents_volume.security_events.suppressed_bytes
   - Endpoint.metrics.documents_volume.security_events.suppressed_count
   - Endpoint.metrics.documents_volume.volume_device_events.sent_bytes

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -82,6 +82,11 @@ fields:
   - Endpoint.metrics.documents_volume.overall.suppressed_count
   - Endpoint.metrics.documents_volume.process_events.sent_bytes
   - Endpoint.metrics.documents_volume.process_events.sent_count
+  - Endpoint.metrics.documents_volume.process_events.sources.sent_bytes
+  - Endpoint.metrics.documents_volume.process_events.sources.sent_count
+  - Endpoint.metrics.documents_volume.process_events.sources.source
+  - Endpoint.metrics.documents_volume.process_events.sources.suppressed_bytes
+  - Endpoint.metrics.documents_volume.process_events.sources.suppressed_count
   - Endpoint.metrics.documents_volume.process_events.suppressed_bytes
   - Endpoint.metrics.documents_volume.process_events.suppressed_count
   - Endpoint.metrics.documents_volume.registry_events.sent_bytes

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -135,6 +135,8 @@ fields:
   - Endpoint.metrics.system_impact.file_events.week_ms
   - Endpoint.metrics.system_impact.kernel_api_events.week_idle_ms
   - Endpoint.metrics.system_impact.kernel_api_events.week_ms
+  - Endpoint.metrics.system_impact.kernel_process_events.week_idle_ms
+  - Endpoint.metrics.system_impact.kernel_process_events.week_ms
   - Endpoint.metrics.system_impact.ldap_client_events.week_idle_ms
   - Endpoint.metrics.system_impact.ldap_client_events.week_ms
   - Endpoint.metrics.system_impact.library_load_events.week_idle_ms

--- a/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_connection_attempted_and_disconnect.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_connection_attempted_and_disconnect.yaml
@@ -60,6 +60,7 @@ fields:
   - host.os.type
   - host.os.version
   - message
+  - network.direction
   - network.transport
   - network.type
   - process.Ext.ancestry

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
@@ -70,6 +70,8 @@ fields:
   - process.Ext.token.elevation_level
   - process.Ext.token.integrity_level_name
   - process.Ext.token.security_attributes
+  - process.Ext.trusted
+  - process.Ext.trusted_descendant
   - process.Ext.windows.zone_identifier
   - process.args
   - process.args_count

--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -533,6 +533,36 @@
       type: long
       description: Total size of suppressed documents
 
+    - name: metrics.documents_volume.process_events.sources
+      level: custom
+      type: object
+      description: An array of Process Event document statistics per source
+
+    - name: metrics.documents_volume.process_events.sources.source
+      level: custom
+      type: keyword
+      description: Process Event document source name
+
+    - name: metrics.documents_volume.process_events.sources.sent_count
+      level: custom
+      type: long
+      description: Number of sent Process Event documents from source
+
+    - name: metrics.documents_volume.process_events.sources.sent_bytes
+      level: custom
+      type: long
+      description: Total size of Process Event sent documents from source
+
+    - name: metrics.documents_volume.process_events.sources.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed Process Event documents from source
+
+    - name: metrics.documents_volume.process_events.sources.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed Process Event documents from source
+
     - name: metrics.documents_volume.library_events.sent_count
       level: custom
       type: long
@@ -572,6 +602,36 @@
       level: custom
       type: long
       description: Total size of suppressed documents
+
+    - name: metrics.documents_volume.security_events.sources
+      level: custom
+      type: object
+      description: An array of Security Event document statistics per source
+
+    - name: metrics.documents_volume.security_events.sources.source
+      level: custom
+      type: keyword
+      description: Security Event document source name
+
+    - name: metrics.documents_volume.security_events.sources.sent_count
+      level: custom
+      type: long
+      description: Number of sent Security Event documents from source
+
+    - name: metrics.documents_volume.security_events.sources.sent_bytes
+      level: custom
+      type: long
+      description: Total size of Security Event sent documents from source
+
+    - name: metrics.documents_volume.security_events.sources.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed Security Event documents from source
+
+    - name: metrics.documents_volume.security_events.sources.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed Security Event documents from source
 
     - name: metrics.documents_volume.dns_events.sent_count
       level: custom

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -303,6 +303,37 @@
       type: long
       description: Number of sent documents
       default_field: false
+    - name: metrics.documents_volume.process_events.sources
+      level: custom
+      type: object
+      description: An array of Process Event document statistics per source
+      default_field: false
+    - name: metrics.documents_volume.process_events.sources.sent_bytes
+      level: custom
+      type: long
+      description: Total size of Process Event sent documents from source
+      default_field: false
+    - name: metrics.documents_volume.process_events.sources.sent_count
+      level: custom
+      type: long
+      description: Number of sent Process Event documents from source
+      default_field: false
+    - name: metrics.documents_volume.process_events.sources.source
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Process Event document source name
+      default_field: false
+    - name: metrics.documents_volume.process_events.sources.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed Process Event documents from source
+      default_field: false
+    - name: metrics.documents_volume.process_events.sources.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed Process Event documents from source
+      default_field: false
     - name: metrics.documents_volume.process_events.suppressed_bytes
       level: custom
       type: long
@@ -342,6 +373,37 @@
       level: custom
       type: long
       description: Number of sent documents
+      default_field: false
+    - name: metrics.documents_volume.security_events.sources
+      level: custom
+      type: object
+      description: An array of Security Event document statistics per source
+      default_field: false
+    - name: metrics.documents_volume.security_events.sources.sent_bytes
+      level: custom
+      type: long
+      description: Total size of Security Event sent documents from source
+      default_field: false
+    - name: metrics.documents_volume.security_events.sources.sent_count
+      level: custom
+      type: long
+      description: Number of sent Security Event documents from source
+      default_field: false
+    - name: metrics.documents_volume.security_events.sources.source
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Security Event document source name
+      default_field: false
+    - name: metrics.documents_volume.security_events.sources.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed Security Event documents from source
+      default_field: false
+    - name: metrics.documents_volume.security_events.sources.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed Security Event documents from source
       default_field: false
     - name: metrics.documents_volume.security_events.suppressed_bytes
       level: custom

--- a/package/endpoint/data_stream/metrics/sample_event.json
+++ b/package/endpoint/data_stream/metrics/sample_event.json
@@ -658,7 +658,16 @@
                     "suppressed_count": 0,
                     "suppressed_bytes": 0,
                     "sent_count": 259,
-                    "sent_bytes": 422247
+                    "sent_bytes": 422247,
+                    "sources": [
+                        {
+                            "source": "diagnostic_4624",
+                            "sent_count": 4,
+                            "sent_bytes": 10240,
+                            "suppressed_count": 0,
+                            "suppressed_bytes": 0
+                        }
+                    ]
                 },
                 "library_events": {
                     "suppressed_count": 0,
@@ -670,7 +679,16 @@
                     "suppressed_count": 0,
                     "suppressed_bytes": 0,
                     "sent_count": 201,
-                    "sent_bytes": 602914
+                    "sent_bytes": 602914,
+                    "sources": [
+                        {
+                            "source": "load_module",
+                            "sent_count": 2,
+                            "sent_bytes": 5000,
+                            "suppressed_count": 1,
+                            "suppressed_bytes": 2500
+                        }
+                    ]
                 },
                 "registry_events": {
                     "suppressed_count": 0,

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2998,6 +2998,12 @@ Metrics documents contain performance information about the endpoint executable 
 | Endpoint.metrics.documents_volume.overall.suppressed_count | Number of suppressed documents | long |
 | Endpoint.metrics.documents_volume.process_events.sent_bytes | Total size of sent documents | long |
 | Endpoint.metrics.documents_volume.process_events.sent_count | Number of sent documents | long |
+| Endpoint.metrics.documents_volume.process_events.sources | An array of Process Event document statistics per source | object |
+| Endpoint.metrics.documents_volume.process_events.sources.sent_bytes | Total size of Process Event sent documents from source | long |
+| Endpoint.metrics.documents_volume.process_events.sources.sent_count | Number of sent Process Event documents from source | long |
+| Endpoint.metrics.documents_volume.process_events.sources.source | Process Event document source name | keyword |
+| Endpoint.metrics.documents_volume.process_events.sources.suppressed_bytes | Total size of suppressed Process Event documents from source | long |
+| Endpoint.metrics.documents_volume.process_events.sources.suppressed_count | Number of suppressed Process Event documents from source | long |
 | Endpoint.metrics.documents_volume.process_events.suppressed_bytes | Total size of suppressed documents | long |
 | Endpoint.metrics.documents_volume.process_events.suppressed_count | Number of suppressed documents | long |
 | Endpoint.metrics.documents_volume.registry_events.sent_bytes | Total size of sent documents | long |
@@ -3006,6 +3012,12 @@ Metrics documents contain performance information about the endpoint executable 
 | Endpoint.metrics.documents_volume.registry_events.suppressed_count | Number of suppressed documents | long |
 | Endpoint.metrics.documents_volume.security_events.sent_bytes | Total size of sent documents | long |
 | Endpoint.metrics.documents_volume.security_events.sent_count | Number of sent documents | long |
+| Endpoint.metrics.documents_volume.security_events.sources | An array of Security Event document statistics per source | object |
+| Endpoint.metrics.documents_volume.security_events.sources.sent_bytes | Total size of Security Event sent documents from source | long |
+| Endpoint.metrics.documents_volume.security_events.sources.sent_count | Number of sent Security Event documents from source | long |
+| Endpoint.metrics.documents_volume.security_events.sources.source | Security Event document source name | keyword |
+| Endpoint.metrics.documents_volume.security_events.sources.suppressed_bytes | Total size of suppressed Security Event documents from source | long |
+| Endpoint.metrics.documents_volume.security_events.sources.suppressed_count | Number of suppressed Security Event documents from source | long |
 | Endpoint.metrics.documents_volume.security_events.suppressed_bytes | Total size of suppressed documents | long |
 | Endpoint.metrics.documents_volume.security_events.suppressed_count | Number of suppressed documents | long |
 | Endpoint.metrics.event_filter.active_global_count | The number of active global event filters | long |

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -513,6 +513,61 @@ Endpoint.metrics.documents_volume.process_events.sent_count:
   normalize: []
   short: Number of sent documents
   type: long
+Endpoint.metrics.documents_volume.process_events.sources:
+  dashed_name: Endpoint-metrics-documents-volume-process-events-sources
+  description: An array of Process Event document statistics per source
+  flat_name: Endpoint.metrics.documents_volume.process_events.sources
+  level: custom
+  name: metrics.documents_volume.process_events.sources
+  normalize: []
+  short: An array of Process Event document statistics per source
+  type: object
+Endpoint.metrics.documents_volume.process_events.sources.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-process-events-sources-sent-bytes
+  description: Total size of Process Event sent documents from source
+  flat_name: Endpoint.metrics.documents_volume.process_events.sources.sent_bytes
+  level: custom
+  name: metrics.documents_volume.process_events.sources.sent_bytes
+  normalize: []
+  short: Total size of Process Event sent documents from source
+  type: long
+Endpoint.metrics.documents_volume.process_events.sources.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-process-events-sources-sent-count
+  description: Number of sent Process Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.process_events.sources.sent_count
+  level: custom
+  name: metrics.documents_volume.process_events.sources.sent_count
+  normalize: []
+  short: Number of sent Process Event documents from source
+  type: long
+Endpoint.metrics.documents_volume.process_events.sources.source:
+  dashed_name: Endpoint-metrics-documents-volume-process-events-sources-source
+  description: Process Event document source name
+  flat_name: Endpoint.metrics.documents_volume.process_events.sources.source
+  ignore_above: 1024
+  level: custom
+  name: metrics.documents_volume.process_events.sources.source
+  normalize: []
+  short: Process Event document source name
+  type: keyword
+Endpoint.metrics.documents_volume.process_events.sources.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-process-events-sources-suppressed-bytes
+  description: Total size of suppressed Process Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.process_events.sources.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.process_events.sources.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed Process Event documents from source
+  type: long
+Endpoint.metrics.documents_volume.process_events.sources.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-process-events-sources-suppressed-count
+  description: Number of suppressed Process Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.process_events.sources.suppressed_count
+  level: custom
+  name: metrics.documents_volume.process_events.sources.suppressed_count
+  normalize: []
+  short: Number of suppressed Process Event documents from source
+  type: long
 Endpoint.metrics.documents_volume.process_events.suppressed_bytes:
   dashed_name: Endpoint-metrics-documents-volume-process-events-suppressed-bytes
   description: Total size of suppressed documents
@@ -584,6 +639,61 @@ Endpoint.metrics.documents_volume.security_events.sent_count:
   name: metrics.documents_volume.security_events.sent_count
   normalize: []
   short: Number of sent documents
+  type: long
+Endpoint.metrics.documents_volume.security_events.sources:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sources
+  description: An array of Security Event document statistics per source
+  flat_name: Endpoint.metrics.documents_volume.security_events.sources
+  level: custom
+  name: metrics.documents_volume.security_events.sources
+  normalize: []
+  short: An array of Security Event document statistics per source
+  type: object
+Endpoint.metrics.documents_volume.security_events.sources.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sources-sent-bytes
+  description: Total size of Security Event sent documents from source
+  flat_name: Endpoint.metrics.documents_volume.security_events.sources.sent_bytes
+  level: custom
+  name: metrics.documents_volume.security_events.sources.sent_bytes
+  normalize: []
+  short: Total size of Security Event sent documents from source
+  type: long
+Endpoint.metrics.documents_volume.security_events.sources.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sources-sent-count
+  description: Number of sent Security Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.security_events.sources.sent_count
+  level: custom
+  name: metrics.documents_volume.security_events.sources.sent_count
+  normalize: []
+  short: Number of sent Security Event documents from source
+  type: long
+Endpoint.metrics.documents_volume.security_events.sources.source:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sources-source
+  description: Security Event document source name
+  flat_name: Endpoint.metrics.documents_volume.security_events.sources.source
+  ignore_above: 1024
+  level: custom
+  name: metrics.documents_volume.security_events.sources.source
+  normalize: []
+  short: Security Event document source name
+  type: keyword
+Endpoint.metrics.documents_volume.security_events.sources.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sources-suppressed-bytes
+  description: Total size of suppressed Security Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.security_events.sources.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.security_events.sources.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed Security Event documents from source
+  type: long
+Endpoint.metrics.documents_volume.security_events.sources.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sources-suppressed-count
+  description: Number of suppressed Security Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.security_events.sources.suppressed_count
+  level: custom
+  name: metrics.documents_volume.security_events.sources.suppressed_count
+  normalize: []
+  short: Number of suppressed Security Event documents from source
   type: long
 Endpoint.metrics.documents_volume.security_events.suppressed_bytes:
   dashed_name: Endpoint-metrics-documents-volume-security-events-suppressed-bytes


### PR DESCRIPTION
Adds the custom documentation entries the endpoint-dev EAF suite found missing when [endpoint-dev #20922](https://github.com/elastic/endpoint-dev/pull/20922) pinned this repo's `8.19` branch as the endpoint-package submodule (build: https://buildkite.com/elastic/endpoint-dev/builds/23075).

Cherry-picked from `main`, in original order:
1. f74d96a3 - Add security event metrics to custom documentation (#652)
2. fe393fa4 - Enhance process event metrics (#653)
3. 7d45502e - Add network.direction to docs (#659)
4. e745043e - Add kernel_process_events fields (#716)

Fixes EAF failures asserting missing custom documentation for:
- Endpoint.metrics.documents_volume.process_events.sources.{sent_bytes,sent_count,source,suppressed_bytes,suppressed_count}
- Endpoint.metrics.documents_volume.security_events.sources.{sent_bytes,sent_count,source,suppressed_bytes,suppressed_count}
- Endpoint.metrics.system_impact.kernel_process_events.{week_ms,week_idle_ms}
- network.direction (macos network connection attempted/disconnect doc)

Generated with Claude Code.

---

**Update:** Follow-up build [#23099](https://buildkite.com/elastic/endpoint-dev/builds/23099) (after the fixes above landed on this branch) flagged 3 more undocumented fields. Added:
5. 0068ff33 - Add process.Ext.trusted to custom docs for already-running process events (#697)
6. 89c1a228 - Add missing field in the ASM API events custom documentation (#726)
7. 332151dc - Fix Linux and macOS behavior alert custom doc for subtechnique fields (#740)

Fixes additional EAF failures for:
- process.Ext.trusted / process.Ext.trusted_descendant (windows_process_already_running.yaml)
- process.Ext.api.metadata.security_descriptor (windows_api_asm.yaml)
- threat.technique.subtechnique.{id,name,reference} (linux/macos_malicious_behavior_alert.yaml)

---

**Update 2 (mappings, not just docs):** review feedback on the endpoint-dev side pointed out that `Endpoint.metrics.documents_volume.{process,security}_events.sources.*` had only ever been added to `custom_documentation` - the fields were never defined in `custom_schemas`, so they are missing from the actual package mappings (the metrics index template is `dynamic: false`, so they are not indexed). This was true on `main` as well; fixed there by #762 and cherry-picked here (regeneration verified on this branch).

The other fields in this PR did not need mapping changes: `subtechnique.*`, `security_descriptor`, `Ext.trusted{,_descendant}`, and `network.direction` were already mapped on 8.19 (only the documentation lagged), and `kernel_process_events.*` lives under `system_impact` which is `enabled: false` (intentionally not indexed), matching main.