### PR TITLE
Add live dump driver response field

### DIFF
--- a/custom_schemas/custom_endpoint_actions.yml
+++ b/custom_schemas/custom_endpoint_actions.yml
@@ -58,6 +58,14 @@
       description: >
         A comment that describes the action that is requested
 
+    - name: data.output.content.dump_executed_from_driver
+      type: boolean
+      level: custom
+      short: dump executed from driver
+      description: >
+        Indicates whether a live kernel memory dump was executed through the kernel driver.
+      example: true
+
     - name: type
       type: keyword
       level: custom

--- a/package/endpoint/data_stream/action_responses/fields/fields.yml
+++ b/package/endpoint/data_stream/action_responses/fields/fields.yml
@@ -92,6 +92,12 @@
       type: text
       description: A comment that describes the action that is requested
       default_field: false
+    - name: data.output.content.dump_executed_from_driver
+      level: custom
+      type: boolean
+      description: Indicates whether a live kernel memory dump was executed through the kernel driver.
+      example: true
+      default_field: false
     - name: started_at
       level: custom
       type: date

--- a/package/endpoint/data_stream/actions/fields/fields.yml
+++ b/package/endpoint/data_stream/actions/fields/fields.yml
@@ -92,6 +92,12 @@
       type: text
       description: A comment that describes the action that is requested
       default_field: false
+    - name: data.output.content.dump_executed_from_driver
+      level: custom
+      type: boolean
+      description: Indicates whether a live kernel memory dump was executed through the kernel driver.
+      example: true
+      default_field: false
     - name: expiration
       level: custom
       type: date

--- a/schemas/v1/action_responses/action_responses.yaml
+++ b/schemas/v1/action_responses/action_responses.yaml
@@ -77,6 +77,17 @@ EndpointActions.data.comment:
   norms: false
   short: comment text
   type: text
+EndpointActions.data.output.content.dump_executed_from_driver:
+  dashed_name: EndpointActions-data-output-content-dump-executed-from-driver
+  description: Indicates whether a live kernel memory dump was executed through the
+    kernel driver.
+  example: true
+  flat_name: EndpointActions.data.output.content.dump_executed_from_driver
+  level: custom
+  name: data.output.content.dump_executed_from_driver
+  normalize: []
+  short: dump executed from driver
+  type: boolean
 EndpointActions.started_at:
   dashed_name: EndpointActions-started-at
   description: Timestamp of start of request

--- a/schemas/v1/actions/actions.yaml
+++ b/schemas/v1/actions/actions.yaml
@@ -67,6 +67,17 @@ EndpointActions.data.comment:
   norms: false
   short: comment text
   type: text
+EndpointActions.data.output.content.dump_executed_from_driver:
+  dashed_name: EndpointActions-data-output-content-dump-executed-from-driver
+  description: Indicates whether a live kernel memory dump was executed through the
+    kernel driver.
+  example: true
+  flat_name: EndpointActions.data.output.content.dump_executed_from_driver
+  level: custom
+  name: data.output.content.dump_executed_from_driver
+  normalize: []
+  short: dump executed from driver
+  type: boolean
 EndpointActions.expiration:
   dashed_name: EndpointActions-expiration
   description: Request expiration timestamp


### PR DESCRIPTION
## Summary

- add the boolean EndpointActions.data.output.content.dump_executed_from_driver field
- generate the action and action-response schemas and package mappings
- expose whether a live kernel memory dump used the kernel driver or user-mode fallback

## Validation

- WSL make (Python 3.11)
- elastic-package build completed successfully