### PR TITLE
Add kernel module name and taint fields to load_module events

### DIFF
--- a/custom_documentation/doc/endpoint/process/linux/linux_process_load_module.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_load_module.md
@@ -65,6 +65,11 @@ This event is generated when when a process loads a kernel module.
 | orchestrator.resource.type |
 | process.Ext.ancestry |
 | process.Ext.command_line_truncated |
+| process.Ext.load_module.name |
+| process.Ext.load_module.src_version |
+| process.Ext.load_module.taint_flags |
+| process.Ext.load_module.taints |
+| process.Ext.load_module.version |
 | process.Ext.ptrace.addr |
 | process.Ext.ptrace.child_pid |
 | process.Ext.ptrace.data |

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_load_module.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_load_module.yaml
@@ -69,6 +69,11 @@ fields:
   - orchestrator.resource.type
   - process.Ext.ancestry
   - process.Ext.command_line_truncated
+  - process.Ext.load_module.name
+  - process.Ext.load_module.src_version
+  - process.Ext.load_module.taint_flags
+  - process.Ext.load_module.taints
+  - process.Ext.load_module.version
   - process.Ext.ptrace.addr
   - process.Ext.ptrace.child_pid
   - process.Ext.ptrace.data

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -197,6 +197,39 @@
       type: long
       description: ptrace data.
 
+    - name: Ext.load_module
+      level: custom
+      type: object
+      description: Object for kernel module load events.
+
+    - name: Ext.load_module.name
+      level: custom
+      type: keyword
+      example: "dummy"
+      description: Name of the kernel module.
+
+    - name: Ext.load_module.version
+      level: custom
+      type: keyword
+      description: Version of the kernel module, if the module declares one.
+
+    - name: Ext.load_module.src_version
+      level: custom
+      type: keyword
+      description: Source version checksum of the kernel module.
+
+    - name: Ext.load_module.taints
+      level: custom
+      type: long
+      example: "4096"
+      description: Bitmask of the taint flags this module sets on the kernel. Zero means the module does not taint the kernel.
+
+    - name: Ext.load_module.taint_flags
+      level: custom
+      type: keyword
+      example: "OE"
+      description: Kernel taint letters for this module, e.g. O for out-of-tree and E for unsigned. Only present when the module taints the kernel.
+
     - name: Ext.memfd
       level: custom
       type: object

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -175,6 +175,13 @@ fields:
               request: {}
               addr: {}
               data: {}
+          load_module:
+            fields:
+              name: {}
+              version: {}
+              src_version: {}
+              taints: {}
+              taint_flags: {}
           shmget:
             fields:
               key: {}

--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,5 +1,8 @@
 - version: "9.5.0-next"
   changes:
+    - description: Add kernel module name and taint fields to Linux load_module events
+      type: enhancement
+      link: https://github.com/elastic/endpoint-package/pull/761
     - description: Add cross-cluster search source to the metadata_united transform for Elastic Defend remote Elasticsearch output support
       type: enhancement
       link: https://github.com/elastic/endpoint-package/pull/756

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -902,6 +902,43 @@
       description: Process ID.
       example: 4242
       default_field: false
+    - name: Ext.load_module
+      level: custom
+      type: object
+      description: Object for kernel module load events.
+      default_field: false
+    - name: Ext.load_module.name
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Name of the kernel module.
+      example: dummy
+      default_field: false
+    - name: Ext.load_module.src_version
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Source version checksum of the kernel module.
+      default_field: false
+    - name: Ext.load_module.taint_flags
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Kernel taint letters for this module, e.g. O for out-of-tree and E for unsigned. Only present when the module taints the kernel.
+      example: OE
+      default_field: false
+    - name: Ext.load_module.taints
+      level: custom
+      type: long
+      description: Bitmask of the taint flags this module sets on the kernel. Zero means the module does not taint the kernel.
+      example: 4096
+      default_field: false
+    - name: Ext.load_module.version
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Version of the kernel module, if the module declares one.
+      default_field: false
     - name: Ext.memfd
       level: custom
       type: object

