### PR TITLE
Add cross-cluster source to metadata_united transform for remote Elasticsearch output support

### DIFF
--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,6 +1,6 @@
 - version: "9.5.0-next"
   changes:
-    - description: TBD
+    - description: Add cross-cluster search source to the metadata_united transform for Elastic Defend remote Elasticsearch output support
       type: enhancement
       link: https://github.com/elastic/endpoint-package/pull/99999
 - version: "9.4.0"

--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -2,7 +2,7 @@
   changes:
     - description: Add cross-cluster search source to the metadata_united transform for Elastic Defend remote Elasticsearch output support
       type: enhancement
-      link: https://github.com/elastic/endpoint-package/pull/99999
+      link: https://github.com/elastic/endpoint-package/pull/756
 - version: "9.4.0"
   changes:
     - description: automatic troubleshooting endpoint context docs

--- a/package/endpoint/elasticsearch/transform/metadata_united/default.json
+++ b/package/endpoint/elasticsearch/transform/metadata_united/default.json
@@ -2,6 +2,7 @@
     "source": {
         "index": [
             "metrics-endpoint.metadata_current_default*",
+            "*:metrics-endpoint.metadata_current_default*",
             ".fleet-agents*"
         ]
     },


### PR DESCRIPTION
Unblocks https://github.com/elastic/kibana/pull/271559

Re-applies #747 (reverted in #749 after it broke Fleet's serverless package install). The Fleet-side fix that strips the `*:` source on serverless (https://github.com/elastic/kibana/pull/275649) is now merged, so this transform change is safe to ship again. The change is identical to #747.

## Change Summary

Adds a cross-cluster (`*:`) source to the `metadata_united` transform so it also reads `metrics-endpoint.metadata_current` from connected remote clusters:

```
"source": { "index": [
  "metrics-endpoint.metadata_current_default*",
  "*:metrics-endpoint.metadata_current_default*",
  ".fleet-agents*"
]}
```

When Elastic Defend agents ship to a **remote Elasticsearch output**, endpoint metadata lands on the remote (data) cluster while `.fleet-agents` stays on the managing cluster. With only the local current index in scope, the join produced agent-only documents and the Endpoint list came up empty. Reading the remote `metadata_current` over CCS lets the join run on the managing cluster and populates the united index.
