### PR TITLE
Add process.ai_agent fields to Windows process event custom documentation

### DIFF
--- a/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
@@ -69,6 +69,8 @@ This event is generated for a process that was already running before Endpoint's
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
 | process.Ext.windows.zone_identifier |
+| process.ai_agent.is_descendant |
+| process.ai_agent.name |
 | process.args |
 | process.args_count |
 | process.code_signature.exists |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_create_and_exit.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_create_and_exit.md
@@ -83,6 +83,8 @@ This event is generated when a process is created or exits.
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
 | process.Ext.windows.zone_identifier |
+| process.ai_agent.is_descendant |
+| process.ai_agent.name |
 | process.args |
 | process.args_count |
 | process.code_signature.exists |

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
@@ -75,6 +75,8 @@ fields:
   - process.Ext.trusted
   - process.Ext.trusted_descendant
   - process.Ext.windows.zone_identifier
+  - process.ai_agent.is_descendant
+  - process.ai_agent.name
   - process.args
   - process.args_count
   - process.code_signature.exists

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create_and_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create_and_exit.yaml
@@ -90,6 +90,8 @@ fields:
   - process.Ext.trusted
   - process.Ext.trusted_descendant
   - process.Ext.windows.zone_identifier
+  - process.ai_agent.is_descendant
+  - process.ai_agent.name
   - process.args
   - process.args_count
   - process.code_signature.exists


### PR DESCRIPTION
## Change Summary

Documents `process.ai_agent.name` and `process.ai_agent.is_descendant` on Windows process events (`create_and_exit`, `already_running`), companion to the Windows GenAI process observability feature in endpoint-dev.

This is a docs-only change: the field schemas and mappings were already merged in #752. Completes cross-platform coverage alongside Linux (#744) and macOS (#773).


### Sample values

```json
{
  "process": {
    "ai_agent": {
      "name": "claude_code",
      "is_descendant": true
    }
  }
}
```

## Release Target

9.6.0
