### PR TITLE
Add process.ai_agent fields to macOS process event custom documentation

### DIFF
--- a/custom_documentation/doc/endpoint/process/macos/macos_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_already_running.md
@@ -50,6 +50,8 @@ This event is generated for a process that was already running before Endpoint's
 | process.Ext.ancestry |
 | process.Ext.command_line_truncated |
 | process.Ext.effective_parent.pid |
+| process.ai_agent.is_descendant |
+| process.ai_agent.name |
 | process.args |
 | process.args_count |
 | process.code_signature.exists |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_fork_exec_exit.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_fork_exec_exit.md
@@ -61,6 +61,8 @@ This event is generated when a process calls `fork()`, `exec()`, or exits.
 | process.Ext.script.path |
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
+| process.ai_agent.is_descendant |
+| process.ai_agent.name |
 | process.args |
 | process.args_count |
 | process.code_signature.exists |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_remote_thread.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_remote_thread.md
@@ -56,6 +56,8 @@ This event is generated when a remote thread is created.
 | process.Ext.command_line_truncated |
 | process.Ext.effective_parent.pid |
 | process.Ext.trusted |
+| process.ai_agent.is_descendant |
+| process.ai_agent.name |
 | process.args |
 | process.args_count |
 | process.code_signature.exists |

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_already_running.yaml
@@ -56,6 +56,8 @@ fields:
   - process.Ext.ancestry
   - process.Ext.command_line_truncated
   - process.Ext.effective_parent.pid
+  - process.ai_agent.is_descendant
+  - process.ai_agent.name
   - process.args
   - process.args_count
   - process.code_signature.exists

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork_exec_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork_exec_exit.yaml
@@ -70,6 +70,8 @@ fields:
   - process.Ext.script.path
   - process.Ext.trusted
   - process.Ext.trusted_descendant
+  - process.ai_agent.is_descendant
+  - process.ai_agent.name
   - process.args
   - process.args_count
   - process.code_signature.exists

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_remote_thread.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_remote_thread.yaml
@@ -61,6 +61,8 @@ fields:
   - process.Ext.command_line_truncated
   - process.Ext.effective_parent.pid
   - process.Ext.trusted
+  - process.ai_agent.is_descendant
+  - process.ai_agent.name
   - process.args
   - process.args_count
   - process.code_signature.exists


### PR DESCRIPTION
## Change Summary

Documents `process.ai_agent.name` and `process.ai_agent.is_descendant` on macOS process events (`fork_exec_exit`, `already_running`, `remote_thread`), companion to the macOS GenAI process observability feature in endpoint-dev (branch `mst/macos-genai-fields`).

This is a docs-only change: the field schemas and mappings were already merged in #752 / #760 (OS-agnostic). 

Markdown pages rendered via `go run ./scripts/generate-docs`; YAML field lists are in the sorted order enforced by `UpdateEndpointPackageDocumentation.py`.

### Sample values

```json
{
  "process": {
    "ai_agent": {
      "name": "claude_code",
      "is_descendant": true
    }
  }
}
```

## Release Target

9.6.0

## Q/A

### For mapping changes:

Not a mapping change — custom documentation only. Mappings for these fields were merged in #752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)