### PR TITLE
[9.4] Add host.domain to endpoint documentation

### DIFF
--- a/custom_documentation/doc/endpoint/alerts/linux/linux_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/linux/linux_malicious_behavior_alert.md
@@ -75,6 +75,7 @@ This alert is generated when a Malicious Behavior alert occurs.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/alerts/linux/linux_malware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/linux/linux_malware_alert.md
@@ -79,6 +79,7 @@ This alert is generated when a Malware alert occurs.
 | file.path |
 | file.size |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/alerts/linux/linux_memory_threat_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/linux/linux_memory_threat_alert.md
@@ -46,6 +46,7 @@ This alert is generated when a Memory Threat alert occurs.
 | event.severity |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/alerts/linux/linux_ransomware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/linux/linux_ransomware_alert.md
@@ -77,6 +77,7 @@ This alert is generated when a Ransomware alert occurs.
 | event.severity |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/alerts/macos/macos_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/macos/macos_malicious_behavior_alert.md
@@ -69,6 +69,7 @@ This alert is generated when a Malicious Behavior alert occurs.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/alerts/macos/macos_malware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/macos/macos_malware_alert.md
@@ -84,6 +84,7 @@ This alert is generated when a macOS Malware alert occurs.
 | file.path |
 | file.size |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/alerts/macos/macos_memory_threat_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/macos/macos_memory_threat_alert.md
@@ -46,6 +46,7 @@ This alert is generated when a macOS Memory Thread alert occurs.
 | event.severity |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/alerts/macos/macos_ransomware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/macos/macos_ransomware_alert.md
@@ -77,6 +77,7 @@ This alert is generated when a Ransomware alert occurs.
 | event.severity |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/alerts/windows/windows_malicious_behavior_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_malicious_behavior_alert.md
@@ -75,6 +75,7 @@ This alert occurs when a Malicious Behavior alert occurs.
 | event.type |
 | file.*<br /><br />file contains the file data from the primary event in Events. It can contain any fields that any other events includes within the file fieldset. |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/alerts/windows/windows_malware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_malware_alert.md
@@ -123,6 +123,7 @@ This alert is generated when a Malware alert occurs.
 | file.pe.product |
 | file.size |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/alerts/windows/windows_memory_threat_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_memory_threat_alert.md
@@ -46,6 +46,7 @@ This alert is generated when a Memory Threat alert occurs.
 | event.severity |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/alerts/windows/windows_ransomware_alert.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_ransomware_alert.md
@@ -78,6 +78,7 @@ This alert is generated when a Ransomware alert occurs.
 | event.severity |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/alerts/windows/windows_shellcode_thread.md
+++ b/custom_documentation/doc/endpoint/alerts/windows/windows_shellcode_thread.md
@@ -167,6 +167,7 @@ This alert is generated when a Shellcode Threat alert occurs.
 | event.severity |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_amsi.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_amsi.md
@@ -28,6 +28,7 @@ This event is generated when Antimalware Scan Interface (AMSI) APIs are called.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_asm.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_asm.md
@@ -35,6 +35,7 @@ This event is generated when ETW AttackSurfaceMonitor events are generated.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_credential_access.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_credential_access.md
@@ -31,6 +31,7 @@ This event is generated when a process attempts to access priviledged credential
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_firewall_anti_tamper.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_firewall_anti_tamper.md
@@ -28,6 +28,7 @@ This event is generated when firewall tampering is detected.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_kernel_audit.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_kernel_audit.md
@@ -35,6 +35,7 @@ This event is generated when ETW Microsoft-Windows-Kernel-Audit-API-Calls events
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_ldap_client.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_ldap_client.md
@@ -28,6 +28,7 @@ This event is generated when LDAP-Client related APIs are called.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_tcpip.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_tcpip.md
@@ -30,6 +30,7 @@ This event is generated when ETW Microsoft-Windows-TCPIP events are generated.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_threat_intelligence.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_threat_intelligence.md
@@ -38,6 +38,7 @@ This event is generated when ETW Threat-Intelligence events are generated.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_win32k.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_win32k.md
@@ -32,6 +32,7 @@ This event is generated when keylogging-related Win32k APIs are called.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_winhttp.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_winhttp.md
@@ -28,6 +28,7 @@ This event is generated when ETW Microsoft-Windows-WebIO events are generated.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_wininet.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_wininet.md
@@ -28,6 +28,7 @@ This event is generated when ETW Microsoft-Windows-WinINet events are generated.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/api/windows/windows_api_wmi.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_wmi.md
@@ -31,6 +31,7 @@ This event is generated when WMI Activity-related APIs are called.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
@@ -40,6 +40,7 @@ This event is generated when a file is created.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_delete.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_delete.md
@@ -38,6 +38,7 @@ This event is generated when a file is deleted.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_endpoint_unquarantine.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_endpoint_unquarantine.md
@@ -36,6 +36,7 @@ This event is generated when Endpoint restores a file from the malware quarantin
 | file.name |
 | file.path |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_rename.md
