### PR TITLE
[endpoint.events.api] add missing agent field mappings

### DIFF
--- a/custom_subsets/elastic_endpoint/api/api.yaml
+++ b/custom_subsets/elastic_endpoint/api/api.yaml
@@ -73,6 +73,11 @@ fields:
           Ext:
             fields:
               variant: {}
+  agent:
+    fields:
+      version: {}
+      type: {}
+      id: {}
   network:
     fields:
       transport: {}

--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,8 +1,8 @@
 - version: "9.6.0-next"
   changes:
-    - description: TBD
-      type: enhancement
-      link: https://github.com/elastic/endpoint-package/pull/999999
+    - description: Add missing agent field mappings to endpoint.events.api
+      type: bugfix
+      link: https://github.com/elastic/endpoint-package/pull/788
 - version: "9.5.0"
   changes:
     - description: Add mappings for process and security event sources metrics

--- a/package/endpoint/changelog.yml
+++ b/package/endpoint/changelog.yml
@@ -1,7 +1,7 @@
 - version: "9.6.0-next"
   changes:
     - description: Add missing agent field mappings to endpoint.events.api
-      type: bugfix
+      type: enhancement
       link: https://github.com/elastic/endpoint-package/pull/788
 - version: "9.5.0"
   changes:

--- a/package/endpoint/data_stream/api/fields/fields.yml
+++ b/package/endpoint/data_stream/api/fields/fields.yml
@@ -859,6 +859,38 @@
       description: Process id.
       example: 4242
       default_field: false
+- name: agent
+  title: Agent
+  group: 2
+  description: 'The agent fields contain the data about the software entity, if any, that collects, detects, or observes events on a host, or takes measurements on a host.
+
+    Examples include Beats. Agents may also run on observers. ECS agent.* fields shall be populated with details of the agent running on the host or observer where the event happened or the measurement was taken.'
+  footnote: 'Examples: In the case of Beats for logs, the agent.name is filebeat. For APM, it is the agent running in the app/service. The agent information does not change if data is sent through queuing systems like Kafka, Redis, or processing systems such as Logstash or APM Server.'
+  type: group
+  default_field: true
+  fields:
+    - name: id
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Unique identifier of this agent (if one exists).
+
+        Example: For Beats this would be beat.id.'
+      example: 8a4f500d
+    - name: type
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: 'Type of the agent.
+
+        The agent type always stays the same and should be given by the agent used. In case of Filebeat the agent would always be Filebeat also if two Filebeat instances are run on the same machine.'
+      example: filebeat
+    - name: version
+      level: core
+      type: keyword
+      ignore_above: 1024
+      description: Version of the agent.
+      example: 6.0.0-rc2
 - name: data_stream
   title: data_stream
   group: 2

--- a/package/endpoint/data_stream/api/sample_event.json
+++ b/package/endpoint/data_stream/api/sample_event.json
@@ -1,5 +1,10 @@
 {
     "@timestamp": "2023-01-09T19:38:51.5141503Z",
+    "agent": {
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "type": "endpoint",
+        "version": "8.7.0"
+    },
     "Target": {
         "process": {
             "Ext": {

--- a/schemas/v1/api/api.yaml
+++ b/schemas/v1/api/api.yaml
@@ -1534,6 +1534,45 @@ Target.process.pid:
   original_fieldset: process
   short: Process id.
   type: long
+agent.id:
+  dashed_name: agent-id
+  description: 'Unique identifier of this agent (if one exists).
+
+    Example: For Beats this would be beat.id.'
+  example: 8a4f500d
+  flat_name: agent.id
+  ignore_above: 1024
+  level: core
+  name: id
+  normalize: []
+  short: Unique identifier of this agent.
+  type: keyword
+agent.type:
+  dashed_name: agent-type
+  description: 'Type of the agent.
+
+    The agent type always stays the same and should be given by the agent used. In
+    case of Filebeat the agent would always be Filebeat also if two Filebeat instances
+    are run on the same machine.'
+  example: filebeat
+  flat_name: agent.type
+  ignore_above: 1024
+  level: core
+  name: type
+  normalize: []
+  short: Type of the agent.
+  type: keyword
+agent.version:
+  dashed_name: agent-version
+  description: Version of the agent.
+  example: 6.0.0-rc2
+  flat_name: agent.version
+  ignore_above: 1024
+  level: core
+  name: version
+  normalize: []
+  short: Version of the agent.
+  type: keyword
 data_stream.dataset:
   dashed_name: data-stream-dataset
   description: Data stream dataset name.


### PR DESCRIPTION
Add the standard `agent` fields to the Endpoint API data stream.

Endpoint already emits these fields, but the stream did not map them, so they were unavailable for search and aggregation.

Regenerate the schema and update the sample event.