### PR TITLE
[9.4] Add mappings for process and security event sources metrics

### DIFF
--- a/custom_schemas/custom_endpoint.yml
+++ b/custom_schemas/custom_endpoint.yml
@@ -570,6 +570,36 @@
       type: long
       description: Total size of suppressed documents
 
+    - name: metrics.documents_volume.process_events.sources
+      level: custom
+      type: object
+      description: An array of Process Event document statistics per source
+
+    - name: metrics.documents_volume.process_events.sources.source
+      level: custom
+      type: keyword
+      description: Process Event document source name
+
+    - name: metrics.documents_volume.process_events.sources.sent_count
+      level: custom
+      type: long
+      description: Number of sent Process Event documents from source
+
+    - name: metrics.documents_volume.process_events.sources.sent_bytes
+      level: custom
+      type: long
+      description: Total size of Process Event sent documents from source
+
+    - name: metrics.documents_volume.process_events.sources.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed Process Event documents from source
+
+    - name: metrics.documents_volume.process_events.sources.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed Process Event documents from source
+
     - name: metrics.documents_volume.library_events.sent_count
       level: custom
       type: long
@@ -609,6 +639,36 @@
       level: custom
       type: long
       description: Total size of suppressed documents
+
+    - name: metrics.documents_volume.security_events.sources
+      level: custom
+      type: object
+      description: An array of Security Event document statistics per source
+
+    - name: metrics.documents_volume.security_events.sources.source
+      level: custom
+      type: keyword
+      description: Security Event document source name
+
+    - name: metrics.documents_volume.security_events.sources.sent_count
+      level: custom
+      type: long
+      description: Number of sent Security Event documents from source
+
+    - name: metrics.documents_volume.security_events.sources.sent_bytes
+      level: custom
+      type: long
+      description: Total size of Security Event sent documents from source
+
+    - name: metrics.documents_volume.security_events.sources.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed Security Event documents from source
+
+    - name: metrics.documents_volume.security_events.sources.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed Security Event documents from source
 
     - name: metrics.documents_volume.dns_events.sent_count
       level: custom

--- a/package/endpoint/data_stream/metrics/fields/fields.yml
+++ b/package/endpoint/data_stream/metrics/fields/fields.yml
@@ -303,6 +303,37 @@
       type: long
       description: Number of sent documents
       default_field: false
+    - name: metrics.documents_volume.process_events.sources
+      level: custom
+      type: object
+      description: An array of Process Event document statistics per source
+      default_field: false
+    - name: metrics.documents_volume.process_events.sources.sent_bytes
+      level: custom
+      type: long
+      description: Total size of Process Event sent documents from source
+      default_field: false
+    - name: metrics.documents_volume.process_events.sources.sent_count
+      level: custom
+      type: long
+      description: Number of sent Process Event documents from source
+      default_field: false
+    - name: metrics.documents_volume.process_events.sources.source
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Process Event document source name
+      default_field: false
+    - name: metrics.documents_volume.process_events.sources.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed Process Event documents from source
+      default_field: false
+    - name: metrics.documents_volume.process_events.sources.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed Process Event documents from source
+      default_field: false
     - name: metrics.documents_volume.process_events.suppressed_bytes
       level: custom
       type: long
@@ -342,6 +373,37 @@
       level: custom
       type: long
       description: Number of sent documents
+      default_field: false
+    - name: metrics.documents_volume.security_events.sources
+      level: custom
+      type: object
+      description: An array of Security Event document statistics per source
+      default_field: false
+    - name: metrics.documents_volume.security_events.sources.sent_bytes
+      level: custom
+      type: long
+      description: Total size of Security Event sent documents from source
+      default_field: false
+    - name: metrics.documents_volume.security_events.sources.sent_count
+      level: custom
+      type: long
+      description: Number of sent Security Event documents from source
+      default_field: false
+    - name: metrics.documents_volume.security_events.sources.source
+      level: custom
+      type: keyword
+      ignore_above: 1024
+      description: Security Event document source name
+      default_field: false
+    - name: metrics.documents_volume.security_events.sources.suppressed_bytes
+      level: custom
+      type: long
+      description: Total size of suppressed Security Event documents from source
+      default_field: false
+    - name: metrics.documents_volume.security_events.sources.suppressed_count
+      level: custom
+      type: long
+      description: Number of suppressed Security Event documents from source
       default_field: false
     - name: metrics.documents_volume.security_events.suppressed_bytes
       level: custom

--- a/package/endpoint/data_stream/metrics/sample_event.json
+++ b/package/endpoint/data_stream/metrics/sample_event.json
@@ -664,7 +664,16 @@
                     "suppressed_count": 0,
                     "suppressed_bytes": 0,
                     "sent_count": 259,
