### PR TITLE
Add AI auth email fields to process events, update linux file events

### DIFF
--- a/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_create.md
@@ -59,6 +59,7 @@ This event is generated when a file is created.
 | host.os.version |
 | message |
 | process.Ext.ancestry |
+| process.ai_agent.name |
 | process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_delete.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_delete.md
@@ -54,6 +54,7 @@ This event is generated when a file is deleted.
 | host.os.version |
 | message |
 | process.Ext.ancestry |
+| process.ai_agent.name |
 | process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_modification.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_modification.md
@@ -59,11 +59,13 @@ This event is generated when a file is modified.
 | host.os.version |
 | message |
 | process.Ext.ancestry |
+| process.ai_agent.name |
 | process.entry_leader.entity_id |
 | process.entry_leader.parent.entity_id |
 | process.group_leader.entity_id |
 | process.session_leader.entity_id |
 | process.parent.entity_id |
+| process.parent.pid |
 | process.command_line |
 | process.entity_id |
 | process.executable |

--- a/custom_documentation/doc/endpoint/file/linux/linux_file_rename.md
+++ b/custom_documentation/doc/endpoint/file/linux/linux_file_rename.md
@@ -62,6 +62,7 @@ This event is generated when a file is renamed.
 | host.os.version |
 | message |
 | process.Ext.ancestry |
+| process.ai_agent.name |
 | process.command_line |
 | process.entity_id |
 | process.entry_leader.entity_id |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_already_running.md
@@ -70,6 +70,7 @@ This event is generated for a process that was already running before Endpoint's
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
 | process.ai_agent.is_descendant |
+| process.ai_agent.email |
 | process.ai_agent.name |
 | process.args |
 | process.args_count |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_fork_exec_exit.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_fork_exec_exit.md
@@ -70,6 +70,7 @@ This event is generated when a process calls `fork()`, `exec()`, exits, or an ag
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
 | process.ai_agent.is_descendant |
+| process.ai_agent.email |
 | process.ai_agent.name |
 | process.args |
 | process.args_count |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_gid_change.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_gid_change.md
@@ -69,6 +69,7 @@ This event is generated when the group id changes for a process.
 | process.Ext.command_line_truncated |
 | process.Ext.trusted_descendant |
 | process.ai_agent.is_descendant |
+| process.ai_agent.email |
 | process.ai_agent.name |
 | process.args |
 | process.args_count |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_load_module.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_load_module.md
@@ -78,6 +78,7 @@ This event is generated when when a process loads a kernel module.
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
 | process.ai_agent.is_descendant |
+| process.ai_agent.email |
 | process.ai_agent.name |
 | process.args |
 | process.args_count |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_memfd_create.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_memfd_create.md
@@ -76,6 +76,7 @@ This event is generated when when a memfd anonymous file is created.
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
 | process.ai_agent.is_descendant |
+| process.ai_agent.email |
 | process.ai_agent.name |
 | process.args |
 | process.args_count |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_ptrace.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_ptrace.md
@@ -73,6 +73,7 @@ This event is generated when when a process calls ptrace_attach on another proce
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
 | process.ai_agent.is_descendant |
+| process.ai_agent.email |
 | process.ai_agent.name |
 | process.args |
 | process.args_count |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_shmget.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_shmget.md
@@ -71,6 +71,7 @@ This event is generated when when a process calls shmget().
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
 | process.ai_agent.is_descendant |
+| process.ai_agent.email |
 | process.ai_agent.name |
 | process.args |
 | process.args_count |

--- a/custom_documentation/doc/endpoint/process/linux/linux_process_uid_change.md
+++ b/custom_documentation/doc/endpoint/process/linux/linux_process_uid_change.md
@@ -69,6 +69,7 @@ This event is generated when the user id changes for a process.
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
 | process.ai_agent.is_descendant |
+| process.ai_agent.email |
 | process.ai_agent.name |
 | process.args |
 | process.args_count |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_already_running.md
