### PR TITLE
[9.6] Document Windows registry save events

### DIFF
--- a/custom_documentation/doc/endpoint/registry/windows/windows_registry_save.md
+++ b/custom_documentation/doc/endpoint/registry/windows/windows_registry_save.md
@@ -1,0 +1,76 @@
+# Windows Registry Save
+
+- OS: Windows
+- Data Stream: `logs-endpoint.events.registry-*`
+- KQL: `event.action : "save" and event.dataset : "endpoint.events.registry" and event.module : "endpoint" and host.os.type : "windows"`
+
+This event is generated when Endpoint blocks an attempt to save a protected Windows registry hive.
+
+
+| Field |
+|---|
+| @timestamp |
+| Effective_process.entity_id |
+| Effective_process.executable |
+| Effective_process.name |
+| Effective_process.pid |
+| agent.id |
+| agent.type |
+| agent.version |
+| data_stream.dataset |
+| data_stream.namespace |
+| data_stream.type |
+| ecs.version |
+| elastic.agent.id |
+| event.action |
+| event.category |
+| event.created |
+| event.dataset |
+| event.id |
+| event.kind |
+| event.module |
+| event.outcome |
+| event.sequence |
+| event.type |
+| host.architecture |
+| host.domain |
+| host.hostname |
+| host.id |
+| host.ip |
+| host.mac |
+| host.name |
+| host.os.Ext.variant |
+| host.os.family |
+| host.os.full |
+| host.os.kernel |
+| host.os.name |
+| host.os.platform |
+| host.os.type |
+| host.os.version |
+| message |
+| process.Ext.ancestry |
+| process.Ext.code_signature.exists |
+| process.Ext.code_signature.status |
+| process.Ext.code_signature.subject_name |
+| process.Ext.code_signature.thumbprint_sha256 |
+| process.Ext.code_signature.trusted |
+| process.code_signature.exists |
+| process.code_signature.status |
+| process.code_signature.subject_name |
+| process.code_signature.thumbprint_sha256 |
+| process.code_signature.trusted |
+| process.entity_id |
+| process.executable |
+| process.name |
+| process.pid |
+| registry.data.bytes |
+| registry.data.strings |
+| registry.data.type |
+| registry.hive |
+| registry.key |
+| registry.path |
+| registry.value |
+| user.domain |
+| user.id |
+| user.name |
+

--- a/custom_documentation/src/endpoint/data_stream/registry/windows/windows_registry_save.yaml
+++ b/custom_documentation/src/endpoint/data_stream/registry/windows/windows_registry_save.yaml
@@ -1,0 +1,80 @@
+overview:
+  name: Windows Registry Save
+  description: 'This event is generated when Endpoint blocks an attempt to save a protected Windows registry hive.
+
+    '
+identification:
+  filter:
+    event.action: save
+    event.dataset: endpoint.events.registry
+    event.module: endpoint
+    host.os.type: windows
+  os:
+  - windows
+  data_stream: logs-endpoint.events.registry-*
+fields:
+  endpoint:
+  - '@timestamp'
+  - Effective_process.entity_id
+  - Effective_process.executable
+  - Effective_process.name
+  - Effective_process.pid
+  - agent.id
+  - agent.type
+  - agent.version
+  - data_stream.dataset
+  - data_stream.namespace
+  - data_stream.type
+  - ecs.version
+  - elastic.agent.id
+  - event.action
+  - event.category
+  - event.created
+  - event.dataset
+  - event.id
+  - event.kind
+  - event.module
+  - event.outcome
+  - event.sequence
+  - event.type
+  - host.architecture
+  - host.domain
+  - host.hostname
+  - host.id
+  - host.ip
+  - host.mac
+  - host.name
+  - host.os.Ext.variant
+  - host.os.family
+  - host.os.full
+  - host.os.kernel
+  - host.os.name
+  - host.os.platform
+  - host.os.type
+  - host.os.version
+  - message
+  - process.Ext.ancestry
+  - process.Ext.code_signature.exists
+  - process.Ext.code_signature.status
+  - process.Ext.code_signature.subject_name
+  - process.Ext.code_signature.thumbprint_sha256
+  - process.Ext.code_signature.trusted
+  - process.code_signature.exists
+  - process.code_signature.status
+  - process.code_signature.subject_name
+  - process.code_signature.thumbprint_sha256
+  - process.code_signature.trusted
+  - process.entity_id
+  - process.executable
+  - process.name
+  - process.pid
+  - registry.data.bytes
+  - registry.data.strings
+  - registry.data.type
+  - registry.hive
+  - registry.key
+  - registry.path
+  - registry.value
+  - user.domain
+  - user.id
+  - user.name


### PR DESCRIPTION
## Change Summary

Adds custom documentation for Windows registry save events (`event.action: save`) generated when Elastic Endpoint blocks an attempt to save a protected registry hive.

This supports `endpoint-dev #21504` and resolves its EAF custom-documentation validation failures.

## Release Target

9.6.0

## Q/A

- [x] I ran `make clean all` and committed the generated documentation
- [x] I validated the documentation against the EAF violation documents