-                    "sent_bytes": 422247
+                    "sent_bytes": 422247,
+                    "sources": [
+                        {
+                            "source": "diagnostic_4624",
+                            "sent_count": 4,
+                            "sent_bytes": 10240,
+                            "suppressed_count": 0,
+                            "suppressed_bytes": 0
+                        }
+                    ]
                 },
                 "library_events": {
                     "suppressed_count": 0,
@@ -676,7 +685,16 @@
                     "suppressed_count": 0,
                     "suppressed_bytes": 0,
                     "sent_count": 201,
-                    "sent_bytes": 602914
+                    "sent_bytes": 602914,
+                    "sources": [
+                        {
+                            "source": "load_module",
+                            "sent_count": 2,
+                            "sent_bytes": 5000,
+                            "suppressed_count": 1,
+                            "suppressed_bytes": 2500
+                        }
+                    ]
                 },
                 "registry_events": {
                     "suppressed_count": 0,

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -3214,6 +3214,12 @@ Metrics documents contain performance information about the endpoint executable 
 | Endpoint.metrics.documents_volume.overall.suppressed_count | Number of suppressed documents | long |
 | Endpoint.metrics.documents_volume.process_events.sent_bytes | Total size of sent documents | long |
 | Endpoint.metrics.documents_volume.process_events.sent_count | Number of sent documents | long |
+| Endpoint.metrics.documents_volume.process_events.sources | An array of Process Event document statistics per source | object |
+| Endpoint.metrics.documents_volume.process_events.sources.sent_bytes | Total size of Process Event sent documents from source | long |
+| Endpoint.metrics.documents_volume.process_events.sources.sent_count | Number of sent Process Event documents from source | long |
+| Endpoint.metrics.documents_volume.process_events.sources.source | Process Event document source name | keyword |
+| Endpoint.metrics.documents_volume.process_events.sources.suppressed_bytes | Total size of suppressed Process Event documents from source | long |
+| Endpoint.metrics.documents_volume.process_events.sources.suppressed_count | Number of suppressed Process Event documents from source | long |
 | Endpoint.metrics.documents_volume.process_events.suppressed_bytes | Total size of suppressed documents | long |
 | Endpoint.metrics.documents_volume.process_events.suppressed_count | Number of suppressed documents | long |
 | Endpoint.metrics.documents_volume.registry_events.sent_bytes | Total size of sent documents | long |
@@ -3222,6 +3228,12 @@ Metrics documents contain performance information about the endpoint executable 
 | Endpoint.metrics.documents_volume.registry_events.suppressed_count | Number of suppressed documents | long |
 | Endpoint.metrics.documents_volume.security_events.sent_bytes | Total size of sent documents | long |
 | Endpoint.metrics.documents_volume.security_events.sent_count | Number of sent documents | long |
+| Endpoint.metrics.documents_volume.security_events.sources | An array of Security Event document statistics per source | object |
+| Endpoint.metrics.documents_volume.security_events.sources.sent_bytes | Total size of Security Event sent documents from source | long |
+| Endpoint.metrics.documents_volume.security_events.sources.sent_count | Number of sent Security Event documents from source | long |
+| Endpoint.metrics.documents_volume.security_events.sources.source | Security Event document source name | keyword |
+| Endpoint.metrics.documents_volume.security_events.sources.suppressed_bytes | Total size of suppressed Security Event documents from source | long |
+| Endpoint.metrics.documents_volume.security_events.sources.suppressed_count | Number of suppressed Security Event documents from source | long |
 | Endpoint.metrics.documents_volume.security_events.suppressed_bytes | Total size of suppressed documents | long |
 | Endpoint.metrics.documents_volume.security_events.suppressed_count | Number of suppressed documents | long |
 | Endpoint.metrics.event_filter.active_global_count | The number of active global event filters | long |

--- a/schemas/v1/metrics/metrics.yaml
+++ b/schemas/v1/metrics/metrics.yaml
@@ -513,6 +513,61 @@ Endpoint.metrics.documents_volume.process_events.sent_count:
   normalize: []
   short: Number of sent documents
   type: long
+Endpoint.metrics.documents_volume.process_events.sources:
+  dashed_name: Endpoint-metrics-documents-volume-process-events-sources
+  description: An array of Process Event document statistics per source
+  flat_name: Endpoint.metrics.documents_volume.process_events.sources
+  level: custom
+  name: metrics.documents_volume.process_events.sources
+  normalize: []
+  short: An array of Process Event document statistics per source
+  type: object
+Endpoint.metrics.documents_volume.process_events.sources.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-process-events-sources-sent-bytes
+  description: Total size of Process Event sent documents from source
+  flat_name: Endpoint.metrics.documents_volume.process_events.sources.sent_bytes
+  level: custom
+  name: metrics.documents_volume.process_events.sources.sent_bytes
+  normalize: []
+  short: Total size of Process Event sent documents from source
+  type: long
+Endpoint.metrics.documents_volume.process_events.sources.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-process-events-sources-sent-count
+  description: Number of sent Process Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.process_events.sources.sent_count
+  level: custom
+  name: metrics.documents_volume.process_events.sources.sent_count
+  normalize: []
+  short: Number of sent Process Event documents from source
+  type: long
+Endpoint.metrics.documents_volume.process_events.sources.source:
+  dashed_name: Endpoint-metrics-documents-volume-process-events-sources-source
+  description: Process Event document source name
+  flat_name: Endpoint.metrics.documents_volume.process_events.sources.source
+  ignore_above: 1024
+  level: custom
+  name: metrics.documents_volume.process_events.sources.source
+  normalize: []
+  short: Process Event document source name
+  type: keyword
+Endpoint.metrics.documents_volume.process_events.sources.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-process-events-sources-suppressed-bytes
+  description: Total size of suppressed Process Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.process_events.sources.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.process_events.sources.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed Process Event documents from source
+  type: long
+Endpoint.metrics.documents_volume.process_events.sources.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-process-events-sources-suppressed-count
+  description: Number of suppressed Process Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.process_events.sources.suppressed_count
+  level: custom
+  name: metrics.documents_volume.process_events.sources.suppressed_count
+  normalize: []
+  short: Number of suppressed Process Event documents from source
+  type: long
 Endpoint.metrics.documents_volume.process_events.suppressed_bytes:
   dashed_name: Endpoint-metrics-documents-volume-process-events-suppressed-bytes
   description: Total size of suppressed documents
@@ -584,6 +639,61 @@ Endpoint.metrics.documents_volume.security_events.sent_count:
   name: metrics.documents_volume.security_events.sent_count
   normalize: []
   short: Number of sent documents
+  type: long
+Endpoint.metrics.documents_volume.security_events.sources:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sources
+  description: An array of Security Event document statistics per source
+  flat_name: Endpoint.metrics.documents_volume.security_events.sources
+  level: custom
+  name: metrics.documents_volume.security_events.sources
+  normalize: []
+  short: An array of Security Event document statistics per source
+  type: object
+Endpoint.metrics.documents_volume.security_events.sources.sent_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sources-sent-bytes
+  description: Total size of Security Event sent documents from source
+  flat_name: Endpoint.metrics.documents_volume.security_events.sources.sent_bytes
+  level: custom
+  name: metrics.documents_volume.security_events.sources.sent_bytes
+  normalize: []
+  short: Total size of Security Event sent documents from source
+  type: long
+Endpoint.metrics.documents_volume.security_events.sources.sent_count:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sources-sent-count
+  description: Number of sent Security Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.security_events.sources.sent_count
+  level: custom
+  name: metrics.documents_volume.security_events.sources.sent_count
+  normalize: []
+  short: Number of sent Security Event documents from source
+  type: long
+Endpoint.metrics.documents_volume.security_events.sources.source:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sources-source
+  description: Security Event document source name
+  flat_name: Endpoint.metrics.documents_volume.security_events.sources.source
+  ignore_above: 1024
+  level: custom
+  name: metrics.documents_volume.security_events.sources.source
+  normalize: []
+  short: Security Event document source name
+  type: keyword
+Endpoint.metrics.documents_volume.security_events.sources.suppressed_bytes:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sources-suppressed-bytes
+  description: Total size of suppressed Security Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.security_events.sources.suppressed_bytes
+  level: custom
+  name: metrics.documents_volume.security_events.sources.suppressed_bytes
+  normalize: []
+  short: Total size of suppressed Security Event documents from source
+  type: long
+Endpoint.metrics.documents_volume.security_events.sources.suppressed_count:
+  dashed_name: Endpoint-metrics-documents-volume-security-events-sources-suppressed-count
+  description: Number of suppressed Security Event documents from source
+  flat_name: Endpoint.metrics.documents_volume.security_events.sources.suppressed_count
+  level: custom
+  name: metrics.documents_volume.security_events.sources.suppressed_count
+  normalize: []
+  short: Number of suppressed Security Event documents from source
   type: long
 Endpoint.metrics.documents_volume.security_events.suppressed_bytes:
   dashed_name: Endpoint-metrics-documents-volume-security-events-suppressed-bytes


### PR DESCRIPTION
Backport of #762 to `9.4` (clean cherry-pick, regeneration verified per-branch).

`Endpoint.metrics.documents_volume.{process,security}_events.sources.*` only ever existed in `custom_documentation` - the fields were never defined in `custom_schemas`, so they are missing from the package mappings. With `dynamic: false` on the metrics index template, endpoint sends these fields but they are not indexed.

Should merge after (or together with) #762.

Related: elastic/endpoint-dev#20924.

Generated with Claude Code.