### PR TITLE
[8.19] Backport keyword type for winlog KeyLength, Flags, CountOfCredentialsReturned

### DIFF
--- a/custom_schemas/custom_winlog.yml
+++ b/custom_schemas/custom_winlog.yml
@@ -113,7 +113,7 @@
 
     - name: event_data.KeyLength
       level: custom
-      type : unsigned_long
+      type : keyword
       description: >
         The length of the NTLM Session Security key. 
 
@@ -320,16 +320,16 @@
 
     - name: event_data.Flags
       level: custom
-      type : unsigned_long
+      type : keyword
       description: >
         Flags.
 
     - name: event_data.CountOfCredentialsReturned
       level: custom
-      type : unsigned_long
+      type : keyword
       description: >
         Credential returned count.
-      example: 0
+      example: "0"
 
     - name: event_data.SchemaFriendlyName
       level: custom

--- a/package/endpoint/data_stream/security/fields/fields.yml
+++ b/package/endpoint/data_stream/security/fields/fields.yml
@@ -1355,9 +1355,10 @@
       default_field: false
     - name: event_data.CountOfCredentialsReturned
       level: custom
-      type: unsigned_long
+      type: keyword
+      ignore_above: 1024
       description: Credential returned count.
-      example: 0
+      example: '0'
       default_field: false
     - name: event_data.DisplayName
       level: custom

--- a/package/endpoint/data_stream/security/sample_event.json
+++ b/package/endpoint/data_stream/security/sample_event.json
@@ -219,7 +219,7 @@
             "DisplayName": "test_data",
             "UserPrincipalName": "test_data",
             "PrimaryGroupId": "513",
-            "CountOfCredentialsReturned": 0,
+            "CountOfCredentialsReturned": "0",
             "SchemaFriendlyName": "Windows Domain Password Credential",
             "Resource": "Domain:target=TestTarget",
             "Identity": "TestUser",

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2843,7 +2843,7 @@ sent by the endpoint.
 | user.name | Short name or login of the user. | keyword |
 | winlog.event_data | The event-specific data. This is a non-exhaustive list of parameters that are used in Windows events. | object |
 | winlog.event_data.AccessReason | The list of access check results. | keyword |
-| winlog.event_data.CountOfCredentialsReturned | Credential returned count. | unsigned_long |
+| winlog.event_data.CountOfCredentialsReturned | Credential returned count. | keyword |
 | winlog.event_data.DisplayName | A name displayed in the address book for a particular account. | keyword |
 | winlog.event_data.EnabledPrivilegeList | The list of enabled user rights. | keyword |
 | winlog.event_data.Identity | Identity information. | keyword |

--- a/schemas/v1/security/security.yaml
+++ b/schemas/v1/security/security.yaml
@@ -2612,13 +2612,13 @@ winlog.event_data.AccessReason:
 winlog.event_data.CountOfCredentialsReturned:
   dashed_name: winlog-event-data-CountOfCredentialsReturned
   description: Credential returned count.
-  example: 0
+  example: '0'
   flat_name: winlog.event_data.CountOfCredentialsReturned
   level: custom
   name: event_data.CountOfCredentialsReturned
   normalize: []
   short: Credential returned count.
-  type: unsigned_long
+  type: keyword
 winlog.event_data.DisplayName:
   dashed_name: winlog-event-data-DisplayName
   description: A name displayed in the address book for a particular account.


### PR DESCRIPTION
Cherry-picks bed057b1 (#715, "CountOfCredentialsReturned: unify data type between endpoint and winlog beat") from `main` onto `8.19`. Regeneration verified on this branch.

Context: prompted by an SDH (elastic/sdh-beats#6709), #715 changed `winlog.event_data.{KeyLength, Flags, CountOfCredentialsReturned}` from `unsigned_long` to `keyword` to match the System integration's mappings, but it was never backported to release branches - and these Security Event fields have shipped since 8.19. Raised by @AsuNa-jp on [elastic/endpoint-dev#20922](https://github.com/elastic/endpoint-dev/pull/20922#issuecomment).

Pairs with an endpoint-dev 8.19 backport of [elastic/endpoint-dev#18158](https://github.com/elastic/endpoint-dev/pull/18158) (code change to emit these values as strings) - the two should land together.

Generated with Claude Code.