@@ -43,6 +43,7 @@ This event is generated when a file is renamed.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_access.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_access.md
@@ -42,6 +42,7 @@ This event is generated when a file is accessed.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_delete.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_delete.md
@@ -42,6 +42,7 @@ This event is generated when a file is deleted.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_endpoint_unquarantine.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_endpoint_unquarantine.md
@@ -36,6 +36,7 @@ This event is generated when Endpoint restores a file from the malware quarantin
 | file.name |
 | file.path |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_extended_attributes_delete.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_extended_attributes_delete.md
@@ -43,6 +43,7 @@ This event is generated when extended file attributes are deleted.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_launch_daemon.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_launch_daemon.md
@@ -42,6 +42,7 @@ This event includes information about a macOS Launch Daemon.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_modification.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_modification.md
@@ -47,6 +47,7 @@ This event is generated when a file is modified.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_mount.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_mount.md
@@ -40,6 +40,7 @@ This event is generated when a file system is mounted.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/macos/macos_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/macos/macos_file_rename.md
@@ -45,6 +45,7 @@ This event is generated when a file is renamed.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_create.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_create.md
@@ -44,6 +44,7 @@ This event is generated when a file is created.
 | file.path |
 | file.size |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_delete.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_delete.md
@@ -39,6 +39,7 @@ This event is generated when a file is deleted.
 | file.path |
 | file.size |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_endpoint_unquarantine.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_endpoint_unquarantine.md
@@ -36,6 +36,7 @@ This event is generated when Endpoint restores a file from the malware quarantin
 | file.name |
 | file.path |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_modification.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_modification.md
@@ -41,6 +41,7 @@ This event is generated when a file is modified.
 | file.path |
 | file.size |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_open.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_open.md
@@ -41,6 +41,7 @@ This event is generated when a file is opened.
 | file.path |
 | file.size |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_overwrite.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_overwrite.md
@@ -41,6 +41,7 @@ This event is generated when a file is overwritten
 | file.path |
 | file.size |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/file/windows/windows_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/windows/windows_file_rename.md
@@ -44,6 +44,7 @@ This event is generated when a file is renamed.
 | file.path |
 | file.size |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/library/macos/macos_library_load.md