--- a/package/endpoint/data_stream/process/sample_event.json
+++ b/package/endpoint/data_stream/process/sample_event.json
@@ -138,6 +138,13 @@
             },
             "windows": {
                 "zone_identifier": 3
+            },
+            "load_module": {
+                "name": "dummy",
+                "version": "1.0",
+                "src_version": "541BA167DCA57C2B4F2D95D",
+                "taints": 12288,
+                "taint_flags": "OE"
             }
         },
         "parent": {

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2409,6 +2409,12 @@ sent by the endpoint.
 | process.Ext.effective_parent.executable | Executable name for the effective process. | keyword |
 | process.Ext.effective_parent.name | Process name for the effective process. | keyword |
 | process.Ext.effective_parent.pid | Process ID. | long |
+| process.Ext.load_module | Object for kernel module load events. | object |
+| process.Ext.load_module.name | Name of the kernel module. | keyword |
+| process.Ext.load_module.src_version | Source version checksum of the kernel module. | keyword |
+| process.Ext.load_module.taint_flags | Kernel taint letters for this module, e.g. O for out-of-tree and E for unsigned. Only present when the module taints the kernel. | keyword |
+| process.Ext.load_module.taints | Bitmask of the taint flags this module sets on the kernel. Zero means the module does not taint the kernel. | long |
+| process.Ext.load_module.version | Version of the kernel module, if the module declares one. | keyword |
 | process.Ext.memfd | Object for memfd events. | object |
 | process.Ext.memfd.flag_allow_seal | Allow sealing operations on this file. | boolean |
 | process.Ext.memfd.flag_cloexec | Sets the the close-on-exec flag on the new file descriptor. | boolean |

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1631,6 +1631,71 @@ process.Ext.effective_parent.pid:
   original_fieldset: Effective_process
   short: Process ID.
   type: long
+process.Ext.load_module:
+  dashed_name: process-Ext-load-module
+  description: Object for kernel module load events.
+  flat_name: process.Ext.load_module
+  level: custom
+  name: Ext.load_module
+  normalize: []
+  short: Object for kernel module load events.
+  type: object
+process.Ext.load_module.name:
+  dashed_name: process-Ext-load-module-name
+  description: Name of the kernel module.
+  example: dummy
+  flat_name: process.Ext.load_module.name
+  ignore_above: 1024
+  level: custom
+  name: Ext.load_module.name
+  normalize: []
+  short: Name of the kernel module.
+  type: keyword
+process.Ext.load_module.src_version:
+  dashed_name: process-Ext-load-module-src-version
+  description: Source version checksum of the kernel module.
+  flat_name: process.Ext.load_module.src_version
+  ignore_above: 1024
+  level: custom
+  name: Ext.load_module.src_version
+  normalize: []
+  short: Source version checksum of the kernel module.
+  type: keyword
+process.Ext.load_module.taint_flags:
+  dashed_name: process-Ext-load-module-taint-flags
+  description: Kernel taint letters for this module, e.g. O for out-of-tree and E
+    for unsigned. Only present when the module taints the kernel.
+  example: OE
+  flat_name: process.Ext.load_module.taint_flags
+  ignore_above: 1024
+  level: custom
+  name: Ext.load_module.taint_flags
+  normalize: []
+  short: Kernel taint letters for this module, e.g. O for out-of-tree and E for unsigned.
+    Only present when the module taints the kernel.
+  type: keyword
+process.Ext.load_module.taints:
+  dashed_name: process-Ext-load-module-taints
+  description: Bitmask of the taint flags this module sets on the kernel. Zero means
+    the module does not taint the kernel.
+  example: '4096'
+  flat_name: process.Ext.load_module.taints
+  level: custom
+  name: Ext.load_module.taints
+  normalize: []
+  short: Bitmask of the taint flags this module sets on the kernel. Zero means the
+    module does not taint the kernel.
+  type: long
+process.Ext.load_module.version:
+  dashed_name: process-Ext-load-module-version
+  description: Version of the kernel module, if the module declares one.
+  flat_name: process.Ext.load_module.version
+  ignore_above: 1024
+  level: custom
+  name: Ext.load_module.version
+  normalize: []
+  short: Version of the kernel module, if the module declares one.
+  type: keyword
 process.Ext.memfd:
   dashed_name: process-Ext-memfd
   description: Object for memfd events.


### PR DESCRIPTION
## Summary

Adds five new fields to Linux `load_module` process events:

| Field | Type | Description |
|---|---|---|
| `process.Ext.load_module.name` | keyword | Canonical kernel module name (`mod->name`) |
| `process.Ext.load_module.version` | keyword | Module version, if declared via `MODULE_VERSION()` |
| `process.Ext.load_module.src_version` | keyword | Module source version checksum |
| `process.Ext.load_module.taints` | long | Bitmask of taint flags the module sets on the kernel (0 = untainted) |
| `process.Ext.load_module.taint_flags` | keyword | Decoded kernel taint letters (e.g. `OE` = out-of-tree + unsigned); only present when nonzero |

Endpoint reads these from the kernel's `module_load` tracepoint (via quark's eBPF probes), giving visibility into which LKM was loaded and whether it tainted the kernel — useful for detecting out-of-tree/unsigned rootkit-style module loads.

Companion changes:
- quark: elastic/quark module-load-taints branch (adds `mod->taints` to the probe and `quark_module_load`)
- endpoint: endpoint-dev branch `nberlin/quark-module-load-taints` (plumbs the fields into ES documents; its EAF test `test_events_load_module` asserts them)

## What changed

- `custom_schemas/custom_process.yml` — field definitions
- `custom_subsets/elastic_endpoint/process/process.yaml` — subset entries
- `custom_documentation/src/.../linux_process_load_module.yaml` — document the new fields
- Regenerated: `package/endpoint/data_stream/process/fields/fields.yml`, `package/endpoint/docs/README.md`, `schemas/v1/process/process.yaml`, `custom_documentation/doc/.../linux_process_load_module.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)