### PR TITLE
Add custom documentation for thread pool API events

### DIFF
--- a/custom_documentation/doc/endpoint/api/windows/windows_api_threadpool.md
+++ b/custom_documentation/doc/endpoint/api/windows/windows_api_threadpool.md
@@ -1,0 +1,73 @@
+# Windows API
+
+- OS: Windows
+- Data Stream: `logs-endpoint.events.api-*`
+- KQL: `event.dataset : "endpoint.events.api" and event.module : "endpoint" and event.provider : "Thread Pool" and host.os.type : "windows"`
+
+This event is generated when ETW Thread Pool events are generated.
+
+| Field |
+|---|
+| @timestamp |
+| agent.id |
+| agent.type |
+| agent.version |
+| data_stream.dataset |
+| data_stream.namespace |
+| data_stream.type |
+| ecs.version |
+| elastic.agent.id |
+| event.category |
+| event.created |
+| event.dataset |
+| event.id |
+| event.kind |
+| event.module |
+| event.outcome |
+| event.provider |
+| event.sequence |
+| event.type |
+| host.architecture |
+| host.domain |
+| host.hostname |
+| host.id |
+| host.ip |
+| host.mac |
+| host.name |
+| host.os.Ext.variant |
+| host.os.family |
+| host.os.full |
+| host.os.kernel |
+| host.os.name |
+| host.os.platform |
+| host.os.type |
+| host.os.version |
+| message |
+| process.Ext.api.behaviors |
+| process.Ext.api.name |
+| process.Ext.api.parameters.argument1 |
+| process.Ext.api.parameters.procedure |
+| process.Ext.api.summary |
+| process.Ext.code_signature.exists |
+| process.Ext.code_signature.status |
+| process.Ext.code_signature.subject_name |
+| process.Ext.code_signature.thumbprint_sha256 |
+| process.Ext.code_signature.trusted |
+| process.Ext.protection |
+| process.Ext.token.integrity_level_name |
+| process.code_signature.exists |
+| process.code_signature.status |
+| process.code_signature.subject_name |
+| process.code_signature.thumbprint_sha256 |
+| process.code_signature.trusted |
+| process.command_line |
+| process.entity_id |
+| process.executable |
+| process.name |
+| process.parent.executable |
+| process.pid |
+| process.thread.id |
+| user.domain |
+| user.id |
+| user.name |
+

--- a/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_threadpool.yaml
+++ b/custom_documentation/src/endpoint/data_stream/api/windows/windows_api_threadpool.yaml
@@ -1,0 +1,76 @@
+overview:
+  name: Windows API
+  description: This event is generated when ETW Thread Pool events are generated.
+identification:
+  filter:
+    event.dataset: endpoint.events.api
+    event.module: endpoint
+    event.provider: Thread Pool
+    host.os.type: windows
+  os:
+  - windows
+  data_stream: logs-endpoint.events.api-*
+fields:
+  endpoint:
+  - '@timestamp'
+  - agent.id
+  - agent.type
+  - agent.version
+  - data_stream.dataset
+  - data_stream.namespace
+  - data_stream.type
+  - ecs.version
+  - elastic.agent.id
+  - event.category
+  - event.created
+  - event.dataset
+  - event.id
+  - event.kind
+  - event.module
+  - event.outcome
+  - event.provider
+  - event.sequence
+  - event.type
+  - host.architecture
+  - host.domain
+  - host.hostname
+  - host.id
+  - host.ip
+  - host.mac
+  - host.name
+  - host.os.Ext.variant
+  - host.os.family
+  - host.os.full
+  - host.os.kernel
+  - host.os.name
+  - host.os.platform
+  - host.os.type
+  - host.os.version
+  - message
+  - process.Ext.api.behaviors
+  - process.Ext.api.name
+  - process.Ext.api.parameters.argument1
+  - process.Ext.api.parameters.procedure
+  - process.Ext.api.summary
+  - process.Ext.code_signature.exists
+  - process.Ext.code_signature.status
+  - process.Ext.code_signature.subject_name
+  - process.Ext.code_signature.thumbprint_sha256
+  - process.Ext.code_signature.trusted
+  - process.Ext.protection
+  - process.Ext.token.integrity_level_name
+  - process.code_signature.exists
+  - process.code_signature.status
+  - process.code_signature.subject_name
+  - process.code_signature.thumbprint_sha256
+  - process.code_signature.trusted
+  - process.command_line
+  - process.entity_id
+  - process.executable
+  - process.name
+  - process.parent.executable
+  - process.pid
+  - process.thread.id
+  - user.domain
+  - user.id
+  - user.name


### PR DESCRIPTION
## Change Summary

<!-- please describe your changes. For mapping changes, describe the usage of the changed fields -->

* https://github.com/elastic/endpoint-dev/pull/21567
Adds custom documentation for ETW Thread Pool provider based API events.


## Release Target

<!-- What is intended Kibana release this is expected to ship with -->
9.6

## Q/A

<!-- delete any sections that are not applicable to your PR -->

### For mapping changes:

- [x] I ran `make` after making the schema changes, and committed all changes