@@ -52,6 +52,7 @@ This event is generated for a process that was already running before Endpoint's
 | process.Ext.command_line_truncated |
 | process.Ext.effective_parent.pid |
 | process.ai_agent.is_descendant |
+| process.ai_agent.email |
 | process.ai_agent.name |
 | process.args |
 | process.args_count |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_fork_exec_exit.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_fork_exec_exit.md
@@ -63,6 +63,7 @@ This event is generated when a process calls `fork()`, `exec()`, or exits.
 | process.Ext.trusted |
 | process.Ext.trusted_descendant |
 | process.ai_agent.is_descendant |
+| process.ai_agent.email |
 | process.ai_agent.name |
 | process.args |
 | process.args_count |

--- a/custom_documentation/doc/endpoint/process/macos/macos_process_remote_thread.md
+++ b/custom_documentation/doc/endpoint/process/macos/macos_process_remote_thread.md
@@ -58,6 +58,7 @@ This event is generated when a remote thread is created.
 | process.Ext.effective_parent.pid |
 | process.Ext.trusted |
 | process.ai_agent.is_descendant |
+| process.ai_agent.email |
 | process.ai_agent.name |
 | process.args |
 | process.args_count |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_already_running.md
@@ -70,6 +70,7 @@ This event is generated for a process that was already running before Endpoint's
 | process.Ext.trusted_descendant |
 | process.Ext.windows.zone_identifier |
 | process.ai_agent.is_descendant |
+| process.ai_agent.email |
 | process.ai_agent.name |
 | process.args |
 | process.args_count |

--- a/custom_documentation/doc/endpoint/process/windows/windows_process_create_and_exit.md
+++ b/custom_documentation/doc/endpoint/process/windows/windows_process_create_and_exit.md
@@ -84,6 +84,7 @@ This event is generated when a process is created or exits.
 | process.Ext.trusted_descendant |
 | process.Ext.windows.zone_identifier |
 | process.ai_agent.is_descendant |
+| process.ai_agent.email |
 | process.ai_agent.name |
 | process.args |
 | process.args_count |

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_create.yaml
@@ -64,6 +64,7 @@ fields:
   - host.os.version
   - message
   - process.Ext.ancestry
+  - process.ai_agent.name
   - process.command_line
   - process.entity_id
   - process.entry_leader.entity_id

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_delete.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_delete.yaml
@@ -59,6 +59,7 @@ fields:
   - host.os.version
   - message
   - process.Ext.ancestry
+  - process.ai_agent.name
   - process.command_line
   - process.entity_id
   - process.entry_leader.entity_id

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_modification.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_modification.yaml
@@ -64,11 +64,13 @@ fields:
   - host.os.version
   - message
   - process.Ext.ancestry
+  - process.ai_agent.name
   - process.entry_leader.entity_id
   - process.entry_leader.parent.entity_id
   - process.group_leader.entity_id
   - process.session_leader.entity_id
   - process.parent.entity_id
+  - process.parent.pid
   - process.command_line
   - process.entity_id
   - process.executable

--- a/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_rename.yaml
+++ b/custom_documentation/src/endpoint/data_stream/file/linux/linux_file_rename.yaml
@@ -67,6 +67,7 @@ fields:
   - host.os.version
   - message
   - process.Ext.ancestry
+  - process.ai_agent.name
   - process.command_line
   - process.entity_id
   - process.entry_leader.entity_id

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_already_running.yaml
@@ -76,6 +76,7 @@ fields:
   - process.Ext.trusted
   - process.Ext.trusted_descendant
   - process.ai_agent.is_descendant
+  - process.ai_agent.email
   - process.ai_agent.name
   - process.args
   - process.args_count

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_fork_exec_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_fork_exec_exit.yaml
@@ -79,6 +79,7 @@ fields:
   - process.Ext.trusted
   - process.Ext.trusted_descendant
   - process.ai_agent.is_descendant