+++ b/custom_documentation/doc/endpoint/library/macos/macos_library_load.md
@@ -47,6 +47,7 @@ This event is generated when a dynlib is loaded.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/library/windows/windows_library_load.md
+++ b/custom_documentation/doc/endpoint/library/windows/windows_library_load.md
@@ -55,6 +55,7 @@ This event is generated when a DLL or driver is loaded.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/metadata/metadata.md
+++ b/custom_documentation/doc/endpoint/metadata/metadata.md
@@ -40,6 +40,7 @@ This is a relatively small state management document that includes details about
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/metrics/metrics.md
+++ b/custom_documentation/doc/endpoint/metrics/metrics.md
@@ -210,6 +210,7 @@ This is an internal state management document that includes metrics on Endpoint'
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/network/linux/linux_network_attempted_accepted_and_disconnect.md
+++ b/custom_documentation/doc/endpoint/network/linux/linux_network_attempted_accepted_and_disconnect.md
@@ -37,6 +37,7 @@ This event is generated when a network session is accepted, attempted or termina
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/network/macos/macos_network_connection_attempted_and_disconnect.md
+++ b/custom_documentation/doc/endpoint/network/macos/macos_network_connection_attempted_and_disconnect.md
@@ -38,6 +38,7 @@ This event is generated when a connection is attempted or a request to terminate
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/network/macos/macos_network_dns_lookup_result.md
+++ b/custom_documentation/doc/endpoint/network/macos/macos_network_dns_lookup_result.md
@@ -41,6 +41,7 @@ This event is generated when results are returned for a DNS lookup request.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/network/windows/windows_network_attempted_accepted_and_disconnect.md
+++ b/custom_documentation/doc/endpoint/network/windows/windows_network_attempted_accepted_and_disconnect.md
@@ -33,6 +33,7 @@ This event is generated when a connection is attempted, a connection is accepted
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/network/windows/windows_network_dns_lookup_requested.md
+++ b/custom_documentation/doc/endpoint/network/windows/windows_network_dns_lookup_requested.md
@@ -33,6 +33,7 @@ This event is generated when a DNS lookup request is initiated.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/network/windows/windows_network_dns_lookup_result.md
+++ b/custom_documentation/doc/endpoint/network/windows/windows_network_dns_lookup_result.md
@@ -34,6 +34,7 @@ This event is generated when results are returned for a DNS lookup request.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/policy/policy_response.md
+++ b/custom_documentation/doc/endpoint/policy/policy_response.md
@@ -88,6 +88,7 @@ This is a state management document that is generated every time Endpoint refres
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_already_running.md
@@ -43,6 +43,7 @@ This event is generated for a process that was already running before Endpoint's
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_fork_exec_exit.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_fork_exec_exit.md
@@ -43,6 +43,7 @@ This event is generated when a process calls `fork()`, `exec()`, exits, or an ag
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_gid_change.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_gid_change.md
@@ -43,6 +43,7 @@ This event is generated when the group id changes for a process.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_load_module.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_load_module.md
@@ -42,6 +42,7 @@ This event is generated when when a process loads a kernel module.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_memfd_create.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_memfd_create.md
@@ -42,6 +42,7 @@ This event is generated when when a memfd anonymous file is created.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_ptrace.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_ptrace.md
@@ -42,6 +42,7 @@ This event is generated when when a process calls ptrace_attach on another proce
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_session_id_change.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_session_id_change.md
@@ -43,6 +43,7 @@ This event is generated when a process's session id changes.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_shmget.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_shmget.md
@@ -42,6 +42,7 @@ This event is generated when when a process calls shmget().
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_text_output.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_text_output.md
@@ -42,6 +42,7 @@ This event is generated when a process generates text output.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_uid_change.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_uid_change.md
@@ -42,6 +42,7 @@ This event is generated when the user id changes for a process.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_already_running.md
@@ -33,6 +33,7 @@ This event is generated for a process that was already running before Endpoint's
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_fork_exec_exit.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_fork_exec_exit.md
@@ -37,6 +37,7 @@ This event is generated when a process calls `fork()`, `exec()`, or exits.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_remote_thread.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_remote_thread.md
@@ -38,6 +38,7 @@ This event is generated when a remote thread is created.
 | group.id |
 | group.name |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
@@ -29,6 +29,7 @@ This event is generated for a process that was already running before Endpoint's
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_create_and_exit.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_create_and_exit.md
@@ -29,6 +29,7 @@ This event is generated when a process is created or exits.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/registry/windows/windows_registry_modification.md
+++ b/custom_documentation/doc/endpoint/registry/windows/windows_registry_modification.md
@@ -33,6 +33,7 @@ This event is generated when the registry is modified.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/registry/windows/windows_registry_query.md
+++ b/custom_documentation/doc/endpoint/registry/windows/windows_registry_query.md
@@ -33,6 +33,7 @@ This event is generated when the Windows registry is queried.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/security/macos/macos_security_gatekeeper_override.md
+++ b/custom_documentation/doc/endpoint/security/macos/macos_security_gatekeeper_override.md
@@ -34,6 +34,7 @@ This event is generated when a user grants a gatekeeper exception
 | file.code_signature.team_id |
 | file.path |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/security/macos/macos_security_log_on.md
+++ b/custom_documentation/doc/endpoint/security/macos/macos_security_log_on.md
@@ -31,6 +31,7 @@ This event is generated when a user logs on to the computer.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/security/macos/macos_security_rdp_log_on.md
+++ b/custom_documentation/doc/endpoint/security/macos/macos_security_rdp_log_on.md
@@ -31,6 +31,7 @@ This event is generated when a user logs on to the computer with screensharing.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/security/macos/macos_security_ssh_log_on.md
+++ b/custom_documentation/doc/endpoint/security/macos/macos_security_ssh_log_on.md
@@ -31,6 +31,7 @@ This event is generated when a user logs on to the computer with SSH.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/security/macos/macos_security_tcc_modify.md
+++ b/custom_documentation/doc/endpoint/security/macos/macos_security_tcc_modify.md
@@ -49,6 +49,7 @@ This event is generated when a Transparency, Consent, and Control (TCC) permissi
 | file.code_signature.team_id |
 | file.path |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/security/windows/windows_security_log_off.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_log_off.md
