### PR TITLE
Backport subtechnique custom documentation to 9.4

### DIFF
--- a/custom_documentation/doc/endpoint/alerts/linux/linux_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/linux/linux_malicious_behavior_alert.md
@@ -111,6 +111,9 @@ This alert is generated when a Malicious Behavior alert occurs.
 | threat.technique.name |
 | threat.technique.reference |
 | threat.technique.subtechnique |
+| threat.technique.subtechnique.id |
+| threat.technique.subtechnique.name |
+| threat.technique.subtechnique.reference |
 | user.Ext.real.id |
 | user.Ext.real.name |
 | user.id |

--- a/custom_documentation/doc/endpoint/alerts/macos/macos_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/macos/macos_malicious_behavior_alert.md
@@ -98,6 +98,9 @@ This alert is generated when a Malicious Behavior alert occurs.
 | threat.technique.name |
 | threat.technique.reference |
 | threat.technique.subtechnique |
+| threat.technique.subtechnique.id |
+| threat.technique.subtechnique.name |
+| threat.technique.subtechnique.reference |
 | user.Ext.real.id |
 | user.Ext.real.name |
 | user.id |

--- a/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malicious_behavior_alert.yaml
@@ -116,6 +116,9 @@ fields:
   - threat.technique.name
   - threat.technique.reference
   - threat.technique.subtechnique
+  - threat.technique.subtechnique.id
+  - threat.technique.subtechnique.name
+  - threat.technique.subtechnique.reference
   - user.Ext.real.id
   - user.Ext.real.name
   - user.id

--- a/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malicious_behavior_alert.yaml
@@ -103,6 +103,9 @@ fields:
   - threat.technique.name
   - threat.technique.reference
   - threat.technique.subtechnique
+  - threat.technique.subtechnique.id
+  - threat.technique.subtechnique.name
+  - threat.technique.subtechnique.reference
   - user.Ext.real.id
   - user.Ext.real.name
   - user.id


### PR DESCRIPTION
Cherry-picks 332151dc ("Fix Linux and macOS behavior alert custom doc for subtechnique fields", #740) from `main` onto `9.4`.

The endpoint-dev EAF suite flagged `threat.technique.subtechnique.{id,name,reference}` as undocumented in `linux_malicious_behavior_alert.yaml` when [endpoint-dev #20924](https://github.com/elastic/endpoint-dev/pull/20924) pinned this repo's `9.4` branch as the endpoint-package submodule (build: https://buildkite.com/elastic/endpoint-dev/builds/23187). Same fix already backported to 8.19 (#754) and 9.3 (#755).

Complements #746, which fixes the other undocumented fields from that build (`process.ai_agent.*`).

Generated with Claude Code.