+  - process.ai_agent.email
   - process.ai_agent.name
   - process.args
   - process.args_count

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_gid_change.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_gid_change.yaml
@@ -74,6 +74,7 @@ fields:
   - process.Ext.command_line_truncated
   - process.Ext.trusted_descendant
   - process.ai_agent.is_descendant
+  - process.ai_agent.email
   - process.ai_agent.name
   - process.args
   - process.args_count

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_load_module.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_load_module.yaml
@@ -82,6 +82,7 @@ fields:
   - process.Ext.trusted
   - process.Ext.trusted_descendant
   - process.ai_agent.is_descendant
+  - process.ai_agent.email
   - process.ai_agent.name
   - process.args
   - process.args_count

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_memfd_create.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_memfd_create.yaml
@@ -80,6 +80,7 @@ fields:
   - process.Ext.trusted
   - process.Ext.trusted_descendant
   - process.ai_agent.is_descendant
+  - process.ai_agent.email
   - process.ai_agent.name
   - process.args
   - process.args_count

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_ptrace.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_ptrace.yaml
@@ -78,6 +78,7 @@ fields:
   - process.Ext.trusted
   - process.Ext.trusted_descendant
   - process.ai_agent.is_descendant
+  - process.ai_agent.email
   - process.ai_agent.name
   - process.args
   - process.args_count

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_shmget.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_shmget.yaml
@@ -75,6 +75,7 @@ fields:
   - process.Ext.trusted
   - process.Ext.trusted_descendant
   - process.ai_agent.is_descendant
+  - process.ai_agent.email
   - process.ai_agent.name
   - process.args
   - process.args_count

--- a/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_uid_change.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/linux/linux_process_uid_change.yaml
@@ -73,6 +73,7 @@ fields:
   - process.Ext.trusted
   - process.Ext.trusted_descendant
   - process.ai_agent.is_descendant
+  - process.ai_agent.email
   - process.ai_agent.name
   - process.args
   - process.args_count

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_already_running.yaml
@@ -58,6 +58,7 @@ fields:
   - process.Ext.command_line_truncated
   - process.Ext.effective_parent.pid
   - process.ai_agent.is_descendant
+  - process.ai_agent.email
   - process.ai_agent.name
   - process.args
   - process.args_count

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork_exec_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_fork_exec_exit.yaml
@@ -72,6 +72,7 @@ fields:
   - process.Ext.trusted
   - process.Ext.trusted_descendant
   - process.ai_agent.is_descendant
+  - process.ai_agent.email
   - process.ai_agent.name
   - process.args
   - process.args_count

--- a/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_remote_thread.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/macos/macos_process_remote_thread.yaml
@@ -63,6 +63,7 @@ fields:
   - process.Ext.effective_parent.pid
   - process.Ext.trusted
   - process.ai_agent.is_descendant
+  - process.ai_agent.email
   - process.ai_agent.name
   - process.args
   - process.args_count

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_already_running.yaml
@@ -76,6 +76,7 @@ fields:
   - process.Ext.trusted_descendant
   - process.Ext.windows.zone_identifier
   - process.ai_agent.is_descendant
+  - process.ai_agent.email
   - process.ai_agent.name
   - process.args
   - process.args_count

--- a/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create_and_exit.yaml
+++ b/custom_documentation/src/endpoint/data_stream/process/windows/windows_process_create_and_exit.yaml
@@ -91,6 +91,7 @@ fields:
   - process.Ext.trusted_descendant
   - process.Ext.windows.zone_identifier
   - process.ai_agent.is_descendant
+  - process.ai_agent.email
   - process.ai_agent.name
   - process.args
   - process.args_count

--- a/custom_schemas/custom_process.yml
+++ b/custom_schemas/custom_process.yml
@@ -84,6 +84,16 @@
         This enables analysts and detection rules to distinguish AI-agent-initiated
         activity from human-initiated activity.
 