@@ -31,6 +31,7 @@ This event is generated when a user logs off of the computer.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
+++ b/custom_documentation/doc/endpoint/security/windows/windows_security_log_on.md
@@ -31,6 +31,7 @@ This event is generated when a user logs on to the computer.
 | event.sequence |
 | event.type |
 | host.architecture |
+| host.domain |
 | host.hostname |
 | host.id |
 | host.ip |

--- a/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malicious_behavior_alert.yaml
@@ -80,6 +80,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_malware_alert.yaml
@@ -84,6 +84,7 @@ fields:
   - file.path
   - file.size
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_memory_threat_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_memory_threat_alert.yaml
@@ -51,6 +51,7 @@ fields:
   - event.severity
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_ransomware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/linux/linux_ransomware_alert.yaml
@@ -81,6 +81,7 @@ fields:
   - event.severity
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malicious_behavior_alert.yaml
@@ -74,6 +74,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_malware_alert.yaml
@@ -89,6 +89,7 @@ fields:
   - file.path
   - file.size
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_memory_threat_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_memory_threat_alert.yaml
@@ -51,6 +51,7 @@ fields:
   - event.severity
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_ransomware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/macos/macos_ransomware_alert.yaml
@@ -81,6 +81,7 @@ fields:
   - event.severity
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malicious_behavior_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malicious_behavior_alert.yaml
@@ -80,6 +80,7 @@ fields:
   - event.type
   - file.*
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_malware_alert.yaml
@@ -128,6 +128,7 @@ fields:
   - file.pe.product
   - file.size
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_memory_threat_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_memory_threat_alert.yaml
@@ -51,6 +51,7 @@ fields:
   - event.severity
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_ransomware_alert.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_ransomware_alert.yaml
@@ -83,6 +83,7 @@ fields:
   - event.severity
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_shellcode_thread.yaml
+++ b/custom_documentation/src/endpoint/data_stream/alerts/windows/windows_shellcode_thread.yaml
@@ -172,6 +172,7 @@ fields:
   - event.severity
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_amsi.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_amsi.yaml
@@ -33,6 +33,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_asm.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_asm.yaml
@@ -39,6 +39,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_credential_access.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_credential_access.yaml
@@ -36,6 +36,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_firewall_anti_tamper.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_firewall_anti_tamper.yaml
@@ -32,6 +32,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_kernel_audit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_kernel_audit.yaml
@@ -40,6 +40,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_ldap_client.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_ldap_client.yaml
@@ -32,6 +32,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_tcpip.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_tcpip.yaml
@@ -35,6 +35,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_threat_intelligence.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_threat_intelligence.yaml
@@ -42,6 +42,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_win32k.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_win32k.yaml
@@ -36,6 +36,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_winhttp.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_winhttp.yaml
@@ -33,6 +33,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_wininet.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_wininet.yaml
@@ -33,6 +33,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_wmi.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_wmi.yaml
@@ -35,6 +35,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
@@ -45,6 +45,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_delete.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_delete.yaml
@@ -43,6 +43,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_endpoint_unquarantine.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_endpoint_unquarantine.yaml
@@ -42,6 +42,7 @@ fields:
   - file.name
   - file.path
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_rename.yaml
@@ -48,6 +48,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_access.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_access.yaml
@@ -47,6 +47,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_delete.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_delete.yaml
@@ -47,6 +47,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_endpoint_unquarantine.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_endpoint_unquarantine.yaml
@@ -42,6 +42,7 @@ fields:
   - file.name
   - file.path
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_extended_attributes_delete.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_extended_attributes_delete.yaml
@@ -48,6 +48,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_launch_daemon.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_launch_daemon.yaml
@@ -47,6 +47,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_modification.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_modification.yaml
@@ -52,6 +52,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_mount.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_mount.yaml
@@ -45,6 +45,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/macos/macos_file_rename.yaml
@@ -50,6 +50,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_create.yaml
@@ -49,6 +49,7 @@ fields:
   - file.path
   - file.size
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_delete.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_delete.yaml
@@ -44,6 +44,7 @@ fields:
   - file.path
   - file.size
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_endpoint_unquarantine.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_endpoint_unquarantine.yaml
@@ -42,6 +42,7 @@ fields:
   - file.name
   - file.path
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_modification.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_modification.yaml
@@ -46,6 +46,7 @@ fields:
   - file.path
   - file.size
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_open.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_open.yaml
@@ -46,6 +46,7 @@ fields:
   - file.path
   - file.size
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_overwrite.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_overwrite.yaml
@@ -46,6 +46,7 @@ fields:
   - file.path
   - file.size
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/windows/windows_file_rename.yaml
@@ -49,6 +49,7 @@ fields:
   - file.path
   - file.size
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/library/macos/macos_library_load.yaml
+++ b/custom_documentation/src/endpoint/data_stream/library/macos/macos_library_load.yaml
@@ -52,6 +52,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/library/windows/windows_library_load.yaml
+++ b/custom_documentation/src/endpoint/data_stream/library/windows/windows_library_load.yaml
@@ -60,6 +60,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/metadata/metadata.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metadata/metadata.yaml
@@ -47,6 +47,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
+++ b/custom_documentation/src/endpoint/data_stream/metrics/metrics.yaml
@@ -217,6 +217,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/network/linux/linux_network_attempted_accepted_and_disconnect.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/linux/linux_network_attempted_accepted_and_disconnect.yaml
@@ -46,6 +46,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_connection_attempted_and_disconnect.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_connection_attempted_and_disconnect.yaml
@@ -46,6 +46,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_dns_lookup_result.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/macos/macos_network_dns_lookup_result.yaml
@@ -47,6 +47,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/network/windows/windows_network_attempted_accepted_and_disconnect.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/windows/windows_network_attempted_accepted_and_disconnect.yaml
@@ -42,6 +42,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/network/windows/windows_network_dns_lookup_requested.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/windows/windows_network_dns_lookup_requested.yaml
@@ -38,6 +38,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/network/windows/windows_network_dns_lookup_result.yaml
+++ b/custom_documentation/src/endpoint/data_stream/network/windows/windows_network_dns_lookup_result.yaml
@@ -40,6 +40,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/policy/policy_response.yaml
+++ b/custom_documentation/src/endpoint/data_stream/policy/policy_response.yaml
@@ -96,6 +96,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_already_running.yaml
@@ -49,6 +49,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_fork_exec_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_fork_exec_exit.yaml
@@ -52,6 +52,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_gid_change.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_gid_change.yaml
@@ -48,6 +48,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_load_module.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_load_module.yaml
@@ -46,6 +46,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_memfd_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_memfd_create.yaml
@@ -46,6 +46,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_ptrace.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_ptrace.yaml
@@ -47,6 +47,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_session_id_change.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_session_id_change.yaml
@@ -48,6 +48,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_shmget.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_shmget.yaml
@@ -46,6 +46,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_text_output.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_text_output.yaml
@@ -47,6 +47,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_uid_change.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_uid_change.yaml
@@ -46,6 +46,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_already_running.yaml
@@ -39,6 +39,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork_exec_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork_exec_exit.yaml
@@ -46,6 +46,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_remote_thread.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_remote_thread.yaml
@@ -43,6 +43,7 @@ fields:
   - group.id
   - group.name
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
@@ -35,6 +35,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create_and_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create_and_exit.yaml
@@ -36,6 +36,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/registry/windows/windows_registry_modification.yaml
+++ b/custom_documentation/src/endpoint/data_stream/registry/windows/windows_registry_modification.yaml
@@ -38,6 +38,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/registry/windows/windows_registry_query.yaml
+++ b/custom_documentation/src/endpoint/data_stream/registry/windows/windows_registry_query.yaml
@@ -38,6 +38,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_gatekeeper_override.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_gatekeeper_override.yaml
@@ -39,6 +39,7 @@ fields:
   - file.code_signature.team_id
   - file.path
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_log_on.yaml
@@ -36,6 +36,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_rdp_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_rdp_log_on.yaml
@@ -36,6 +36,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_ssh_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_ssh_log_on.yaml
@@ -36,6 +36,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_tcc_modify.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/macos/macos_security_tcc_modify.yaml
@@ -55,6 +55,7 @@ fields:
   - file.code_signature.team_id
   - file.path
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_off.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_off.yaml
@@ -36,6 +36,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip

--- a/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
+++ b/custom_documentation/src/endpoint/data_stream/security/windows/windows_security_log_on.yaml
@@ -36,6 +36,7 @@ fields:
   - event.sequence
   - event.type
   - host.architecture
+  - host.domain
   - host.hostname
   - host.id
   - host.ip


### PR DESCRIPTION
Backport of #781 to `9.4`.

## Summary

- document `host.domain` as a common field across Endpoint event types
- update the generated custom documentation to match the source YAML

## Why

Endpoint events emit `host.domain`, but the endpoint-package custom documentation did not list it consistently. This aligns the documented event schemas with the emitted field.

## Validation

- ran `make` in WSL
- built `endpoint-9.4.1.zip`
- verified `host.domain` in the metadata field schema
- verified the `metadata_current` and `metadata_united` destination index-template mappings
