### PR TITLE
sets example value for kernel taints as a number not string

### DIFF
--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -221,7 +221,7 @@
     - name: Ext.load_module.taints
       level: custom
       type: long
-      example: "4096"
+      example: 4096
       description: Bitmask of the taint flags this module sets on the kernel. Zero means the module does not taint the kernel.
 
     - name: Ext.load_module.taint_flags

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -1678,7 +1678,7 @@ process.Ext.load_module.taints:
   dashed_name: process-Ext-load-module-taints
   description: Bitmask of the taint flags this module sets on the kernel. Zero means
     the module does not taint the kernel.
-  example: '4096'
+  example: 4096
   flat_name: process.Ext.load_module.taints
   level: custom
   name: Ext.load_module.taints


### PR DESCRIPTION
## Change Summary

process field `Ext.load_module.taints` is type `long`. The example value was set as a quoted-string number. This removes the quotes.

(This was causing issues with formatting, where the generated file `package/endpoint/data_stream/process/fields/fields.yml` contained the unquoted numerical value, and new runs of `make` would put back quotes on unrelated PR builds)


## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