+    - name: ai_agent.email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      alpha: This field is alpha and subject to change.
+      short: Email address of the user associated with the AI-agent tool.
+      description: >
+        Email address of the user associated with the AI-agent tool
+        that initiated this process.
+
     - name: ai_agent.is_descendant
       level: extended
       type: boolean

--- a/custom_subsets/elastic_endpoint/process/process.yaml
+++ b/custom_subsets/elastic_endpoint/process/process.yaml
@@ -104,6 +104,7 @@ fields:
     fields:
       ai_agent:
         fields:
+          email: {}
           is_descendant: {}
           name: {}
       args: {}

--- a/package/endpoint/data_stream/process/fields/fields.yml
+++ b/package/endpoint/data_stream/process/fields/fields.yml
@@ -1172,6 +1172,12 @@
 
         When a process is identified as a known AI-agent development tool, these fields can be populated on the process event and propagated to descendant processes. This enables analysts and detection rules to distinguish AI-agent-initiated activity from human-initiated activity.'
       default_field: false
+    - name: ai_agent.email
+      level: extended
+      type: keyword
+      ignore_above: 1024
+      description: Email address of the user associated with the AI-agent tool that initiated this process.
+      default_field: false
     - name: ai_agent.is_descendant
       level: extended
       type: boolean

--- a/package/endpoint/docs/README.md
+++ b/package/endpoint/docs/README.md
@@ -2466,6 +2466,7 @@ sent by the endpoint.
 | process.Ext.windows | Platform-specific Windows fields | object |
 | process.Ext.windows.zone_identifier | Windows zone identifier for a process's executable file | keyword |
 | process.ai_agent | Fields describing an AI-agent tool associated with a process. When a process is identified as a known AI-agent development tool, these fields can be populated on the process event and propagated to descendant processes. This enables analysts and detection rules to distinguish AI-agent-initiated activity from human-initiated activity. | object |
+| process.ai_agent.email | Email address of the user associated with the AI-agent tool that initiated this process. | keyword |
 | process.ai_agent.is_descendant | True when this process was spawned, directly or transitively, by a known AI-agent tool process. | boolean |
 | process.ai_agent.name | Canonical name of the AI-agent tool associated with this process or its ancestor. Examples include `cursor`, `claude_code`, `codex`, `copilot`, `ollama`, and `gemini_cli`. | keyword |
 | process.args | Array of process arguments, starting with the absolute path to the executable. May be filtered to protect sensitive information. | keyword |

--- a/schemas/v1/process/process.yaml
+++ b/schemas/v1/process/process.yaml
@@ -2119,6 +2119,18 @@ process.ai_agent:
   normalize: []
   short: AI-agent tool identification fields.
   type: object
+process.ai_agent.email:
+  alpha: This field is alpha and subject to change.
+  dashed_name: process-ai-agent-email
+  description: Email address of the user associated with the AI-agent tool that initiated
+    this process.
+  flat_name: process.ai_agent.email
+  ignore_above: 1024
+  level: extended
+  name: ai_agent.email
+  normalize: []
+  short: Email address of the user associated with the AI-agent tool.
+  type: keyword
 process.ai_agent.is_descendant:
   alpha: This field is alpha and subject to change.
   dashed_name: process-ai-agent-is-descendant


### PR DESCRIPTION
## Change Summary

This brings the PR up to date with https://github.com/elastic/endpoint-dev/pull/21634, mostly by adding pre-existing `process.ai_agent.name` fields. This also adds `process.parent.pid` to the linux file events, which was missing when I created them. 


### Sample values


Sample document:

```json

            "pid": 570283,
            "working_directory": "/home/alexk/endpoint-dev/Python",
            "entity_id": "yKC8D/BoBbawWNpzKWgI1Q",
            "ai_agent": {
                "name": "claude_code",
                "is_descendant": false,
                "email": "test@example.com"
            },
```


## Release Target

9.6.0


### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
- [ ] If this is a `metadata` change, I also updated both transform destination schemas to match